### PR TITLE
refactor: prayList 드로워 이전

### DIFF
--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -1,13 +1,13 @@
 import { supabase } from "../../supabase/client";
-import { PrayCard } from "../../supabase/types/tables";
+import { PrayCard, PrayCardWithProfiles } from "../../supabase/types/tables";
 
 export const fetchPrayCardListByGroupId = async (
   groupId: string | undefined
-): Promise<PrayCard[] | null> => {
+): Promise<PrayCardWithProfiles[] | null> => {
   if (!groupId) return null;
   const { data, error } = await supabase
     .from("pray_card")
-    .select("*")
+    .select(`*, profiles (id, full_name, avatar_url)`)
     .eq("group_id", groupId)
     .is("deleted_at", null);
   // TODO : 이후에 7일 이내의 데이터만 가져오도록 수정 필요
@@ -15,16 +15,16 @@ export const fetchPrayCardListByGroupId = async (
     console.error("error", error);
     return null;
   }
-  return data as PrayCard[];
+  return data as PrayCardWithProfiles[];
 };
 
 export const fetchPrayCardListByUserId = async (
   userId: string | undefined
-): Promise<PrayCard[] | null> => {
+): Promise<PrayCardWithProfiles[] | null> => {
   if (!userId) return null;
   const { data, error } = await supabase
     .from("pray_card")
-    .select("*")
+    .select(`*, profiles (id, full_name, avatar_url)`)
     .eq("user_id", userId)
     .is("deleted_at", null)
     .limit(10); // TODO: 이후 페이지네이션 적용 필요
@@ -32,7 +32,7 @@ export const fetchPrayCardListByUserId = async (
     console.error("error", error);
     return null;
   }
-  return data as PrayCard[];
+  return data as PrayCardWithProfiles[];
 };
 
 export const createPrayCard = async (

--- a/src/components/member/Member.tsx
+++ b/src/components/member/Member.tsx
@@ -1,4 +1,7 @@
-import { MemberWithProfiles, PrayCard } from "supabase/types/tables";
+import {
+  MemberWithProfiles,
+  PrayCardWithProfiles,
+} from "supabase/types/tables";
 import { getISODate } from "../../lib/utils";
 import {
   Drawer,
@@ -13,7 +16,7 @@ import PrayCardUI from "../prayCard/PrayCardUI";
 interface MemberProps {
   currentUserId: string | undefined;
   member: MemberWithProfiles | undefined;
-  prayCardList: PrayCard[];
+  prayCardList: PrayCardWithProfiles[];
 }
 
 const Member: React.FC<MemberProps> = ({
@@ -51,11 +54,7 @@ const Member: React.FC<MemberProps> = ({
           <DrawerDescription></DrawerDescription>
         </DrawerHeader>
         {/* PrayCard */}
-        <PrayCardUI
-          currentUserId={currentUserId}
-          member={member}
-          prayCard={prayCard}
-        />
+        <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
         {/* PrayCard */}
       </DrawerContent>
     </Drawer>

--- a/src/components/member/MemberList.tsx
+++ b/src/components/member/MemberList.tsx
@@ -74,7 +74,7 @@ const MemberList: React.FC<MembersProps> = ({ currentUserId, groupId }) => {
       <div className="flex flex-col gap-2">
         <div className="text-sm">Members({otherMembers.length + 1})</div>
         <div className="flex flex-col gap-2">
-          <TodayPrayBtn />
+          <TodayPrayBtn currentUserId={currentUserId} />
           {otherMembers.map((member) => (
             <Member
               key={member.id}

--- a/src/components/member/MemberList.tsx
+++ b/src/components/member/MemberList.tsx
@@ -4,6 +4,7 @@ import { ClipLoader } from "react-spinners";
 import { userIdPrayCardListHash } from "../../../supabase/types/tables";
 import Member from "./Member";
 import PrayCardCreateModal from "../prayCard/PrayCardCreateModal";
+import TodayPrayBtn from "../prayCard/TodayPrayBtn";
 
 interface MembersProps {
   currentUserId: string | undefined;
@@ -73,6 +74,7 @@ const MemberList: React.FC<MembersProps> = ({ currentUserId, groupId }) => {
       <div className="flex flex-col gap-2">
         <div className="text-sm">Members({otherMembers.length + 1})</div>
         <div className="flex flex-col gap-2">
+          <TodayPrayBtn />
           {otherMembers.map((member) => (
             <Member
               key={member.id}

--- a/src/components/prayCard/PrayCardBtn.tsx
+++ b/src/components/prayCard/PrayCardBtn.tsx
@@ -1,10 +1,10 @@
 import { PrayType } from "@/Enums/prayType";
-import { PrayCard } from "supabase/types/tables";
+import { PrayCardWithProfiles } from "supabase/types/tables";
 import useBaseStore from "@/stores/baseStore";
 
 interface PrayCardBtnProps {
   currentUserId: string | undefined;
-  prayCard: PrayCard | undefined;
+  prayCard: PrayCardWithProfiles | undefined;
 }
 
 const PrayCardBtn: React.FC<PrayCardBtnProps> = ({

--- a/src/components/prayCard/PrayCardBtn.tsx
+++ b/src/components/prayCard/PrayCardBtn.tsx
@@ -22,7 +22,7 @@ const PrayCardBtn: React.FC<PrayCardBtnProps> = ({
   };
 
   return (
-    <div className="flex justify-between w-full">
+    <div className="flex justify-center space-x-8">
       {Object.values(PrayType).map((type) => {
         const { emoji, text } = getEmoji(type as PrayType);
         return (
@@ -31,7 +31,7 @@ const PrayCardBtn: React.FC<PrayCardBtnProps> = ({
             onClick={() =>
               createPray(prayCard?.id, currentUserId, type as PrayType)
             }
-            className={`w-[90px] py-2 px-4 flex flex-col items-center rounded-2xl ${
+            className={`w-[90px] py-2 px-2 flex flex-col items-center rounded-2xl ${
               todayPrayType === type
                 ? "bg-gray-300 cursor-not-allowed"
                 : "bg-purple-100 text-black"
@@ -39,7 +39,7 @@ const PrayCardBtn: React.FC<PrayCardBtnProps> = ({
             disabled={Boolean(todayPrayType)}
           >
             <div className="text-2xl">{emoji}</div>
-            <div>{text}</div>
+            <div className="text-sm">{text}</div>
           </button>
         );
       })}

--- a/src/components/prayCard/PrayCardCalendar.tsx
+++ b/src/components/prayCard/PrayCardCalendar.tsx
@@ -1,9 +1,9 @@
 import { getISODate, getISOToday } from "@/lib/utils";
 import useBaseStore from "@/stores/baseStore";
-import { Pray, PrayCard } from "supabase/types/tables";
+import { Pray, PrayCardWithProfiles } from "supabase/types/tables";
 
 interface PrayCardCalendarProps {
-  prayCard: PrayCard | undefined;
+  prayCard: PrayCardWithProfiles | undefined;
   prayData: Pray[];
 }
 

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -1,0 +1,59 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from "@/components/ui/carousel";
+import useBaseStore from "@/stores/baseStore";
+import PrayCardUI from "./PrayCardUI";
+import { type CarouselApi } from "@/components/ui/carousel";
+import { useEffect, useState } from "react";
+
+interface PrayCardListProps {
+  currentUserId: string | undefined;
+}
+
+// TODO: PrayData 한번에 가져와서 미리 렌더링 할 수 있도록 수정
+const PrayCardList: React.FC<PrayCardListProps> = ({ currentUserId }) => {
+  const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
+
+  const [api, setApi] = useState<CarouselApi>();
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+    setCurrent(api.selectedScrollSnap() + 1);
+    api.on("select", () => {
+      setCurrent(api.selectedScrollSnap() + 1);
+    });
+  }, [api]);
+
+  return (
+    <Carousel setApi={setApi}>
+      <CarouselContent>
+        <CarouselItem className="basis-5/6 pointer-events-none">
+          <div className="flex justify-center items-center w-full aspect-square">
+            start
+          </div>
+        </CarouselItem>
+        {groupPrayCardList?.map((prayCard, index) => (
+          <CarouselItem key={prayCard.id} className="basis-5/6">
+            {(current - 1 === index + 2 ||
+              current === index + 2 ||
+              current + 1 === index + 2) && (
+              <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
+            )}
+          </CarouselItem>
+        ))}
+        <CarouselItem className="basis-5/6 pointer-events-none">
+          <div className="flex justify-center items-center w-full aspect-square">
+            end
+          </div>
+        </CarouselItem>
+      </CarouselContent>
+    </Carousel>
+  );
+};
+
+export default PrayCardList;

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,22 +1,16 @@
 import useBaseStore from "@/stores/baseStore";
 import { useEffect } from "react";
-import { MemberWithProfiles, PrayCard } from "supabase/types/tables";
+import { PrayCardWithProfiles } from "supabase/types/tables";
 import PrayCardCalendar from "./PrayCardCalendar";
 import PrayCardBtn from "./PrayCardBtn";
 import { ClipLoader } from "react-spinners";
-import { current } from "immer";
 
 interface PrayCardProps {
   currentUserId: string | undefined;
-  member: MemberWithProfiles | undefined;
-  prayCard: PrayCard | undefined;
+  prayCard: PrayCardWithProfiles | undefined;
 }
 
-const PrayCardUI: React.FC<PrayCardProps> = ({
-  currentUserId,
-  member,
-  prayCard,
-}) => {
+const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
   const userPrayData = useBaseStore((state) => state.userPrayData);
   const fetchPrayDataByUserId = useBaseStore(
     (state) => state.fetchPrayDataByUserId
@@ -38,10 +32,10 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
     <div className="flex flex-col h-full p-5 bg-blue-50 rounded-2xl">
       <div className="flex items-center gap-2">
         <img
-          src={member?.profiles.avatar_url || ""}
+          src={prayCard?.profiles.avatar_url || ""}
           className="w-5 h-5 rounded-full"
         />
-        <div className="text-sm">{member?.profiles.full_name}</div>
+        <div className="text-sm">{prayCard?.profiles.full_name}</div>
       </div>
       <div className="flex h-full justify-center items-center">
         {prayCard?.content}
@@ -52,7 +46,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
   return (
     <div className="flex flex-col h-full gap-6">
       {PrayCardBody}
-      {currentUserId != member?.user_id && (
+      {currentUserId != prayCard?.user_id && (
         <div className="flex flex-col gap-6">
           <PrayCardCalendar prayCard={prayCard} prayData={userPrayData || []} />
           <PrayCardBtn currentUserId={currentUserId} prayCard={prayCard} />

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -29,7 +29,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
   }
 
   const PrayCardBody = (
-    <div className="flex flex-col h-full p-5 bg-blue-50 rounded-2xl">
+    <div className="flex flex-col h-50vh p-5 bg-blue-50 rounded-2xl">
       <div className="flex items-center gap-2">
         <img
           src={prayCard?.profiles.avatar_url || ""}
@@ -44,7 +44,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
   );
 
   return (
-    <div className="flex flex-col h-full gap-6">
+    <div className="flex flex-col gap-6">
       {PrayCardBody}
       {currentUserId != prayCard?.user_id && (
         <div className="flex flex-col gap-6">

--- a/src/components/prayCard/TodayPrayBtn.tsx
+++ b/src/components/prayCard/TodayPrayBtn.tsx
@@ -1,0 +1,43 @@
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import PrayCardList from "./PrayCardList";
+
+interface TodayPrayBtnProps {
+  currentUserId: string | undefined;
+}
+
+const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ currentUserId }) => {
+  const todayPrayBtn = (
+    <div
+      className="className= flex flex-col justify-center h-12
+      bg-black text-white
+      rounded cursor-pointer
+      "
+    >
+      오늘의 기도
+    </div>
+  );
+
+  return (
+    <Drawer>
+      <DrawerTrigger>{todayPrayBtn}</DrawerTrigger>
+      <DrawerContent className="max-w-[480px] mx-auto w-full h-[90%] pb-20">
+        <DrawerHeader>
+          <DrawerTitle></DrawerTitle>
+          <DrawerDescription></DrawerDescription>
+        </DrawerHeader>
+        {/* PrayCardList */}
+        <PrayCardList currentUserId={currentUserId} />
+        {/* PrayCardList */}
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default TodayPrayBtn;

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -13,6 +13,7 @@ import {
   MemberWithProfiles,
   Pray,
   PrayCard,
+  PrayCardWithProfiles,
   UserIdMemberHash,
   userIdPrayCardListHash,
 } from "../../supabase/types/tables";
@@ -57,16 +58,16 @@ export interface BaseStore {
   ) => Promise<Member | null>;
 
   // prayCard
-  groupPrayCardList: PrayCard[] | null;
-  userPrayCardList: PrayCard[] | null;
+  groupPrayCardList: PrayCardWithProfiles[] | null;
+  userPrayCardList: PrayCardWithProfiles[] | null;
   userIdPrayCardListHash: userIdPrayCardListHash | null;
-  targetPrayCard: PrayCard | null;
+  targetPrayCard: PrayCardWithProfiles | null;
   inputPrayCardContent: string;
   fetchPrayCardListByGroupId: (groupId: string | undefined) => Promise<void>;
   fetchPrayCardListByUserId: (userId: string | undefined) => Promise<void>;
   createUserIdPrayCardListHash: (
     memberList: MemberWithProfiles[],
-    groupPrayCardList: PrayCard[]
+    groupPrayCardList: PrayCardWithProfiles[]
   ) => userIdPrayCardListHash;
   createPrayCard: (
     groupId: string | undefined,
@@ -79,6 +80,7 @@ export interface BaseStore {
   prayData: Pray[] | null;
   userPrayData: Pray[] | null;
   todayPrayType: string | null;
+  isTodayPray: boolean;
   fetchPrayData: (prayCardId: string | undefined) => Promise<void>;
   fetchPrayDataByUserId: (
     prayCardId: string | undefined,
@@ -197,7 +199,7 @@ const useBaseStore = create<BaseStore>()(
     },
     createUserIdPrayCardListHash: (
       memberList: MemberWithProfiles[],
-      groupPrayCardList: PrayCard[]
+      groupPrayCardList: PrayCardWithProfiles[]
     ) => {
       const userIdPrayCardListHash = memberList.reduce((hash, member) => {
         hash[member.user_id || ""] = [];
@@ -229,6 +231,7 @@ const useBaseStore = create<BaseStore>()(
     prayData: null,
     userPrayData: null,
     todayPrayType: null,
+    isTodayPray: false,
     fetchPrayData: async (prayCardId: string | undefined) => {
       const prayData = await fetchPrayData(prayCardId);
       set((state) => {

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -18,10 +18,14 @@ export interface MemberWithProfiles extends Member {
   profiles: Profiles;
 }
 
+export interface PrayCardWithProfiles extends PrayCard {
+  profiles: Profiles;
+}
+
 export interface UserIdMemberHash {
   [key: string]: MemberWithProfiles;
 }
 
 export interface userIdPrayCardListHash {
-  [key: string]: PrayCard[];
+  [key: string]: PrayCardWithProfiles[];
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,10 +2,10 @@
 module.exports = {
   darkMode: ["class"],
   content: [
-    './pages/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}',
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {
@@ -71,7 +71,19 @@ module.exports = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      height: {
+        "10vh": "10vh",
+        "20vh": "20vh",
+        "30vh": "30vh",
+        "40vh": "40vh",
+        "50vh": "50vh",
+        "60vh": "60vh",
+        "70vh": "70vh",
+        "80vh": "80vh",
+        "90vh": "90vh",
+        "100vh": "100vh",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],
-}
+};


### PR DESCRIPTION
prayList 드로워를 이전합니다.

PrayCardUI 를 재사용하기 위해 카드를 넘길 때마다 재랜더링 되도록 작성하였는데
이 부분은 이후에 한번에 불러올 수 있도록 수정하면 좋을 것 같습니다.