### PR TITLE
fix: 기도제목 길어졌을 때 scroll처리, 줄바꿈 처리

### DIFF
--- a/src/components/member/Member.tsx
+++ b/src/components/member/Member.tsx
@@ -45,7 +45,7 @@ const Member: React.FC<MemberProps> = ({
         />
         <h3>{member?.profiles.full_name}</h3>
       </div>
-      <div className="text-left text-sm text-gray-600">
+      <div className="text-left text-sm text-gray-600 whitespace-pre-line">
         {currentUserId != member?.user_id
           ? prayCard?.content || "아직 기도제목이 없어요"
           : myPrayerContent || "아직 기도제목이 없어요"}

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,5 +1,5 @@
 import useBaseStore from "@/stores/baseStore";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import PrayCardCalendar from "./WeeklyCalendar";
 import ReactionBtn from "./ReactionBtn";
@@ -26,7 +26,13 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
   );
 
   const myPrayerContent = useBaseStore((state) => state.myPrayerContent);
+
+  console.log(myPrayerContent);
   const [content, setContent] = useState(prayCard?.content || "");
+  const [isScrollable, setIsScrollable] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  console.log(content);
 
   useEffect(() => {
     fetchPrayDataByUserId(
@@ -44,6 +50,13 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
     prayCard?.content,
     myPrayerContent,
   ]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      setIsScrollable(textarea.scrollHeight > textarea.clientHeight);
+    }
+  }, [content]);
 
   if (!prayDataHash[prayCard?.id || ""]) {
     return (
@@ -63,15 +76,22 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
         />
         <div className="text-sm">{prayCard?.profiles.full_name}</div>
       </div>
-      <div className="flex h-full justify-center items-center">
+      <div
+        className={`flex justify-center  h-full overflow-y-auto ${
+          isScrollable ? "items-start" : "items-center"
+        }`}
+      >
         {isEditingPrayCard ? (
           <textarea
+            ref={textareaRef}
             className="w-full h-full p-2 rounded-md border border-gray-300"
             value={content}
             onChange={(e) => setContent(e.target.value)}
+            maxLength={200}
+            style={{ resize: "none", overflow: "auto" }}
           />
         ) : (
-          <p>{content}</p>
+          <p className="whitespace-pre-line">{content}</p>
         )}
       </div>
     </div>

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -81,11 +81,10 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
         {isEditingPrayCard ? (
           <textarea
             ref={textareaRef}
-            className="w-full h-full p-2 rounded-md border border-gray-300"
+            className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            maxLength={200}
-            style={{ resize: "none", overflow: "auto" }}
+            maxLength={400}
           />
         ) : (
           <p className="whitespace-pre-line">{content}</p>

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -27,12 +27,9 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
 
   const myPrayerContent = useBaseStore((state) => state.myPrayerContent);
 
-  console.log(myPrayerContent);
   const [content, setContent] = useState(prayCard?.content || "");
   const [isScrollable, setIsScrollable] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-  console.log(content);
 
   useEffect(() => {
     fetchPrayDataByUserId(

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -78,7 +78,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ currentUserId, prayCard }) => {
           isScrollable ? "items-start" : "items-center"
         }`}
       >
-        {isEditingPrayCard ? (
+        {prayCard?.user_id == currentUserId && isEditingPrayCard ? (
           <textarea
             ref={textareaRef}
             className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -35,7 +35,6 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
       return null;
     }
     sleep(500).then(() => {
-      console.log("와아아다닫다다다ㅏㄷ다");
       carouselApi.scrollNext();
     });
   };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c86941a7-8729-4e53-ba0e-7975ec39290b)
![image](https://github.com/user-attachments/assets/2008626f-3f79-4c53-9fba-5d84c906bb74)
![image](https://github.com/user-attachments/assets/a38caccc-5561-475d-b1ba-3ac73aba4445)

(스크롤 사진도 캡쳐하려 했는데 힘드네용ㅠ)

- [x]  영역을 넘어간 경우 스크롤 처리
- [x]  item-center로 인해서 윗내용이 잘리는 경우 분기처리
- [x]  줄바꿈 처리

https://www.notion.so/mmyeong/fix-c8a472f11ecd4b70afa33b4a18cc1768?pvs=4