### PR TITLE
refactor: 기도제목 7일 필터 및 작성 예외처리

### DIFF
--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -2,16 +2,21 @@ import { getISOToday } from "@/lib/utils";
 import { supabase } from "../../supabase/client";
 import { PrayCard, PrayCardWithProfiles } from "../../supabase/types/tables";
 
-export const fetchPrayCardListByGroupId = async (
-  groupId: string | undefined
+export const fetchGroupPrayCardList = async (
+  groupId: string | undefined,
+  startDt: string,
+  endDt: string
 ): Promise<PrayCardWithProfiles[] | null> => {
   if (!groupId) return null;
   const { data, error } = await supabase
     .from("pray_card")
     .select(`*, profiles (id, full_name, avatar_url)`)
     .eq("group_id", groupId)
-    .is("deleted_at", null);
-  // TODO : 이후에 7일 이내의 데이터만 가져오도록 수정 필요
+    .gte("created_at", startDt)
+    .lt("created_at", endDt)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
   if (error) {
     console.error("error", error);
     return null;
@@ -19,16 +24,22 @@ export const fetchPrayCardListByGroupId = async (
   return data as PrayCardWithProfiles[];
 };
 
-export const fetchPrayCardListByUserId = async (
-  userId: string | undefined
+export const fetchUserPrayCardListByGroupId = async (
+  userId: string | undefined,
+  groupId: string | undefined,
+  startDt: string,
+  endDt: string
 ): Promise<PrayCardWithProfiles[] | null> => {
-  if (!userId) return null;
+  if (!userId || !groupId) return null;
   const { data, error } = await supabase
     .from("pray_card")
     .select(`*, profiles (id, full_name, avatar_url)`)
     .eq("user_id", userId)
+    .eq("group_id", groupId)
+    .gte("created_at", startDt)
+    .lt("created_at", endDt)
     .is("deleted_at", null)
-    .limit(10); // TODO: 이후 페이지네이션 적용 필요
+    .order("created_at", { ascending: false });
   if (error) {
     console.error("error", error);
     return null;

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -27,8 +27,8 @@ export const fetchGroupPrayCardList = async (
 export const fetchUserPrayCardListByGroupId = async (
   userId: string | undefined,
   groupId: string | undefined,
-  startDt: string,
-  endDt: string
+  limit: number = 10,
+  offset: number = 0
 ): Promise<PrayCardWithProfiles[] | null> => {
   if (!userId || !groupId) return null;
   const { data, error } = await supabase
@@ -36,10 +36,9 @@ export const fetchUserPrayCardListByGroupId = async (
     .select(`*, profiles (id, full_name, avatar_url)`)
     .eq("user_id", userId)
     .eq("group_id", groupId)
-    .gte("created_at", startDt)
-    .lt("created_at", endDt)
     .is("deleted_at", null)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
   if (error) {
     console.error("error", error);
     return null;

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -61,7 +61,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
     : "아직 기도제목이 없어요";
 
   const MyMemberUI = (
-    <div className="flex flex-col gap-2 cursor-pointer bg-blue-100 p-4 rounded ">
+    <div className="w-full flex flex-col gap-2 cursor-pointer bg-blue-100 p-4 rounded ">
       <div className="flex items-center gap-2">
         <img
           src={member?.profiles.avatar_url || ""}
@@ -80,8 +80,10 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   return (
     <Drawer>
       <DrawerTrigger className="focus:outline-none">
-        <div className="text-sm ">내 기도제목</div>
-        {MyMemberUI}
+        <div className="flex flex-col items-start gap-2">
+          <div className="text-base text-gray-950">My</div>
+          {MyMemberUI}
+        </div>
       </DrawerTrigger>
 
       <DrawerContent className="max-w-[480px] mx-auto w-full h-[90%] px-10 pb-20 focus:outline-none">

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -26,19 +26,14 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   );
   const userPrayCardList = useBaseStore((state) => state.userPrayCardList);
 
-  const startDt = getISOTodayDate();
-  const endDt = getISOTodayDate(7);
-
   useEffect(() => {
     getMemberByUserId(currentUserId);
-    fetchUserPrayCardListByGroupId(currentUserId, groupId, startDt, endDt);
+    fetchUserPrayCardListByGroupId(currentUserId, groupId);
   }, [
     currentUserId,
     groupId,
     getMemberByUserId,
     fetchUserPrayCardListByGroupId,
-    startDt,
-    endDt,
   ]);
 
   if (!member || !userPrayCardList) {
@@ -49,7 +44,10 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
     );
   }
 
-  if (userPrayCardList.length === 0) {
+  if (
+    userPrayCardList.length === 0 ||
+    userPrayCardList[0].created_at < getISOTodayDate(-6)
+  ) {
     return (
       <PrayCardCreateModal currentUserId={currentUserId} groupId={groupId} />
     );

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -24,8 +24,8 @@ const OtherMemberList: React.FC<MembersProps> = ({
     (state) => state.fetchMemberListByGroupId
   );
 
-  const startDt = getISOTodayDate();
-  const endDt = getISOTodayDate(7);
+  const startDt = getISOTodayDate(-6);
+  const endDt = getISOTodayDate();
 
   useEffect(() => {
     fetchMemberListByGroupId(groupId);
@@ -45,6 +45,8 @@ const OtherMemberList: React.FC<MembersProps> = ({
       </div>
     );
   }
+
+  console.log(groupPrayCardList);
 
   const otherMembers = memberList.filter(
     (member) => member.user_id !== currentUserId

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -78,7 +78,9 @@ const OtherMemberList: React.FC<MembersProps> = ({
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
-        <div className="text-sm">Members({otherMembers.length + 1})</div>
+        <div className="text-base text-gray-950">
+          Members({otherMembers.length + 1})
+        </div>
         <div className="flex flex-col gap-2">
           {otherMembers.map((member) => (
             <Member

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -4,6 +4,7 @@ import { ClipLoader } from "react-spinners";
 import { userIdPrayCardListHash } from "../../../supabase/types/tables";
 import Member from "./Member";
 import PrayCardCreateModal from "../prayCard/PrayCardCreateModal";
+import { getISOTodayDate } from "@/lib/utils";
 
 interface MembersProps {
   currentUserId: string;
@@ -16,17 +17,26 @@ const OtherMemberList: React.FC<MembersProps> = ({
 }) => {
   const memberList = useBaseStore((state) => state.memberList);
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
-  const fetchPrayCardListByGroupId = useBaseStore(
-    (state) => state.fetchPrayCardListByGroupId
+  const fetchGroupPrayCardList = useBaseStore(
+    (state) => state.fetchGroupPrayCardList
   );
   const fetchMemberListByGroupId = useBaseStore(
     (state) => state.fetchMemberListByGroupId
   );
 
+  const startDt = getISOTodayDate();
+  const endDt = getISOTodayDate(7);
+
   useEffect(() => {
     fetchMemberListByGroupId(groupId);
-    fetchPrayCardListByGroupId(groupId);
-  }, [fetchMemberListByGroupId, fetchPrayCardListByGroupId, groupId]);
+    fetchGroupPrayCardList(groupId, startDt, endDt);
+  }, [
+    fetchMemberListByGroupId,
+    fetchGroupPrayCardList,
+    groupId,
+    startDt,
+    endDt,
+  ]);
 
   if (!memberList || !groupPrayCardList) {
     return (

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -76,21 +76,19 @@ const OtherMemberList: React.FC<MembersProps> = ({
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-2">
+      <div className="text-base text-gray-950">
+        Members({otherMembers.length + 1})
+      </div>
       <div className="flex flex-col gap-2">
-        <div className="text-base text-gray-950">
-          Members({otherMembers.length + 1})
-        </div>
-        <div className="flex flex-col gap-2">
-          {otherMembers.map((member) => (
-            <Member
-              key={member.id}
-              currentUserId={currentUserId}
-              member={member}
-              prayCardList={userIdPrayCardListHash[member.user_id || ""]}
-            ></Member>
-          ))}
-        </div>
+        {otherMembers.map((member) => (
+          <Member
+            key={member.id}
+            currentUserId={currentUserId}
+            member={member}
+            prayCardList={userIdPrayCardListHash[member.user_id || ""]}
+          ></Member>
+        ))}
       </div>
     </div>
   );

--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -34,15 +34,10 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
   };
 
   return (
-    <div className="flex flex-col items-center justify-start min-h-screen gap-4">
-      <div className="w-full flex flex-col">
-        <div className="text-lg font-bold">기도제목 작성 </div>
-        <div className="text-sm text-gray-500">
-          기도제목을 작성하면 그룹에 참여할 수 있어요
-        </div>
-      </div>
+    <div className="flex flex-col items-center min-h-screen gap-4">
+      <div className="w-full flex flex-col"></div>
       <Textarea
-        className="h-48 placeholder-gray-50"
+        className="h-80 placeholder-gray-50 p-5"
         style={{
           fontSize: "16px",
         }}
@@ -50,13 +45,18 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
         value={inputPrayCardContent}
         onChange={(e) => setPrayCardContent(e.target.value)}
       />
+
       <div className="w-full flex flex-col items-center justify-center text-center">
         <Button
           className="w-full bg-black hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           onClick={() => handleCreatePrayCard(currentUserId, groupId)}
+          disabled={!inputPrayCardContent}
         >
           그룹 참여하기
         </Button>
+      </div>
+      <div className="text-sm text-gray-500">
+        기도제목을 작성하면 그룹에 참여할 수 있어요
       </div>
     </div>
   );

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -29,8 +29,8 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
     (state) => state.setPrayCardCarouselApi
   );
 
-  const startDt = getISOTodayDate();
-  const endDt = getISOTodayDate(7);
+  const startDt = getISOTodayDate(-6);
+  const endDt = getISOTodayDate();
 
   useEffect(() => {
     // TODO: 초기화 이후에 재랜더링 필요(useEffect 무한 로딩 고려)

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -7,6 +7,7 @@ import useBaseStore from "@/stores/baseStore";
 import PrayCardUI from "./PrayCardUI";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
+import { getISOTodayDate } from "@/lib/utils";
 
 interface PrayCardListProps {
   currentUserId: string;
@@ -18,8 +19,8 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
   groupId,
 }) => {
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
-  const fetchPrayCardListByGroupId = useBaseStore(
-    (state) => state.fetchPrayCardListByGroupId
+  const fetchGroupPrayCardList = useBaseStore(
+    (state) => state.fetchGroupPrayCardList
   );
   const prayCardCarouselApi = useBaseStore(
     (state) => state.prayCardCarouselApi
@@ -28,16 +29,19 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
     (state) => state.setPrayCardCarouselApi
   );
 
+  const startDt = getISOTodayDate();
+  const endDt = getISOTodayDate(7);
+
   useEffect(() => {
-    // TODO: 초기화 이후에 재랜더링 필요
-    fetchPrayCardListByGroupId(groupId);
+    // TODO: 초기화 이후에 재랜더링 필요(useEffect 무한 로딩 고려)
+    fetchGroupPrayCardList(groupId, startDt, endDt);
     prayCardCarouselApi?.on("select", () => {
       const currentIndex = prayCardCarouselApi.selectedScrollSnap();
       const carouselLength = prayCardCarouselApi.scrollSnapList().length;
       if (currentIndex == 0) prayCardCarouselApi.scrollNext();
       if (currentIndex == carouselLength - 1) prayCardCarouselApi.scrollPrev();
     });
-  }, [prayCardCarouselApi, fetchPrayCardListByGroupId, groupId]);
+  }, [prayCardCarouselApi, fetchGroupPrayCardList, groupId, startDt, endDt]);
 
   if (!groupPrayCardList) {
     return (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,12 +19,14 @@ export const getISOToday = () => {
   return isoString.replace("Z", "+09:00");
 };
 
-export const getISOTodayDate = () => {
+export const getISOTodayDate = (n: number = 0) => {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
+  const afterDt = new Date(today.getTime() + n * 24 * 60 * 60 * 1000);
+
   const koreaOffset = 9 * 60;
-  const koreaTime = new Date(today.getTime() + koreaOffset * 60 * 1000);
+  const koreaTime = new Date(afterDt.getTime() + koreaOffset * 60 * 1000);
 
   const isoString = koreaTime.toISOString();
 

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -84,8 +84,7 @@ const GroupPage: React.FC = () => {
         <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
       </div>
       <div className="flex flex-col gap-2">
-        <div className="text-sm ">내 기도제목</div>
-        <MyMember currentUserId={user!.id} />
+        <MyMember currentUserId={user!.id} groupId={targetGroup?.id} />
         {isPrayToday ? (
           <OtherMemberList
             currentUserId={user!.id}

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -15,7 +15,6 @@ import {
   PrayCard,
   PrayCardWithProfiles,
   UserIdMemberHash,
-  userIdPrayCardListHash,
   TodayPrayTypeHash,
   PrayDataHash,
   PrayWithProfiles,
@@ -28,8 +27,8 @@ import {
 } from "@/apis/member";
 import {
   createPrayCard,
-  fetchPrayCardListByGroupId,
-  fetchPrayCardListByUserId,
+  fetchGroupPrayCardList,
+  fetchUserPrayCardListByGroupId,
   updatePrayCardContent,
 } from "@/apis/prayCard";
 import { PrayType } from "@/Enums/prayType";
@@ -78,18 +77,22 @@ export interface BaseStore {
   // prayCard
   groupPrayCardList: PrayCardWithProfiles[] | null;
   userPrayCardList: PrayCardWithProfiles[] | null;
-  userIdPrayCardListHash: userIdPrayCardListHash | null;
   targetPrayCard: PrayCardWithProfiles | null;
   inputPrayCardContent: string;
   isEditingPrayCard: boolean;
   myPrayerContent: string | null;
   setMyPrayerContent: (myPrayerContent: string) => void;
-  fetchPrayCardListByGroupId: (groupId: string | undefined) => Promise<void>;
-  fetchPrayCardListByUserId: (userId: string | undefined) => Promise<void>;
-  createUserIdPrayCardListHash: (
-    memberList: MemberWithProfiles[],
-    groupPrayCardList: PrayCardWithProfiles[]
-  ) => userIdPrayCardListHash;
+  fetchGroupPrayCardList: (
+    groupId: string | undefined,
+    startDt: string,
+    endDt: string
+  ) => Promise<void>;
+  fetchUserPrayCardListByGroupId: (
+    userId: string | undefined,
+    groupId: string | undefined,
+    startDt: string,
+    endDt: string
+  ) => Promise<void>;
   createPrayCard: (
     groupId: string | undefined,
     userId: string | undefined,
@@ -227,7 +230,6 @@ const useBaseStore = create<BaseStore>()(
     // prayCard
     groupPrayCardList: null,
     userPrayCardList: null,
-    userIdPrayCardListHash: null,
     targetPrayCard: null,
     inputPrayCardContent: "",
     isEditingPrayCard: false,
@@ -242,34 +244,37 @@ const useBaseStore = create<BaseStore>()(
         state.isEditingPrayCard = isEditingPrayCard;
       });
     },
-    fetchPrayCardListByGroupId: async (groupId: string | undefined) => {
-      const groupPrayCardList = await fetchPrayCardListByGroupId(groupId);
+    fetchGroupPrayCardList: async (
+      groupId: string | undefined,
+      startDt: string,
+      endDt: string
+    ) => {
+      const groupPrayCardList = await fetchGroupPrayCardList(
+        groupId,
+        startDt,
+        endDt
+      );
       set((state) => {
         state.groupPrayCardList = groupPrayCardList;
       });
     },
-    fetchPrayCardListByUserId: async (userId: string | undefined) => {
-      const userPrayCardList = await fetchPrayCardListByUserId(userId);
+    fetchUserPrayCardListByGroupId: async (
+      userId: string | undefined,
+      groupId: string | undefined,
+      startDt: string,
+      endDt: string
+    ) => {
+      const userPrayCardList = await fetchUserPrayCardListByGroupId(
+        userId,
+        groupId,
+        startDt,
+        endDt
+      );
       set((state) => {
         state.userPrayCardList = userPrayCardList;
       });
     },
-    createUserIdPrayCardListHash: (
-      memberList: MemberWithProfiles[],
-      groupPrayCardList: PrayCardWithProfiles[]
-    ) => {
-      const userIdPrayCardListHash = memberList.reduce((hash, member) => {
-        hash[member.user_id || ""] = [];
-        return hash;
-      }, {} as userIdPrayCardListHash);
-      groupPrayCardList.forEach((prayCard) => {
-        userIdPrayCardListHash[prayCard.user_id || ""].push(prayCard);
-      });
-      set((state) => {
-        state.userIdPrayCardListHash = userIdPrayCardListHash;
-      });
-      return userIdPrayCardListHash;
-    },
+
     createPrayCard: async (
       groupId: string | undefined,
       userId: string | undefined,

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -89,9 +89,7 @@ export interface BaseStore {
   ) => Promise<void>;
   fetchUserPrayCardListByGroupId: (
     userId: string | undefined,
-    groupId: string | undefined,
-    startDt: string,
-    endDt: string
+    groupId: string | undefined
   ) => Promise<void>;
   createPrayCard: (
     groupId: string | undefined,
@@ -260,15 +258,11 @@ const useBaseStore = create<BaseStore>()(
     },
     fetchUserPrayCardListByGroupId: async (
       userId: string | undefined,
-      groupId: string | undefined,
-      startDt: string,
-      endDt: string
+      groupId: string | undefined
     ) => {
       const userPrayCardList = await fetchUserPrayCardListByGroupId(
         userId,
-        groupId,
-        startDt,
-        endDt
+        groupId
       );
       set((state) => {
         state.userPrayCardList = userPrayCardList;


### PR DESCRIPTION

<img width="297" alt="image" src="https://github.com/user-attachments/assets/4b2a34dc-cf3b-4162-b111-605521c0e2b8">

이제 7일 이내의 기도제목 카드만 올라옵니다.
생성한지 7일 지나면 다시 작성뷰로 넘어갑니다.

### 체크리스트
- [x] 기도제목 카드 7일 필터링
- [x]  기도제목 7일 만료 되면(또는 없으면) 기도제목 생성 창으로 이동
    - [x] 생성창 참여 버튼 활성화 체크
    - [x] 개인 기도제목 feching 함수 페이지네이션
- [x]  orderby
    - [x]  PrayCardList 