### PR TITLE
refactor: 기도제목 작성뷰 이전

### DIFF
--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -34,3 +34,23 @@ export const fetchPrayCardListByUserId = async (
   }
   return data as PrayCard[];
 };
+
+export const createPrayCard = async (
+  groupId: string | undefined,
+  userId: string | undefined,
+  content: string
+): Promise<PrayCard | null> => {
+  if (!groupId || !userId) {
+    console.error("groupId, userId is required");
+    return null;
+  }
+  const { error, data } = await supabase
+    .from("pray_card")
+    .insert([{ group_id: groupId, user_id: userId, content }])
+    .select();
+  if (error) {
+    console.error("error", error);
+    return null;
+  }
+  return data ? data[0] : null;
+};

--- a/src/components/member/Member.tsx
+++ b/src/components/member/Member.tsx
@@ -2,21 +2,21 @@ import { MemberWithProfiles, PrayCard } from "supabase/types/tables";
 import { formatDateString } from "../../lib/utils";
 
 interface MemberProps {
-  member: MemberWithProfiles;
+  member: MemberWithProfiles | undefined;
   prayCardList: PrayCard[];
 }
 
 const Member: React.FC<MemberProps> = ({ member, prayCardList }) => {
   const prayCard = prayCardList[0] || null;
   return (
-    <div className="flex flex-col gap-2 cursor-pointer bg-gray-600 p-4 rounded mb-2 ">
+    <div className="flex flex-col gap-2 cursor-pointer bg-gray-600 p-4 rounded ">
       <div className="flex items-center">
         <img
-          src={member.profiles.avatar_url || ""}
-          alt={`${member.profiles.full_name}'s avatar`}
+          src={member?.profiles.avatar_url || ""}
+          alt={`${member?.profiles.full_name}'s avatar`}
           className="w-5 h-5 rounded-full mr-4"
         />
-        <h3 className="text-white">{member.profiles.full_name}</h3>
+        <h3 className="text-white">{member?.profiles.full_name}</h3>
       </div>
       <div className="text-left text-sm text-gray-300">
         {prayCard?.content || "아직 기도제목이 없어요"}

--- a/src/components/member/Member.tsx
+++ b/src/components/member/Member.tsx
@@ -1,12 +1,12 @@
 import { MemberWithProfiles, PrayCard } from "supabase/types/tables";
 import { formatDateString } from "../../lib/utils";
 
-interface ProfileProps {
+interface MemberProps {
   member: MemberWithProfiles;
   prayCardList: PrayCard[];
 }
 
-const Profile: React.FC<ProfileProps> = ({ member, prayCardList }) => {
+const Member: React.FC<MemberProps> = ({ member, prayCardList }) => {
   const prayCard = prayCardList[0] || null;
   return (
     <div className="flex flex-col gap-2 cursor-pointer bg-gray-600 p-4 rounded mb-2 ">
@@ -28,4 +28,4 @@ const Profile: React.FC<ProfileProps> = ({ member, prayCardList }) => {
   );
 };
 
-export default Profile;
+export default Member;

--- a/src/components/member/MemberList.tsx
+++ b/src/components/member/MemberList.tsx
@@ -3,6 +3,7 @@ import useBaseStore from "@/stores/baseStore";
 import { ClipLoader } from "react-spinners";
 import { userIdPrayCardListHash } from "../../../supabase/types/tables";
 import Member from "./Member";
+import PrayCardCreateModal from "../prayCard/PrayCardCreateModal";
 
 interface MembersProps {
   currentUserId: string | undefined;
@@ -46,7 +47,10 @@ const MemberList: React.FC<MembersProps> = ({ currentUserId, groupId }) => {
   }, {} as userIdPrayCardListHash);
 
   if (!userIdPrayCardListHash[currentUserId || ""]) {
-    return <div>기도카드 작성 모달</div>;
+    // TODO: 모달로 변경 필요
+    return (
+      <PrayCardCreateModal currentUserId={currentUserId} groupId={groupId} />
+    );
   }
 
   return (

--- a/src/components/member/MemberList.tsx
+++ b/src/components/member/MemberList.tsx
@@ -38,6 +38,13 @@ const MemberList: React.FC<MembersProps> = ({ currentUserId, groupId }) => {
     );
   }
 
+  const currentMember = memberList.find(
+    (member) => member.user_id === currentUserId
+  );
+  const otherMembers = memberList.filter(
+    (member) => member.user_id !== currentUserId
+  );
+
   const userIdPrayCardListHash = memberList.reduce((hash, member) => {
     const prayCardList = groupPrayCardList.filter(
       (prayCard) => prayCard.user_id === member.user_id
@@ -54,15 +61,26 @@ const MemberList: React.FC<MembersProps> = ({ currentUserId, groupId }) => {
   }
 
   return (
-    <div>
-      맴버 리스트
-      {memberList.map((member) => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <div className="text-sm ">내 기도제목</div>
         <Member
-          key={member.id}
-          member={member}
-          prayCardList={userIdPrayCardListHash[member.user_id || ""]}
-        ></Member>
-      ))}
+          member={currentMember}
+          prayCardList={userIdPrayCardListHash[currentUserId || ""]}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="text-sm">Members({otherMembers.length + 1})</div>
+        <div className="flex flex-col gap-2">
+          {otherMembers.map((member) => (
+            <Member
+              key={member.id}
+              member={member}
+              prayCardList={userIdPrayCardListHash[member.user_id || ""]}
+            ></Member>
+          ))}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -1,0 +1,64 @@
+import { Textarea } from "../ui/textarea";
+import { Button } from "../ui/button";
+import useBaseStore from "@/stores/baseStore";
+
+interface PrayCardCreateModalProps {
+  currentUserId: string | undefined;
+  groupId: string | undefined;
+}
+
+const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
+  currentUserId,
+  groupId,
+}) => {
+  const memberList = useBaseStore((state) => state.memberList);
+  const inputPrayCardContent = useBaseStore(
+    (state) => state.inputPrayCardContent
+  );
+  const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
+  const createMember = useBaseStore((state) => state.createMember);
+  const createPrayCard = useBaseStore((state) => state.createPrayCard);
+
+  const handleCreatePrayCard = async (
+    currentUserId: string | undefined,
+    groupId: string | undefined
+  ) => {
+    const isMember = memberList?.some(
+      (member) => member.user_id === currentUserId
+    );
+    if (!isMember) {
+      await createMember(groupId, currentUserId);
+    }
+    await createPrayCard(groupId, currentUserId, inputPrayCardContent);
+    window.location.reload();
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-start min-h-screen mt-4 gap-4">
+      <div className="w-full flex flex-col">
+        <div className="text-lg font-bold">기도제목 작성 </div>
+        <div className="text-sm text-gray-500">
+          기도제목을 작성하면 그룹에 참여할 수 있어요
+        </div>
+      </div>
+      <div className="flex items-center justify-center w-full">
+        <Textarea
+          className="h-48"
+          placeholder="여기에 기도제목을 작성해주세요..."
+          value={inputPrayCardContent}
+          onChange={(e) => setPrayCardContent(e.target.value)}
+        />
+      </div>
+      <div className="mt-4 flex flex-col items-center justify-center text-center">
+        <Button
+          className="w-full bg-black hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          onClick={() => handleCreatePrayCard(currentUserId, groupId)}
+        >
+          그룹 참여하기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PrayCardCreateModal;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -44,7 +44,7 @@ const GroupPage: React.FC = () => {
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-10">
       <div className="flex justify-between items-center">
         <div className="text-lg font-bold">{targetGroup?.name} 그룹</div>
         <KakaoShareButton

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -13,6 +13,7 @@ import {
 import { fetchGroupListByUserId, getGroup, createGroup } from "@/apis/group";
 import { fetchMemberListByGroupId, createMember } from "@/apis/member";
 import {
+  createPrayCard,
   fetchPrayCardListByGroupId,
   fetchPrayCardListByUserId,
 } from "@/apis/prayCard";
@@ -30,6 +31,7 @@ export interface BaseStore {
   inputGroupName: string;
   fetchGroupListByUserId: (userId: string | undefined) => Promise<void>;
   getGroup: (groupId: string | undefined) => Promise<void>;
+  setGroupName: (groupName: string) => void;
   createGroup: (
     userId: string | undefined,
     name: string | undefined,
@@ -45,19 +47,25 @@ export interface BaseStore {
     groupId: string | undefined,
     userId: string | undefined
   ) => Promise<Member | null>;
-  setGroupName: (groupName: string) => void;
 
   // prayCard
   groupPrayCardList: PrayCard[] | null;
   userPrayCardList: PrayCard[] | null;
   userIdPrayCardListHash: userIdPrayCardListHash | null;
   targetPrayCard: PrayCard | null;
+  inputPrayCardContent: string;
   fetchPrayCardListByGroupId: (groupId: string | undefined) => Promise<void>;
   fetchPrayCardListByUserId: (userId: string | undefined) => Promise<void>;
   createUserIdPrayCardListHash: (
     memberList: MemberWithProfiles[],
     groupPrayCardList: PrayCard[]
   ) => userIdPrayCardListHash;
+  createPrayCard: (
+    groupId: string | undefined,
+    userId: string | undefined,
+    content: string
+  ) => Promise<PrayCard | null>;
+  setPrayCardContent: (content: string) => void;
 }
 
 const useBaseStore = create<BaseStore>()(
@@ -142,9 +150,6 @@ const useBaseStore = create<BaseStore>()(
       userId: string | undefined
     ): Promise<Member | null> => {
       const member = await createMember(groupId, userId);
-      set((state) => {
-        state.targetMember = member;
-      });
       return member;
     },
 
@@ -153,6 +158,7 @@ const useBaseStore = create<BaseStore>()(
     userPrayCardList: null,
     userIdPrayCardListHash: null,
     targetPrayCard: null,
+    inputPrayCardContent: "",
     fetchPrayCardListByGroupId: async (groupId: string | undefined) => {
       const groupPrayCardList = await fetchPrayCardListByGroupId(groupId);
       set((state) => {
@@ -180,6 +186,19 @@ const useBaseStore = create<BaseStore>()(
         state.userIdPrayCardListHash = userIdPrayCardListHash;
       });
       return userIdPrayCardListHash;
+    },
+    createPrayCard: async (
+      groupId: string | undefined,
+      userId: string | undefined,
+      content: string
+    ) => {
+      const prayCard = await createPrayCard(groupId, userId, content);
+      return prayCard;
+    },
+    setPrayCardContent: (content: string) => {
+      set((state) => {
+        state.inputPrayCardContent = content;
+      });
     },
   }))
 );


### PR DESCRIPTION
기도제목 작성뷰를 이전합니다.

Member fetch 과정에서 현재 유저가 member 목록에 없을 때 insert 하는 부분이 있었는데
이부분 사이드이펙트가 있을 것 같아 기도제목 작성할 때 Member insert 하도록 수정하였습니다.

기존에 Profiles 로 사용되고 있는 컴포넌트는 일단 통일을 위해 Member 로 가져갔습니다.
(MemberList-Member 구조)
이후에 논의에 따라 Profile 로 통일해도 좋을 것 같습니다.

### 체크리스트
- [x]  현재 맴버(내 기도제목), Member 목록 구분
- [x]  첫 유저 기도카드 생성 및 기존 유저 기도카드 생성 구분
    ~~memberList 에 있으면 기도카드만 생성~~
    ~~없으면 Member, 기도카드 같이 생성~~

### 노션 링크
https://www.notion.so/mmyeong/refactor-8d93e6e0be3e45938073cf683a57daee?pvs=4