### PR TITLE
fix: textarea 내 기도제목으로 나오는 버그 수정

### DIFF
--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -103,7 +103,11 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
           isScrollable ? "items-start" : "items-center"
         }`}
       >
-        {prayCard?.user_id == currentUserId && isEditingPrayCard ? (
+        {prayCard?.user_id !== currentUserId ? (
+          <p className="whitespace-pre-line">
+            {prayCard?.content || member?.pray_summary}
+          </p>
+        ) : isEditingPrayCard ? (
           <textarea
             ref={textareaRef}
             className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"


### PR DESCRIPTION
<img width="360" alt="image" src="https://github.com/user-attachments/assets/1ae24fa7-a3b1-4a9a-9e63-7d2e523eafa2">

다 내 기도제목으로 나오고 있었습니다.