### PR TITLE
refactor: PrayCardList 데이터 관리

### DIFF
--- a/src/apis/pray.ts
+++ b/src/apis/pray.ts
@@ -59,24 +59,6 @@ export const fetchPrayDataByUserId = async (
   return data as Pray[];
 };
 
-export const bulkFetchPrayDataByUserId = async (
-  prayCardIds: string[] | undefined,
-  userId: string | undefined
-): Promise<Pray[]> => {
-  if (!userId || !prayCardIds) return [];
-  const { data, error } = await supabase
-    .from("pray")
-    .select("*")
-    .in("pray_card_id", prayCardIds)
-    .eq("user_id", userId)
-    .is("deleted_at", null);
-  if (error) {
-    console.error("error", error);
-    return [];
-  }
-  return data as Pray[];
-};
-
 export const createPray = async (
   PrayCardId: string | undefined,
   userId: string | undefined,

--- a/src/apis/pray.ts
+++ b/src/apis/pray.ts
@@ -59,6 +59,24 @@ export const fetchPrayDataByUserId = async (
   return data as Pray[];
 };
 
+export const bulkFetchPrayDataByUserId = async (
+  prayCardIds: string[] | undefined,
+  userId: string | undefined
+): Promise<Pray[]> => {
+  if (!userId || !prayCardIds) return [];
+  const { data, error } = await supabase
+    .from("pray")
+    .select("*")
+    .in("pray_card_id", prayCardIds)
+    .eq("user_id", userId)
+    .is("deleted_at", null);
+  if (error) {
+    console.error("error", error);
+    return [];
+  }
+  return data as Pray[];
+};
+
 export const createPray = async (
   PrayCardId: string | undefined,
   userId: string | undefined,

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -3,12 +3,8 @@ import {
   CarouselContent,
   CarouselItem,
 } from "@/components/ui/carousel";
-import { PrayType } from "@/Enums/prayType";
-import { getISODate, getISOToday } from "@/lib/utils";
 import useBaseStore from "@/stores/baseStore";
-import { useEffect } from "react";
-import { ClipLoader } from "react-spinners";
-import { Pray } from "supabase/types/tables";
+import PrayCardUI from "./PrayCardUI";
 
 interface PrayCardListProps {
   currentUserId: string | undefined;
@@ -17,63 +13,6 @@ interface PrayCardListProps {
 // TODO: PrayData 한번에 가져와서 미리 렌더링 할 수 있도록 수정
 const PrayCardList: React.FC<PrayCardListProps> = ({ currentUserId }) => {
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
-  const bulkFetchPrayDataByUserId = useBaseStore(
-    (state) => state.bulkFetchPrayDataByUserId
-  );
-  const prayCardIdPrayDataHash = useBaseStore(
-    (state) => state.prayCardIdPrayDataHash
-  );
-  const createPray = useBaseStore((state) => state.createPray);
-
-  useEffect(() => {
-    if (groupPrayCardList) {
-      bulkFetchPrayDataByUserId(
-        currentUserId,
-        groupPrayCardList.map((prayCard) => prayCard.id)
-      );
-    }
-  }, [bulkFetchPrayDataByUserId, currentUserId, groupPrayCardList]);
-
-  if (!prayCardIdPrayDataHash) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <ClipLoader size={50} color={"#123abc"} loading={true} />
-      </div>
-    );
-  }
-
-  const getEmoji = (prayType: PrayType) => {
-    if (prayType === "pray") return { emoji: "🙏", text: "기도해요" };
-    if (prayType === "good") return { emoji: "👍", text: "힘내세요" };
-    if (prayType === "like") return { emoji: "❤️", text: "응원해요" };
-    return { emoji: "", text: "" };
-  };
-
-  const generateDates = (
-    createdAt: string | undefined,
-    prayData: Pray[] | undefined
-  ) => {
-    if (!createdAt) return [];
-    const startDate = getISODate(createdAt);
-    const dateList = [];
-
-    for (let i = 0; i < 7; i++) {
-      const newDate = new Date(startDate);
-      newDate.setDate(new Date(startDate).getDate() + i);
-      const newDateString = newDate.toISOString().split("T")[0];
-
-      const pray = prayData?.find((entry) => {
-        const prayDate = getISODate(entry.created_at).split("T")[0];
-        return prayDate === newDateString;
-      });
-
-      const emoji = pray ? getEmoji(pray.pray_type as PrayType)["emoji"] : "";
-      dateList.push({ date: newDateString, emoji: emoji });
-    }
-    return dateList;
-  };
-
-  const currentDate = getISOToday().split("T")[0];
 
   return (
     <Carousel>
@@ -83,97 +22,11 @@ const PrayCardList: React.FC<PrayCardListProps> = ({ currentUserId }) => {
             start
           </div>
         </CarouselItem>
-        {groupPrayCardList?.map((prayCard) => {
-          const prayData = prayCardIdPrayDataHash[prayCard.id];
-          const weeklyDays = generateDates(prayCard.created_at, prayData);
-          const todayPrayType = prayData?.find(
-            (pray) =>
-              pray.user_id === currentUserId &&
-              new Date(pray.created_at.split("T")[0]) >=
-                new Date(getISOToday().split("T")[0])
-          )?.pray_type;
-
-          return (
-            <CarouselItem key={prayCard.id} className="basis-5/6">
-              {/* prayCardBody */}
-              <div className="flex flex-col h-50vh p-5 bg-blue-50 rounded-2xl">
-                <div className="flex items-center gap-2">
-                  <img
-                    src={prayCard?.profiles.avatar_url || ""}
-                    className="w-5 h-5 rounded-full"
-                  />
-                  <div className="text-sm">{prayCard?.profiles.full_name}</div>
-                </div>
-                <div className="flex h-full justify-center items-center">
-                  {prayCard?.content}
-                </div>
-              </div>
-              {/* prayCardBody */}
-
-              {/* weeklyCalendar */}
-              <div className="flex justify-center space-x-4">
-                {weeklyDays.map((date) => {
-                  const isToday = date.date === currentDate;
-                  const day = new Date(date.date).getDate(); // Extract the day part of the date
-                  return (
-                    <div key={date.date} className="flex flex-col items-center">
-                      <span
-                        className={`text-sm ${
-                          isToday ? "font-bold text-black" : "text-gray-400"
-                        }`}
-                      >
-                        {day}
-                      </span>
-                      <div
-                        className={`w-8 h-8 flex items-center justify-center rounded ${
-                          isToday ? "bg-red-100" : "bg-gray-200"
-                        }`}
-                      >
-                        <span
-                          className={`text-2xl ${
-                            isToday ? "text-red-500" : "text-gray-500"
-                          }`}
-                        >
-                          {date.emoji}
-                        </span>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-              {/* weeklyCalendar */}
-
-              {/* ReactionBtn */}
-              <div className="flex justify-center space-x-8">
-                {Object.values(PrayType).map((type) => {
-                  const { emoji, text } = getEmoji(type as PrayType);
-                  return (
-                    <button
-                      key={type}
-                      onClick={() =>
-                        createPray(
-                          prayCard?.id,
-                          currentUserId,
-                          type as PrayType
-                        )
-                      }
-                      className={`w-[90px] py-2 px-2 flex flex-col items-center rounded-2xl ${
-                        todayPrayType === type
-                          ? "bg-gray-300 cursor-not-allowed"
-                          : "bg-purple-100 text-black"
-                      }`}
-                      disabled={Boolean(todayPrayType)}
-                    >
-                      <div className="text-2xl">{emoji}</div>
-                      <div className="text-sm">{text}</div>
-                    </button>
-                  );
-                })}
-              </div>
-              {/* ReactionBtn */}
-            </CarouselItem>
-          );
-        })}
+        {groupPrayCardList?.map((prayCard) => (
+          <CarouselItem key={prayCard.id} className="basis-5/6">
+            <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
+          </CarouselItem>
+        ))}
         <CarouselItem className="basis-5/6 pointer-events-none">
           <div className="flex justify-center items-center w-full aspect-square">
             end

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -3,10 +3,12 @@ import {
   CarouselContent,
   CarouselItem,
 } from "@/components/ui/carousel";
+import { PrayType } from "@/Enums/prayType";
+import { getISODate, getISOToday } from "@/lib/utils";
 import useBaseStore from "@/stores/baseStore";
-import PrayCardUI from "./PrayCardUI";
-import { type CarouselApi } from "@/components/ui/carousel";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { ClipLoader } from "react-spinners";
+import { Pray } from "supabase/types/tables";
 
 interface PrayCardListProps {
   currentUserId: string | undefined;
@@ -15,37 +17,163 @@ interface PrayCardListProps {
 // TODO: PrayData 한번에 가져와서 미리 렌더링 할 수 있도록 수정
 const PrayCardList: React.FC<PrayCardListProps> = ({ currentUserId }) => {
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
-
-  const [api, setApi] = useState<CarouselApi>();
-  const [current, setCurrent] = useState(0);
+  const bulkFetchPrayDataByUserId = useBaseStore(
+    (state) => state.bulkFetchPrayDataByUserId
+  );
+  const prayCardIdPrayDataHash = useBaseStore(
+    (state) => state.prayCardIdPrayDataHash
+  );
+  const createPray = useBaseStore((state) => state.createPray);
 
   useEffect(() => {
-    if (!api) {
-      return;
+    if (groupPrayCardList) {
+      bulkFetchPrayDataByUserId(
+        currentUserId,
+        groupPrayCardList.map((prayCard) => prayCard.id)
+      );
     }
-    setCurrent(api.selectedScrollSnap() + 1);
-    api.on("select", () => {
-      setCurrent(api.selectedScrollSnap() + 1);
-    });
-  }, [api]);
+  }, [bulkFetchPrayDataByUserId, currentUserId, groupPrayCardList]);
+
+  if (!prayCardIdPrayDataHash) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={50} color={"#123abc"} loading={true} />
+      </div>
+    );
+  }
+
+  const getEmoji = (prayType: PrayType) => {
+    if (prayType === "pray") return { emoji: "🙏", text: "기도해요" };
+    if (prayType === "good") return { emoji: "👍", text: "힘내세요" };
+    if (prayType === "like") return { emoji: "❤️", text: "응원해요" };
+    return { emoji: "", text: "" };
+  };
+
+  const generateDates = (
+    createdAt: string | undefined,
+    prayData: Pray[] | undefined
+  ) => {
+    if (!createdAt) return [];
+    const startDate = getISODate(createdAt);
+    const dateList = [];
+
+    for (let i = 0; i < 7; i++) {
+      const newDate = new Date(startDate);
+      newDate.setDate(new Date(startDate).getDate() + i);
+      const newDateString = newDate.toISOString().split("T")[0];
+
+      const pray = prayData?.find((entry) => {
+        const prayDate = getISODate(entry.created_at).split("T")[0];
+        return prayDate === newDateString;
+      });
+
+      const emoji = pray ? getEmoji(pray.pray_type as PrayType)["emoji"] : "";
+      dateList.push({ date: newDateString, emoji: emoji });
+    }
+    return dateList;
+  };
+
+  const currentDate = getISOToday().split("T")[0];
 
   return (
-    <Carousel setApi={setApi}>
+    <Carousel>
       <CarouselContent>
         <CarouselItem className="basis-5/6 pointer-events-none">
           <div className="flex justify-center items-center w-full aspect-square">
             start
           </div>
         </CarouselItem>
-        {groupPrayCardList?.map((prayCard, index) => (
-          <CarouselItem key={prayCard.id} className="basis-5/6">
-            {(current - 1 === index + 2 ||
-              current === index + 2 ||
-              current + 1 === index + 2) && (
-              <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
-            )}
-          </CarouselItem>
-        ))}
+        {groupPrayCardList?.map((prayCard) => {
+          const prayData = prayCardIdPrayDataHash[prayCard.id];
+          const weeklyDays = generateDates(prayCard.created_at, prayData);
+          const todayPrayType = prayData?.find(
+            (pray) =>
+              pray.user_id === currentUserId &&
+              new Date(pray.created_at.split("T")[0]) >=
+                new Date(getISOToday().split("T")[0])
+          )?.pray_type;
+
+          return (
+            <CarouselItem key={prayCard.id} className="basis-5/6">
+              {/* prayCardBody */}
+              <div className="flex flex-col h-50vh p-5 bg-blue-50 rounded-2xl">
+                <div className="flex items-center gap-2">
+                  <img
+                    src={prayCard?.profiles.avatar_url || ""}
+                    className="w-5 h-5 rounded-full"
+                  />
+                  <div className="text-sm">{prayCard?.profiles.full_name}</div>
+                </div>
+                <div className="flex h-full justify-center items-center">
+                  {prayCard?.content}
+                </div>
+              </div>
+              {/* prayCardBody */}
+
+              {/* weeklyCalendar */}
+              <div className="flex justify-center space-x-4">
+                {weeklyDays.map((date) => {
+                  const isToday = date.date === currentDate;
+                  const day = new Date(date.date).getDate(); // Extract the day part of the date
+                  return (
+                    <div key={date.date} className="flex flex-col items-center">
+                      <span
+                        className={`text-sm ${
+                          isToday ? "font-bold text-black" : "text-gray-400"
+                        }`}
+                      >
+                        {day}
+                      </span>
+                      <div
+                        className={`w-8 h-8 flex items-center justify-center rounded ${
+                          isToday ? "bg-red-100" : "bg-gray-200"
+                        }`}
+                      >
+                        <span
+                          className={`text-2xl ${
+                            isToday ? "text-red-500" : "text-gray-500"
+                          }`}
+                        >
+                          {date.emoji}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              {/* weeklyCalendar */}
+
+              {/* ReactionBtn */}
+              <div className="flex justify-center space-x-8">
+                {Object.values(PrayType).map((type) => {
+                  const { emoji, text } = getEmoji(type as PrayType);
+                  return (
+                    <button
+                      key={type}
+                      onClick={() =>
+                        createPray(
+                          prayCard?.id,
+                          currentUserId,
+                          type as PrayType
+                        )
+                      }
+                      className={`w-[90px] py-2 px-2 flex flex-col items-center rounded-2xl ${
+                        todayPrayType === type
+                          ? "bg-gray-300 cursor-not-allowed"
+                          : "bg-purple-100 text-black"
+                      }`}
+                      disabled={Boolean(todayPrayType)}
+                    >
+                      <div className="text-2xl">{emoji}</div>
+                      <div className="text-sm">{text}</div>
+                    </button>
+                  );
+                })}
+              </div>
+              {/* ReactionBtn */}
+            </CarouselItem>
+          );
+        })}
         <CarouselItem className="basis-5/6 pointer-events-none">
           <div className="flex justify-center items-center w-full aspect-square">
             end

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,8 +1,8 @@
 import useBaseStore from "@/stores/baseStore";
 import { useEffect } from "react";
 import { PrayCardWithProfiles } from "supabase/types/tables";
-import PrayCardCalendar from "./PrayCardCalendar";
-import PrayCardBtn from "./PrayCardBtn";
+import PrayCardCalendar from "./WeeklyCalendar";
+import ReactionBtn from "./ReactionBtn";
 import { ClipLoader } from "react-spinners";
 
 interface PrayCardProps {
@@ -49,7 +49,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
       {currentUserId != prayCard?.user_id && (
         <div className="flex flex-col gap-6">
           <PrayCardCalendar prayCard={prayCard} prayData={userPrayData || []} />
-          <PrayCardBtn currentUserId={currentUserId} prayCard={prayCard} />
+          <ReactionBtn currentUserId={currentUserId} prayCard={prayCard} />
         </div>
       )}
     </div>

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -11,7 +11,7 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   currentUserId,
   prayCard,
 }) => {
-  const todayPrayType = useBaseStore((state) => state.todayPrayType);
+  const todayPrayTypeHash = useBaseStore((state) => state.todayPrayTypeHash);
   const createPray = useBaseStore((state) => state.createPray);
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const setIsPrayToday = useBaseStore((state) => state.setIsPrayToday);
@@ -37,11 +37,11 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
             key={type}
             onClick={handleClick(type as PrayType)}
             className={`w-[90px] py-2 px-2 flex flex-col items-center rounded-2xl ${
-              todayPrayType === type
+              todayPrayTypeHash[prayCard?.id || ""] === type
                 ? "bg-gray-300 cursor-not-allowed"
                 : "bg-purple-100 text-black"
             }`}
-            disabled={Boolean(todayPrayType)}
+            disabled={Boolean(todayPrayTypeHash[prayCard?.id || ""])}
           >
             <div className="text-2xl">{emoji}</div>
             <div className="text-sm">{text}</div>

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -2,12 +2,12 @@ import { PrayType } from "@/Enums/prayType";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import useBaseStore from "@/stores/baseStore";
 
-interface PrayCardBtnProps {
+interface ReactionBtnProps {
   currentUserId: string | undefined;
   prayCard: PrayCardWithProfiles | undefined;
 }
 
-const PrayCardBtn: React.FC<PrayCardBtnProps> = ({
+const ReactionBtn: React.FC<ReactionBtnProps> = ({
   currentUserId,
   prayCard,
 }) => {
@@ -52,4 +52,4 @@ const PrayCardBtn: React.FC<PrayCardBtnProps> = ({
   );
 };
 
-export default PrayCardBtn;
+export default ReactionBtn;

--- a/src/components/prayCard/WeeklyCalendar.tsx
+++ b/src/components/prayCard/WeeklyCalendar.tsx
@@ -11,7 +11,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   prayCard,
   prayData,
 }) => {
-  const todayPrayType = useBaseStore((state) => state.todayPrayType);
+  const todayPrayTypeHash = useBaseStore((state) => state.todayPrayTypeHash);
 
   const getEmoji = (prayType: string | null) => {
     if (prayType === "pray") return "🙏";
@@ -68,7 +68,9 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
                   isToday ? "text-red-500" : "text-gray-500"
                 }`}
               >
-                {isToday ? getEmoji(todayPrayType) : date.emoji}
+                {isToday
+                  ? getEmoji(todayPrayTypeHash[prayCard?.id || ""])
+                  : date.emoji}
               </span>
             </div>
           </div>

--- a/src/components/prayCard/WeeklyCalendar.tsx
+++ b/src/components/prayCard/WeeklyCalendar.tsx
@@ -45,7 +45,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   const weeklyDays = generateDates(prayCard?.created_at, prayData);
 
   return (
-    <div className="flex justify-center space-x-4">
+    <div className="flex justify-around">
       {weeklyDays.map((date) => {
         const isToday = date.date === currentDate;
         const day = new Date(date.date).getDate(); // Extract the day part of the date

--- a/src/components/prayCard/WeeklyCalendar.tsx
+++ b/src/components/prayCard/WeeklyCalendar.tsx
@@ -2,12 +2,12 @@ import { getISODate, getISOToday } from "@/lib/utils";
 import useBaseStore from "@/stores/baseStore";
 import { Pray, PrayCardWithProfiles } from "supabase/types/tables";
 
-interface PrayCardCalendarProps {
+interface WeeklyCalendarProps {
   prayCard: PrayCardWithProfiles | undefined;
   prayData: Pray[];
 }
 
-const PrayCardCalender: React.FC<PrayCardCalendarProps> = ({
+const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   prayCard,
   prayData,
 }) => {
@@ -78,4 +78,4 @@ const PrayCardCalender: React.FC<PrayCardCalendarProps> = ({
   );
 };
 
-export default PrayCardCalender;
+export default WeeklyCalendar;

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -1,5 +1,4 @@
 import {
-  bulkFetchPrayDataByUserId,
   createPray,
   fetchIsPrayToday,
   fetchPrayData,
@@ -18,7 +17,6 @@ import {
   PrayCardWithProfiles,
   UserIdMemberHash,
   userIdPrayCardListHash,
-  prayCardIdPrayDataHash,
   TodayPrayTypeHash,
 } from "../../supabase/types/tables";
 import { fetchGroupListByUserId, getGroup, createGroup } from "@/apis/group";
@@ -97,7 +95,6 @@ export interface BaseStore {
     userId: string | undefined,
     prayType: PrayType
   ) => Promise<Pray | null>;
-  setTodayPrayType: (prayCardId: string, prayType: PrayType) => void;
 }
 
 const useBaseStore = create<BaseStore>()(
@@ -286,11 +283,6 @@ const useBaseStore = create<BaseStore>()(
         state.todayPrayTypeHash[prayCardId!] = prayType;
       });
       return pray;
-    },
-    setTodayPrayType: (prayCardId: string, prayType: PrayType) => {
-      set((state) => {
-        state.todayPrayTypeHash[prayCardId] = prayType;
-      });
     },
   }))
 );

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -1,3 +1,4 @@
+import { PrayType } from "@/Enums/prayType";
 import { Database } from "./database";
 
 export type Group = Database["public"]["Tables"]["group"]["Row"];
@@ -32,4 +33,8 @@ export interface userIdPrayCardListHash {
 
 export interface prayCardIdPrayDataHash {
   [key: string]: Pray[];
+}
+
+export interface TodayPrayTypeHash {
+  [prayCardId: string]: PrayType;
 }

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -29,3 +29,7 @@ export interface UserIdMemberHash {
 export interface userIdPrayCardListHash {
   [key: string]: PrayCardWithProfiles[];
 }
+
+export interface prayCardIdPrayDataHash {
+  [key: string]: Pray[];
+}

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -31,10 +31,6 @@ export interface userIdPrayCardListHash {
   [key: string]: PrayCardWithProfiles[];
 }
 
-export interface prayCardIdPrayDataHash {
-  [key: string]: Pray[];
-}
-
 export interface TodayPrayTypeHash {
   [prayCardId: string]: PrayType | null;
 }

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -36,5 +36,5 @@ export interface prayCardIdPrayDataHash {
 }
 
 export interface TodayPrayTypeHash {
-  [prayCardId: string]: PrayType;
+  [prayCardId: string]: PrayType | null;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/de9c9016-e3cf-4f4d-ad96-456956546841)


PrayList 의 캐러셀 부분 데이터 관리를 재정의 합니다.
todayPrayTypeHash[prayCardId] 를 통해 전역 변수를 동적으로 할당하여 관리할 수 있도록 합니다.

### 체크리스트
- [x] todayPrayType 사용처를 todayPrayTypeHash 로 변경
- [x] PrayCardBtn -> ReactionBtn // PrayCardCalendar -> WeeklyCalendar 파일명 변경

https://www.notion.so/mmyeong/refactor-8d93e6e0be3e45938073cf683a57daee?pvs=4

