### PR TITLE
fix: 생성버튼 비활성화 상태 관리

### DIFF
--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -17,6 +17,12 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
   const inputPrayCardContent = useBaseStore(
     (state) => state.inputPrayCardContent
   );
+  const isDisabledPrayCardCreateBtn = useBaseStore(
+    (state) => state.isDisabledPrayCardCreateBtn
+  );
+  const setIsDisabledPrayCardCreateBtn = useBaseStore(
+    (state) => state.setIsDisabledPrayCardCreateBtn
+  );
   const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
   const createMember = useBaseStore((state) => state.createMember);
   const updateMember = useBaseStore((state) => state.updateMember);
@@ -26,6 +32,7 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
     currentUserId: string | undefined,
     groupId: string | undefined
   ) => {
+    setIsDisabledPrayCardCreateBtn(true);
     if (!member) {
       const newMember = await createMember(groupId, currentUserId);
       await updateMember(newMember?.id, inputPrayCardContent);
@@ -53,7 +60,7 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
         <Button
           className="w-full bg-black hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           onClick={() => handleCreatePrayCard(currentUserId, groupId)}
-          disabled={!inputPrayCardContent}
+          disabled={isDisabledPrayCardCreateBtn}
         >
           그룹 참여하기
         </Button>

--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -2,6 +2,7 @@ import { Textarea } from "../ui/textarea";
 import { Button } from "../ui/button";
 import useBaseStore from "@/stores/baseStore";
 import { MemberWithProfiles } from "supabase/types/tables";
+import { useEffect } from "react";
 
 interface PrayCardCreateModalProps {
   currentUserId: string | undefined;
@@ -42,6 +43,10 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
     await createPrayCard(groupId, currentUserId, inputPrayCardContent);
     window.location.reload();
   };
+
+  useEffect(() => {
+    setPrayCardContent(member?.pray_summary || "");
+  }, [member, setPrayCardContent]);
 
   return (
     <div className="flex flex-col items-center min-h-screen gap-4">

--- a/src/components/todayPray/TodayPrayBtn.tsx
+++ b/src/components/todayPray/TodayPrayBtn.tsx
@@ -1,5 +1,4 @@
 import useBaseStore from "@/stores/baseStore";
-import { Button } from "../ui/button";
 
 const TodayPrayBtn: React.FC = () => {
   const setOpenTodayPrayDrawer = useBaseStore(
@@ -7,15 +6,15 @@ const TodayPrayBtn: React.FC = () => {
   );
 
   return (
-    <Button
+    <button
       className="shadow-md
-        flex flex-col justify-center w-32 h-11
+        flex justify-center items-center w-32 h-11
         bg-todayPrayBtn text-white
         rounded-xl cursor-pointer"
       onClick={() => setOpenTodayPrayDrawer(true)}
     >
       기도 시작하기
-    </Button>
+    </button>
   );
 };
 

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -15,16 +15,17 @@ const GroupCreatePage: React.FC = () => {
   const createGroup = useBaseStore((state) => state.createGroup);
   const inputGroupName = useBaseStore((state) => state.inputGroupName);
   const setGroupName = useBaseStore((state) => state.setGroupName);
+  const isDisabledGroupCreateBtn = useBaseStore(
+    (state) => state.isDisabledGroupCreateBtn
+  );
+  const setIsDisabledGroupCreateBtn = useBaseStore(
+    (state) => state.setIsDisabledGroupCreateBtn
+  );
   const groupList = useBaseStore((state) => state.groupList);
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
-
   const fetchGroupListByUserId = useBaseStore(
     (state) => state.fetchGroupListByUserId
   );
-
-  useEffect(() => {
-    fetchGroupListByUserId(user!.id);
-  }, [fetchGroupListByUserId, user]);
 
   const handleCreateGroup = async (
     userId: string | undefined,
@@ -36,15 +37,14 @@ const GroupCreatePage: React.FC = () => {
       });
       return;
     }
-    if (inputGroupName.trim() === "") {
-      toast({
-        description: "그룹 이름을 입력해주세요.",
-      });
-      return;
-    }
+    setIsDisabledGroupCreateBtn(true);
     const targetGroup = await createGroup(userId, inputGroupName, "intro");
     targetGroup && navigate("/group/" + targetGroup.id, { replace: true });
   };
+
+  useEffect(() => {
+    fetchGroupListByUserId(user!.id);
+  }, [fetchGroupListByUserId, user]);
 
   if (!groupList) {
     return (
@@ -74,6 +74,7 @@ const GroupCreatePage: React.FC = () => {
         <Button
           onClick={() => handleCreateGroup(user?.id, inputGroupName)}
           className="w-full"
+          disabled={isDisabledGroupCreateBtn}
         >
           그룹 생성하기
         </Button>

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -61,9 +61,11 @@ export interface BaseStore {
   groupList: Group[] | null;
   targetGroup: Group | null;
   inputGroupName: string;
+  isDisabledGroupCreateBtn: boolean;
   fetchGroupListByUserId: (userId: string | undefined) => Promise<void>;
   getGroup: (groupId: string | undefined) => Promise<void>;
   setGroupName: (groupName: string) => void;
+  setIsDisabledGroupCreateBtn: (isDisabled: boolean) => void;
   createGroup: (
     userId: string | undefined,
     name: string | undefined,
@@ -97,6 +99,7 @@ export interface BaseStore {
   targetPrayCard: PrayCardWithProfiles | null;
   inputPrayCardContent: string;
   isEditingPrayCard: boolean;
+  isDisabledPrayCardCreateBtn: boolean;
   prayCardCarouselApi: CarouselApi | null;
   fetchGroupPrayCardList: (
     groupId: string | undefined,
@@ -113,6 +116,9 @@ export interface BaseStore {
     content: string
   ) => Promise<PrayCard | null>;
   setIsEditingPrayCard: (isEditingPrayCard: boolean) => void;
+  setIsDisabledPrayCardCreateBtn: (
+    isDisabledPrayCardCreateBtn: boolean
+  ) => void;
   updatePrayCardContent: (prayCardId: string, content: string) => Promise<void>;
   setPrayCardContent: (content: string) => void;
   setPrayCardCarouselApi: (prayCardCarouselApi: CarouselApi) => void;
@@ -180,6 +186,7 @@ const useBaseStore = create<BaseStore>()(
     groupList: null,
     targetGroup: null,
     inputGroupName: "",
+    isDisabledGroupCreateBtn: false,
     fetchGroupListByUserId: async (userId: string | undefined) => {
       const data = await fetchGroupListByUserId(userId);
       set((state) => {
@@ -206,6 +213,12 @@ const useBaseStore = create<BaseStore>()(
     setGroupName: (groupName: string) => {
       set((state) => {
         state.inputGroupName = groupName;
+        state.isDisabledGroupCreateBtn = groupName.trim() === "";
+      });
+    },
+    setIsDisabledGroupCreateBtn: (isDisabled: boolean) => {
+      set((state) => {
+        state.isDisabledGroupCreateBtn = isDisabled;
       });
     },
     openTodayPrayDrawer: false,
@@ -252,6 +265,7 @@ const useBaseStore = create<BaseStore>()(
     targetPrayCard: null,
     inputPrayCardContent: "",
     isEditingPrayCard: false,
+    isDisabledPrayCardCreateBtn: false,
     prayCardCarouselApi: null,
     setIsEditingPrayCard: (isEditingPrayCard: boolean) => {
       set((state) => {
@@ -302,6 +316,12 @@ const useBaseStore = create<BaseStore>()(
     setPrayCardContent: (content: string) => {
       set((state) => {
         state.inputPrayCardContent = content;
+        state.isDisabledPrayCardCreateBtn = content.trim() === "";
+      });
+    },
+    setIsDisabledPrayCardCreateBtn: (isDisabled: boolean) => {
+      set((state) => {
+        state.isDisabledPrayCardCreateBtn = isDisabled;
       });
     },
     setPrayCardCarouselApi: (prayCardCarouselApi: CarouselApi) => {


### PR DESCRIPTION
생성버튼을 여러번 클릭했을 때 나는 다중생성 문제를 해결합니다.
생성 버튼 클릭 핸들링 함수에서 비활성화 상태를 관리합니다.

### 체크리스트
- [x]  기도 카드 광클 테스트
- [x]  그룹 생성 광클 테스트
- [x]  isDisable~ 변수를 통한 disable 상태 관리

![image](https://github.com/user-attachments/assets/66cc109e-2d16-4920-ac7e-1528b0d44c05)
![image](https://github.com/user-attachments/assets/2be352ff-153f-4ec3-86b9-f6d70256387d)
→ 기도 카드와 그룹 생성 테스트 과정에서 기존과 다르게 하나씩 생성되는 것을 확인하였습니다.
