### PR TITLE
refactor: GroupBody 분리 및 MemberList 분기처리

### DIFF
--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -30,11 +30,11 @@ const GroupBody: React.FC<GroupBodyProps> = ({
   targetGroup,
 }) => {
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
-  const openTodayPrayDrawer = useBaseStore(
-    (state) => state.openTodayPrayDrawer
+  const isOpenTodayPrayDrawer = useBaseStore(
+    (state) => state.isOpenTodayPrayDrawer
   );
-  const setOpenTodayPrayDrawer = useBaseStore(
-    (state) => state.setOpenTodayPrayDrawer
+  const setIsOpenTodayPrayDrawer = useBaseStore(
+    (state) => state.setIsOpenTodayPrayDrawer
   );
   const isParamsGroupIdinGroupList = groupList.some(
     (group) => group.id === targetGroup?.id
@@ -85,7 +85,10 @@ const GroupBody: React.FC<GroupBodyProps> = ({
         )}
       </div>
 
-      <Drawer open={openTodayPrayDrawer} onOpenChange={setOpenTodayPrayDrawer}>
+      <Drawer
+        open={isOpenTodayPrayDrawer}
+        onOpenChange={setIsOpenTodayPrayDrawer}
+      >
         <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] pb-20">
           <DrawerHeader>
             <DrawerTitle></DrawerTitle>

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -1,7 +1,6 @@
 import { Group } from "supabase/types/tables";
 import useBaseStore from "@/stores/baseStore";
 import PrayCardList from "@/components/prayCard/PrayCardList";
-import TodayPrayBtn from "@/components/todayPray/TodayPrayBtn";
 import MyMember from "@/components/member/MyMember";
 import LimitGroupCard from "@/components/group/LimitGroupCard";
 import OtherMemberList from "@/components/member/OtherMemberList";

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -1,0 +1,107 @@
+import { Group } from "supabase/types/tables";
+import useBaseStore from "@/stores/baseStore";
+import PrayCardList from "@/components/prayCard/PrayCardList";
+import TodayPrayBtn from "@/components/todayPray/TodayPrayBtn";
+import MyMember from "@/components/member/MyMember";
+import LimitGroupCard from "@/components/group/LimitGroupCard";
+import OtherMemberList from "@/components/member/OtherMemberList";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import PrayCardCreateModal from "../prayCard/PrayCardCreateModal";
+import { getISOTodayDate } from "@/lib/utils";
+
+import { useEffect } from "react";
+import { ClipLoader } from "react-spinners";
+
+interface GroupBodyProps {
+  currentUserId: string;
+  groupList: Group[];
+  targetGroup: Group | null;
+}
+
+const GroupBody: React.FC<GroupBodyProps> = ({
+  currentUserId,
+  groupList,
+  targetGroup,
+}) => {
+  const isPrayToday = useBaseStore((state) => state.isPrayToday);
+  const openTodayPrayDrawer = useBaseStore(
+    (state) => state.openTodayPrayDrawer
+  );
+  const setOpenTodayPrayDrawer = useBaseStore(
+    (state) => state.setOpenTodayPrayDrawer
+  );
+  const isParamsGroupIdinGroupList = groupList.some(
+    (group) => group.id === targetGroup?.id
+  );
+  const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
+
+  const member = useBaseStore((state) => state.targetMember);
+  const memberLoading = useBaseStore((state) => state.memberLoading);
+  const getMember = useBaseStore((state) => state.getMember);
+
+  useEffect(() => {
+    if (targetGroup) getMember(currentUserId, targetGroup.id);
+  }, [currentUserId, targetGroup, getMember]);
+
+  if (memberLoading) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={50} color={"#123abc"} loading={true} />
+      </div>
+    );
+  }
+
+  if (groupList.length == maxGroupCount && !isParamsGroupIdinGroupList) {
+    return <LimitGroupCard />;
+  }
+
+  if (member == null || member.updated_at < getISOTodayDate(-6)) {
+    return (
+      <PrayCardCreateModal
+        currentUserId={currentUserId}
+        groupId={targetGroup?.id}
+        member={member}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-4">
+        <MyMember currentUserId={currentUserId} groupId={targetGroup?.id} />
+        <OtherMemberList
+          currentUserId={currentUserId}
+          groupId={targetGroup?.id}
+        />
+      </div>
+
+      <Drawer open={openTodayPrayDrawer} onOpenChange={setOpenTodayPrayDrawer}>
+        <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] pb-20">
+          <DrawerHeader>
+            <DrawerTitle></DrawerTitle>
+            <DrawerDescription></DrawerDescription>
+          </DrawerHeader>
+          {/* PrayCardList */}
+          <PrayCardList
+            currentUserId={currentUserId}
+            groupId={targetGroup?.id}
+          />
+          {/* PrayCardList */}
+        </DrawerContent>
+      </Drawer>
+      {isPrayToday && (
+        <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
+          <TodayPrayBtn />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default GroupBody;

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -17,6 +17,7 @@ import { getISOTodayDate } from "@/lib/utils";
 
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
+import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
 
 interface GroupBodyProps {
   currentUserId: string;
@@ -75,10 +76,14 @@ const GroupBody: React.FC<GroupBodyProps> = ({
     <>
       <div className="flex flex-col gap-4">
         <MyMember currentUserId={currentUserId} groupId={targetGroup?.id} />
-        <OtherMemberList
-          currentUserId={currentUserId}
-          groupId={targetGroup?.id}
-        />
+        {isPrayToday ? (
+          <OtherMemberList
+            currentUserId={currentUserId}
+            groupId={targetGroup?.id}
+          />
+        ) : (
+          <TodayPrayStartCard />
+        )}
       </div>
 
       <Drawer open={openTodayPrayDrawer} onOpenChange={setOpenTodayPrayDrawer}>
@@ -95,11 +100,6 @@ const GroupBody: React.FC<GroupBodyProps> = ({
           {/* PrayCardList */}
         </DrawerContent>
       </Drawer>
-      {isPrayToday && (
-        <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
-          <TodayPrayBtn />
-        </div>
-      )}
     </>
   );
 };

--- a/src/components/member/MemberInviteCard.tsx
+++ b/src/components/member/MemberInviteCard.tsx
@@ -1,6 +1,6 @@
 import { KakaoShareButton } from "../KakaoShareBtn";
 
-export const GroupInviteCard = () => {
+export const MemberInviteCard = () => {
   return (
     <div className="flex flex-col gap-4 border p-10 rounded-lg shadow-md bg-white items-center h-60vh">
       <img
@@ -24,4 +24,4 @@ export const GroupInviteCard = () => {
   );
 };
 
-export default GroupInviteCard;
+export default MemberInviteCard;

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -1,4 +1,4 @@
-import { getISOTodayDate, reduceString } from "../../lib/utils";
+import { reduceString } from "../../lib/utils";
 import {
   Drawer,
   DrawerContent,
@@ -11,7 +11,6 @@ import PrayCardUI from "../prayCard/PrayCardUI";
 import useBaseStore from "@/stores/baseStore";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
-import PrayCardCreateModal from "../prayCard/PrayCardCreateModal";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 
 interface MemberProps {
@@ -52,20 +51,6 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
       <div className="flex justify-center items-center h-screen">
         <ClipLoader size={50} color={"#123abc"} loading={true} />
       </div>
-    );
-  }
-
-  if (
-    member == null ||
-    userPrayCardList.length === 0 ||
-    userPrayCardList[0].created_at < getISOTodayDate(-6)
-  ) {
-    return (
-      <PrayCardCreateModal
-        currentUserId={currentUserId}
-        groupId={groupId}
-        member={member}
-      />
     );
   }
 

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -4,6 +4,8 @@ import { ClipLoader } from "react-spinners";
 import { userIdPrayCardListHash } from "../../../supabase/types/tables";
 import OtherMember from "./OtherMember";
 import { getISOTodayDate } from "@/lib/utils";
+import MemberInviteCard from "./MemberInviteCard";
+import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
 
 interface OtherMembersProps {
   currentUserId: string;
@@ -14,7 +16,11 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   currentUserId,
   groupId,
 }) => {
+  const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const memberList = useBaseStore((state) => state.memberList);
+  const fetchMemberListByGroupId = useBaseStore(
+    (state) => state.fetchMemberListByGroupId
+  );
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
   const fetchGroupPrayCardList = useBaseStore(
     (state) => state.fetchGroupPrayCardList
@@ -25,7 +31,14 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
 
   useEffect(() => {
     fetchGroupPrayCardList(groupId, startDt, endDt);
-  }, [fetchGroupPrayCardList, groupId, startDt, endDt]);
+    fetchMemberListByGroupId(groupId);
+  }, [
+    fetchGroupPrayCardList,
+    fetchMemberListByGroupId,
+    groupId,
+    startDt,
+    endDt,
+  ]);
 
   if (!memberList || !groupPrayCardList) {
     return (
@@ -47,6 +60,8 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
     return hash;
   }, {} as userIdPrayCardListHash);
 
+  if (otherMembers.length === 0) return <MemberInviteCard />;
+  if (!isPrayToday) return <TodayPrayStartCard />;
   return (
     <div className="flex flex-col gap-2">
       <div className="text-sm text-gray-950 p-2">

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -5,7 +5,7 @@ import { userIdPrayCardListHash } from "../../../supabase/types/tables";
 import OtherMember from "./OtherMember";
 import { getISOTodayDate } from "@/lib/utils";
 import MemberInviteCard from "./MemberInviteCard";
-import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
+import TodayPrayBtn from "../todayPray/TodayPrayBtn";
 
 interface OtherMembersProps {
   currentUserId: string;
@@ -16,7 +16,6 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   currentUserId,
   groupId,
 }) => {
-  const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const memberList = useBaseStore((state) => state.memberList);
   const fetchMemberListByGroupId = useBaseStore(
     (state) => state.fetchMemberListByGroupId
@@ -61,7 +60,6 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   }, {} as userIdPrayCardListHash);
 
   if (otherMembers.length === 0) return <MemberInviteCard />;
-  if (!isPrayToday) return <TodayPrayStartCard />;
   return (
     <div className="flex flex-col gap-2">
       <div className="text-sm text-gray-950 p-2">
@@ -76,6 +74,9 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
             prayCardList={userIdPrayCardListHash[member.user_id || ""]}
           ></OtherMember>
         ))}
+      </div>
+      <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
+        <TodayPrayBtn />
       </div>
     </div>
   );

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -16,7 +16,7 @@ import iconUserMono from "@/assets/icon-user-mono.svg";
 interface PrayCardProps {
   currentUserId: string;
   prayCard: PrayCardWithProfiles | null;
-  member?: MemberWithProfiles | undefined;
+  member?: MemberWithProfiles | null;
 }
 
 const PrayCardUI: React.FC<PrayCardProps> = ({

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -4,38 +4,21 @@ import { ClipLoader } from "react-spinners";
 import useAuth from "../hooks/useAuth";
 import useBaseStore from "@/stores/baseStore";
 import { KakaoShareButton } from "@/components/KakaoShareBtn";
-import OtherMemberList from "@/components/member/OtherMemberList";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
+
 import GroupMenuBtn from "../components/GroupMenuBtn";
 import { getDomainUrl } from "@/lib/utils";
-import PrayCardList from "@/components/prayCard/PrayCardList";
-import TodayPrayBtn from "@/components/todayPray/TodayPrayBtn";
-import TodayPrayStartCard from "@/components/todayPray/TodayPrayStartCard";
-import MyMember from "@/components/member/MyMember";
-import LimitGroupCard from "@/components/group/LimitGroupCard";
-import GroupInviteCard from "@/components/todayPray/GroupInviteCard";
+
 import inviteMemberIcon from "@/assets/inviteMemberIcon.svg";
+import GroupBody from "@/components/group/GroupBody";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
 
   const { groupId: paramsGroupId } = useParams();
-  const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
   const groupList = useBaseStore((state) => state.groupList);
   const targetGroup = useBaseStore((state) => state.targetGroup);
   const getGroup = useBaseStore((state) => state.getGroup);
-  const memberList = useBaseStore((state) => state.memberList);
-
-  const fetchMemberListByGroupId = useBaseStore(
-    (state) => state.fetchMemberListByGroupId
-  );
 
   const fetchGroupListByUserId = useBaseStore(
     (state) => state.fetchGroupListByUserId
@@ -71,10 +54,6 @@ const GroupPage: React.FC = () => {
     if (targetGroup) fetchIsPrayToday(user!.id, targetGroup.id);
   }, [user, targetGroup, fetchIsPrayToday]);
 
-  useEffect(() => {
-    fetchMemberListByGroupId(paramsGroupId);
-  }, [fetchMemberListByGroupId, paramsGroupId]);
-
   if (!groupList || (paramsGroupId && !targetGroup) || isPrayToday == null) {
     return (
       <div className="flex justify-center items-center h-screen">
@@ -84,12 +63,6 @@ const GroupPage: React.FC = () => {
   }
 
   const domainUrl = getDomainUrl();
-  const otherMembers = memberList
-    ? memberList.filter((member) => member.user_id !== user!.id)
-    : [];
-  const isParamsGroupIdinGroupList = groupList.some(
-    (group) => group.id === paramsGroupId
-  );
 
   return (
     <div className="flex flex-col gap-10">
@@ -105,52 +78,11 @@ const GroupPage: React.FC = () => {
         <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
       </div>
 
-      {groupList.length == maxGroupCount && !isParamsGroupIdinGroupList ? (
-        <LimitGroupCard />
-      ) : (
-        <>
-          <div className="flex flex-col gap-4">
-            <MyMember currentUserId={user!.id} groupId={paramsGroupId} />
-            {otherMembers.length > 0 ? (
-              <>
-                {isPrayToday ? (
-                  <OtherMemberList
-                    currentUserId={user!.id}
-                    groupId={targetGroup?.id}
-                  />
-                ) : (
-                  <TodayPrayStartCard />
-                )}
-              </>
-            ) : (
-              <GroupInviteCard />
-            )}
-          </div>
-
-          <Drawer
-            open={isOpenTodayPrayDrawer}
-            onOpenChange={setIsOpenTodayPrayDrawer}
-          >
-            <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] pb-20">
-              <DrawerHeader>
-                <DrawerTitle></DrawerTitle>
-                <DrawerDescription></DrawerDescription>
-              </DrawerHeader>
-              {/* PrayCardList */}
-              <PrayCardList
-                currentUserId={user!.id}
-                groupId={targetGroup?.id}
-              />
-              {/* PrayCardList */}
-            </DrawerContent>
-          </Drawer>
-          {isPrayToday && (
-            <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
-              <TodayPrayBtn />
-            </div>
-          )}
-        </>
-      )}
+      <GroupBody
+        currentUserId={user!.id}
+        groupList={groupList}
+        targetGroup={targetGroup}
+      />
     </div>
   );
 };

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -23,12 +23,6 @@ const GroupPage: React.FC = () => {
   const fetchGroupListByUserId = useBaseStore(
     (state) => state.fetchGroupListByUserId
   );
-  const isOpenTodayPrayDrawer = useBaseStore(
-    (state) => state.isOpenTodayPrayDrawer
-  );
-  const setIsOpenTodayPrayDrawer = useBaseStore(
-    (state) => state.setIsOpenTodayPrayDrawer
-  );
 
   const fetchIsPrayToday = useBaseStore((state) => state.fetchIsPrayToday);
   const isPrayToday = useBaseStore((state) => state.isPrayToday);


### PR DESCRIPTION
### 작업 설명

<img src="https://github.com/user-attachments/assets/5704528b-f8d7-4651-ad4d-59455b6f778e" width="150">

기도카드 생성뷰에서 그룹 초대 카드가 같이 노출되고 있는 부분을 해결합니다.

원인: 기도카드 생성은 MyMember 에서 관리하고 그룹초대는 groupPage 에서 관리하면서 나타난 엣지 케이스
해결: 
	1. 그룹 입장 관련은 GroupBody 에서 분기처리 ( 기도카드 작성, 그룹 초과 )
	2. MemberList 노출 관련은 OtherMemberList 에서 분기처리 ( 오늘의 기도카드, 멤버 초대카드 )

### 인수 테스트 진행 결과

<img src="https://github.com/user-attachments/assets/1a9a1648-2b67-4628-a55f-8f94dcefe19f" width="150">
<img src="https://github.com/user-attachments/assets/85946b14-10a4-475d-93f4-ca957e679904" width="150">
<img src="https://github.com/user-attachments/assets/9466c79e-0eaa-451f-b712-3b91e7be24d1" width="150">
<img src="https://github.com/user-attachments/assets/ea01cfa2-fd7e-46eb-8ad2-820319a1d3a1" width="150">

[앞에 2개: 그룹 입장 관련], [뒤에 2개: Member 관련]


### 노션 테스크
https://www.notion.so/mmyeong/refactor-GroupBody-6e274f174bd04c66a107021c22b8faf7?pvs=4