### PR TITLE
fix: 그룹메뉴 생성 에러 해결

### DIFF
--- a/src/components/GroupMenuBtn.tsx
+++ b/src/components/GroupMenuBtn.tsx
@@ -29,20 +29,27 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
           <SheetTitle className="text-end">PrayU 그룹</SheetTitle>
           <SheetClose className="focus:outline-none">
             <div className="flex flex-col gap-4 items-end text-gray-500">
-              {userGroupList.map((group) => (
-                <a
-                  key={group.id}
-                  href={`/group/${group.id}`}
-                  className={`${
-                    group.id === targetGroup?.id
-                      ? "text-black font-bold underline"
-                      : ""
-                  }`}
-                >
-                  {group.name}
-                </a>
-              ))}
-              <a href={"/group/new"}>+ 그룹 만들기</a>
+              {userGroupList.map(
+                (group) =>
+                  group && (
+                    <a
+                      key={group.id}
+                      href={`${import.meta.env.VITE_BASE_URL}/group/${
+                        group.id
+                      }`}
+                      className={`${
+                        group.id === targetGroup?.id
+                          ? "text-black font-bold underline"
+                          : ""
+                      }`}
+                    >
+                      {group.name}
+                    </a>
+                  )
+              )}
+              <a href={`${import.meta.env.VITE_BASE_URL}/group/new`}>
+                + 그룹 만들기
+              </a>
               <a href={`${import.meta.env.VITE_PRAY_KAKAO_CHANNEL_CHAT_URL}`}>
                 문의하기
               </a>

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -7,7 +7,7 @@ import { KakaoShareButton } from "@/components/KakaoShareBtn";
 import MemberList from "@/components/member/MemberList";
 import { Drawer } from "@/components/ui/drawer";
 import PrayCardContent from "@/components/prayCard/PrayCardContent";
-import GroupMenu from "../components/GroupMenuBtn";
+import GroupMenuBtn from "../components/GroupMenuBtn";
 import { getDomainUrl } from "@/lib/utils";
 
 const GroupPage: React.FC = () => {
@@ -57,7 +57,7 @@ const GroupPage: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-10">
-      <GroupMenu userGroupList={groupList} targetGroup={targetGroup} />
+      <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
       <div className="flex justify-between items-center">
         <div className="text-lg font-bold">{targetGroup?.name} 그룹</div>
         <KakaoShareButton


### PR DESCRIPTION
db 를 건드린 탓에 그룹메뉴 렌더링에서 에러가 발생했습니다. 이를 해결하고자 fetch 해 온 groupList 의 원소 중 null 인 값에 대해서는 a 태그를 생성하지 않도록 분기처리 하였습니다. 