### PR TITLE
refactor: goupPage 이전

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider } from "./components/auth/AuthProvider";
 import PrivateRoute from "./components/auth/PrivateRoute";
 import MainPage from "./pages/MainPage";
 import GroupPage from "./pages/GroupPage";
+import GroupCreatePage from "./pages/GroupCreatePage";
 
 const App = () => {
   return (
@@ -17,6 +18,14 @@ const App = () => {
                 element={
                   <PrivateRoute>
                     <GroupPage />
+                  </PrivateRoute>
+                }
+              ></Route>
+              <Route
+                path="/group/new"
+                element={
+                  <PrivateRoute>
+                    <GroupCreatePage />
                   </PrivateRoute>
                 }
               ></Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,14 @@ const App = () => {
                   </PrivateRoute>
                 }
               ></Route>
+              <Route
+                path="/group/:groupId"
+                element={
+                  <PrivateRoute>
+                    <GroupPage />
+                  </PrivateRoute>
+                }
+              ></Route>
               {/* <Route path="*" element={<NotFound />}></Route> */}
             </Routes>
           </AuthProvider>

--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -1,9 +1,10 @@
-import { supabase } from "../../supabase/client";
+import { supabase } from "./../../supabase/client";
 import { MemberWithGroup, Group } from "../../supabase/types/tables";
 
 export const fetchGroupListByUserId = async (
-  userId: string
+  userId: string | undefined
 ): Promise<Group[] | null> => {
+  if (!userId) return null;
   const { data, error } = await supabase
     .from("member")
     .select(`group (*)`)
@@ -16,7 +17,10 @@ export const fetchGroupListByUserId = async (
   return (data as MemberWithGroup[]).map((member) => member.group);
 };
 
-export const getGroup = async (groupId: string): Promise<Group | null> => {
+export const getGroup = async (
+  groupId: string | undefined
+): Promise<Group | null> => {
+  if (!groupId) return null;
   const { error, data } = await supabase
     .from("group")
     .select("*")
@@ -27,4 +31,24 @@ export const getGroup = async (groupId: string): Promise<Group | null> => {
     return null;
   }
   return data;
+};
+
+export const createGroup = async (
+  userId: string | undefined,
+  name: string | undefined,
+  intro: string | undefined
+): Promise<Group | null> => {
+  if (!userId || !name || !intro) {
+    console.error("userId, name, intro is required");
+    return null;
+  }
+  const { error, data } = await supabase
+    .from("group")
+    .insert([{ user_id: userId, name, intro }])
+    .select();
+  if (error) {
+    console.error("error", error);
+    return null;
+  }
+  return data ? data[0] : null;
 };

--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -1,0 +1,30 @@
+import { supabase } from "../../supabase/client";
+import { MemberWithGroup, Group } from "../../supabase/types/tables";
+
+export const fetchGroupListByUserId = async (
+  userId: string
+): Promise<Group[] | null> => {
+  const { data, error } = await supabase
+    .from("member")
+    .select(`group (*)`)
+    .eq("user_id", userId)
+    .is("deleted_at", null);
+  if (error) {
+    console.error("error", error);
+    return null;
+  }
+  return (data as MemberWithGroup[]).map((member) => member.group);
+};
+
+export const getGroup = async (groupId: string): Promise<Group | null> => {
+  const { error, data } = await supabase
+    .from("group")
+    .select("*")
+    .eq("id", groupId)
+    .single();
+  if (error) {
+    console.error("error", error);
+    return null;
+  }
+  return data;
+};

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -1,0 +1,34 @@
+import { supabase } from "../../supabase/client";
+import { Member } from "../../supabase/types/tables";
+
+export const fetchMemberListByGroupId = async (
+  groupId: string | undefined
+): Promise<Member[] | null> => {
+  if (!groupId) return null;
+  const { data, error } = await supabase
+    .from("member")
+    .select("*")
+    .eq("group_id", groupId)
+    .is("deleted_at", null);
+  if (error) {
+    console.error("error", error);
+    return null;
+  }
+  return data as Member[];
+};
+
+export const createMember = async (
+  groupId: string | undefined,
+  userId: string | undefined
+): Promise<Member | null> => {
+  if (!groupId || !userId) return null;
+  const { error, data } = await supabase
+    .from("member")
+    .insert([{ group_id: groupId, user_id: userId }])
+    .select();
+  if (error) {
+    console.error("error", error);
+    return null;
+  }
+  return data ? data[0] : null;
+};

--- a/src/components/KakaoShareBtn.tsx
+++ b/src/components/KakaoShareBtn.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect } from "react";
+import { ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+declare global {
+  interface Window {
+    Kakao: Kakao;
+  }
+}
+
+interface Kakao {
+  init: (apiKey: string) => void;
+  isInitialized: () => boolean;
+  Link: {
+    sendDefault: (linkObject: KakaoLinkObject) => void;
+  };
+}
+
+interface KakaoLinkObject {
+  objectType: string;
+  content: {
+    title: string;
+    description: string;
+    imageUrl: string;
+    link: {
+      mobileWebUrl: string;
+      webUrl: string;
+    };
+  };
+  buttons: Array<{
+    title: string;
+    link: {
+      mobileWebUrl: string;
+      webUrl: string;
+    };
+  }>;
+}
+
+interface KakaoShareButtonProps {
+  webUrl: string;
+}
+
+export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
+  webUrl,
+}) => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://t1.kakaocdn.net/kakao_js_sdk/2.1.0/kakao.min.js";
+    script.async = true;
+
+    script.onload = () => {
+      if (!window.Kakao.isInitialized()) {
+        window.Kakao.init(`${import.meta.env.VITE_KAKAO_APP_KEY}`);
+      }
+    };
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  const shareToKakao = (shareUrl: string) => {
+    if (window.Kakao) {
+      window.Kakao.Link.sendDefault({
+        objectType: "feed",
+        content: {
+          title: "카카오톡 공유하기",
+          description: "이것은 카카오톡 공유 예제입니다.",
+          imageUrl: "IMAGE_URL_HERE",
+          link: {
+            mobileWebUrl: shareUrl,
+            webUrl: shareUrl,
+          },
+        },
+        buttons: [
+          {
+            title: "웹으로 보기",
+            link: {
+              mobileWebUrl: shareUrl,
+              webUrl: shareUrl,
+            },
+          },
+        ],
+      });
+    }
+  };
+
+  return (
+    <Button onClick={() => shareToKakao(webUrl)} variant="ghost" size="icon">
+      <img src="https://developers.kakao.com/assets/img/about/logos/kakaotalksharing/kakaotalk_sharing_btn_medium.png" />
+    </Button>
+  );
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import useBaseStore from "@/stores/baseStore";
+import useAuth from "../hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from "@/components/ui/carousel";
+
+const GroupCreatePage: React.FC = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const createGroup = useBaseStore((state) => state.createGroup);
+  const inputGroupName = useBaseStore((state) => state.inputGroupName);
+  const setGroupName = useBaseStore((state) => state.setGroupName);
+
+  const handleCreateGroup = async (
+    userId: string | undefined,
+    inputGroupName: string
+  ) => {
+    if (inputGroupName.trim() === "") {
+      alert("그룹 이름을 입력해주세요.");
+      return;
+    }
+    const targetGroup = await createGroup(userId, inputGroupName, "intro");
+    targetGroup && navigate("/group/" + targetGroup.id);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2">
+        <div className="text-lg font-bold">PrayU 그룹 생성</div>
+      </div>
+
+      <Carousel>
+        <CarouselContent className="aspect-square">
+          <CarouselItem className=" bg-gray-500">
+            <div className="bg-gray-400 aspect-square"></div>
+          </CarouselItem>
+          <CarouselItem className=" bg-gray-500">
+            <div className="bg-gray-400 aspect-square"></div>
+          </CarouselItem>
+          <CarouselItem className=" bg-gray-500">
+            <div className="bg-gray-400 aspect-square"></div>
+          </CarouselItem>
+        </CarouselContent>
+      </Carousel>
+
+      <div className="text-sm font-bold">그룹명</div>
+      <div className="flex flex-col items-center gap-4 w-full ">
+        <Input
+          type="text"
+          value={inputGroupName}
+          onChange={(e) => setGroupName(e.target.value)}
+          placeholder="그룹 이름을 입력해주세요"
+        />
+        <Button
+          onClick={() => handleCreateGroup(user?.id, inputGroupName)}
+          className="w-full"
+        >
+          그룹 생성하기
+        </Button>
+        <div className="text-xs text-gray-500">
+          기존 그룹에 참여하고 싶은 경우 그룹장에게 초대링크를 요청해 주세요
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupCreatePage;

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -1,13 +1,49 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ClipLoader } from "react-spinners";
 import useAuth from "../hooks/useAuth";
+import useBaseStore from "@/stores/baseStore";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const { groupId: paramsGroupId } = useParams();
+  const groupList = useBaseStore((state) => state.groupList);
+  const targetGroup = useBaseStore((state) => state.targetGroup);
+  const getGroup = useBaseStore((state) => state.getGroup);
+  const fetchGroupListByUserId = useBaseStore(
+    (state) => state.fetchGroupListByUserId
+  );
+
+  useEffect(() => {
+    fetchGroupListByUserId(user?.id);
+    if (paramsGroupId) getGroup(paramsGroupId);
+  }, [fetchGroupListByUserId, user, paramsGroupId, getGroup]);
+
+  useEffect(() => {
+    if (!paramsGroupId && groupList) {
+      if (groupList.length === 0) {
+        navigate("/group/new");
+        return;
+      } else {
+        navigate(`/group/${groupList[0].id}`);
+        return;
+      }
+    }
+  }, [groupList, navigate, paramsGroupId]);
+
+  if (!groupList || (paramsGroupId && !targetGroup)) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={50} color={"#123abc"} loading={true} />
+      </div>
+    );
+  }
 
   return (
-    <div>
-      <h1 className="text-yellow-300">Group Page</h1>
-      <h2>{user?.id}</h2>
+    <div className="flex flex-col gap-2">
+      <div className="text-lg font-bold">{targetGroup?.name} 그룹</div>
     </div>
   );
 };

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { ClipLoader } from "react-spinners";
 import useAuth from "../hooks/useAuth";
 import useBaseStore from "@/stores/baseStore";
+import { KakaoShareButton } from "@/components/KakaoShareBtn";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
@@ -43,7 +44,12 @@ const GroupPage: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-lg font-bold">{targetGroup?.name} 그룹</div>
+      <div className="flex justify-between items-center">
+        <div className="text-lg font-bold">{targetGroup?.name} 그룹</div>
+        <KakaoShareButton
+          webUrl={`${import.meta.env.VITE_BASE_URL}/${targetGroup?.id}`}
+        ></KakaoShareButton>
+      </div>
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Auth } from "@supabase/auth-ui-react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { supabase } from "../../supabase/client";
 import useAuth from "../hooks/useAuth";
@@ -12,7 +13,16 @@ import {
 const MainPage: React.FC = () => {
   const { user } = useAuth();
 
-  console.log(user?.id);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  if (user) {
+    navigate("/group", { replace: true });
+  }
+
+  const from = location.state?.from?.pathname || "/group";
+  const redirectUrl = `${import.meta.env.VITE_BASE_URL}${from}`;
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-col gap-2  ">
@@ -37,7 +47,7 @@ const MainPage: React.FC = () => {
         </CarouselContent>
       </Carousel>
       <Auth
-        redirectTo={import.meta.env.VITE_BASE_URL}
+        redirectTo={redirectUrl}
         supabaseClient={supabase}
         appearance={{ theme: ThemeSupa }}
         onlyThirdPartyProviders={true}

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -3,6 +3,7 @@ import { immer } from "zustand/middleware/immer";
 import { supabase } from "../../supabase/client";
 import { User } from "@supabase/supabase-js";
 import { Group } from "../../supabase/types/tables";
+import { fetchGroupListByUserId, getGroup } from "@/apis/group";
 
 export interface BaseStore {
   // user
@@ -14,8 +15,8 @@ export interface BaseStore {
   // group
   groupList: Group[] | null;
   targetGroup: Group | null;
-  fetchGroupListByUserId: (userId: string) => void;
-  getGroup: (groupId: string) => void;
+  fetchGroupListByUserId: (userId: string | undefined) => void;
+  getGroup: (groupId: string | undefined) => void;
 }
 
 const useBaseStore = create<BaseStore>()(
@@ -54,30 +55,16 @@ const useBaseStore = create<BaseStore>()(
     // group
     groupList: null,
     targetGroup: null,
-    fetchGroupListByUserId: async (userId: string) => {
-      const { error, data } = await supabase
-        .from("group")
-        .select("*")
-        .eq("user_id", userId);
-      if (error) {
-        console.error("error", error);
-        return;
-      }
+    fetchGroupListByUserId: async (userId: string | undefined) => {
+      if (!userId) return;
+      const data = await fetchGroupListByUserId(userId);
       set((state) => {
         state.groupList = data;
       });
     },
-    getGroup: async (groupId: string) => {
-      const { data, error } = await supabase
-        .from("group")
-        .select("*")
-        .eq("id", groupId)
-        .is("deleted_at", null)
-        .single();
-      if (error) {
-        console.error("Error get group ID:", error);
-        return null;
-      }
+    getGroup: async (groupId: string | undefined) => {
+      if (!groupId) return;
+      const data = await getGroup(groupId);
       set((state) => {
         state.targetGroup = data;
       });

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -9,3 +9,7 @@ export type Profiles = Database["public"]["Tables"]["profiles"]["Row"];
 export type PrayCard = Database["public"]["Tables"]["pray_card"]["Row"];
 
 export type Pray = Database["public"]["Tables"]["pray"]["Row"];
+
+export interface MemberWithGroup extends Member {
+  group: Group;
+}


### PR DESCRIPTION
### 작업 설명
group 도메인에 필요한 페이지와 컴포넌트들을 이전합니다.

### 체크리스트
- [x]  카카오 공유 버튼
- [x]  라우팅, 데이터 fetching 관련 API 쿼리
- [x] GroupPage 이전
- [x]  createGroup 페이지

https://www.notion.so/mmyeong/refactor-8d93e6e0be3e45938073cf683a57daee?pvs=4
