### PR TITLE
feat: 내 기도제목에서 반응 개수 확인하기

### DIFF
--- a/src/Enums/prayType.ts
+++ b/src/Enums/prayType.ts
@@ -1,5 +1,33 @@
+import prayIcon from "@/assets/pray.svg";
+import goodIcon from "@/assets/good.svg";
+import likeIcon from "@/assets/like.svg";
+import prayIconToOther from "@/assets/prayToOther.svg";
+import goodIconToOther from "@/assets/goodToOther.svg";
+import likeIconToOther from "@/assets/likeToOther.svg";
+
 export enum PrayType {
   GOOD = "good",
   PRAY = "pray",
   LIKE = "like",
 }
+
+export const PrayTypeDatas = {
+  [PrayType.PRAY]: {
+    img: prayIcon,
+    reactImg: prayIconToOther,
+    emoji: "🙏",
+    text: "기도해요",
+  },
+  [PrayType.GOOD]: {
+    img: goodIcon,
+    reactImg: goodIconToOther,
+    emoji: "👍",
+    text: "힘내세요",
+  },
+  [PrayType.LIKE]: {
+    img: likeIcon,
+    reactImg: likeIconToOther,
+    emoji: "❤️",
+    text: "응원해요",
+  },
+};

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -33,7 +33,11 @@ export const fetchUserPrayCardListByGroupId = async (
   if (!userId || !groupId) return null;
   const { data, error } = await supabase
     .from("pray_card")
-    .select(`*, profiles (id, full_name, avatar_url)`)
+    .select(
+      `*, 
+      profiles (id, full_name, avatar_url),
+      pray (id, pray_card_id, user_id, pray_type, created_at, updated_at)`
+    )
     .eq("user_id", userId)
     .eq("group_id", groupId)
     .is("deleted_at", null)

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -12,8 +12,7 @@ import useBaseStore from "@/stores/baseStore";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
 import PrayCardCreateModal from "../prayCard/PrayCardCreateModal";
-import { getDateDistance, getDateDistanceText } from "@toss/date";
-import { getISOOnlyDate } from "@/lib/utils";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 
 interface MemberProps {
   currentUserId: string;
@@ -64,35 +63,40 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
     );
   }
 
-  const dateDistance = getDateDistance(
-    new Date(getISOOnlyDate(member?.updated_at ?? null)),
-    new Date(getISOTodayDate())
-  );
-
-  let dateDistanceText = getDateDistanceText(dateDistance, {
-    days: (t) => 1 <= t.days,
-    hours: () => false,
-    minutes: () => false,
-    seconds: () => false,
-  });
-
-  if (dateDistance.days < 1) {
-    dateDistanceText = "오늘";
-  }
+  const prayCard = userPrayCardList[0];
+  const prayDatasForMe = prayCard.pray;
 
   const MyMemberUI = (
     <div className="w-full flex flex-col gap-2 cursor-pointer bg-white p-4 rounded-2xl shadow-md">
-      <div className="flex items-center gap-2">
+      <div className="flex">
         <h3 className="font-bold">내 기도제목</h3>
       </div>
       <div className="text-left text-sm text-gray-600">
         {reduceString(inputPrayCardContent, 20)}
       </div>
-      <div className="text-gray-400 text-left text-xs">{dateDistanceText}</div>
+      <div className="w-fit flex bg-gray-100 rounded-lg p-2">
+        {Object.values(PrayType).map((type) => {
+          return (
+            <div key={type} className={`w-[40px] flex gap-1`}>
+              <div className="flex justify-center items-center gap-1 ">
+                <img
+                  src={PrayTypeDatas[type].img}
+                  alt={PrayTypeDatas[type].emoji}
+                  className="w-4 h-4 opacity-90"
+                />
+                <p className="text-xs text-gray-600">
+                  {
+                    prayDatasForMe?.filter((pray) => pray.pray_type === type)
+                      .length
+                  }
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
-
-  const prayCard = userPrayCardList[0];
 
   return (
     <Drawer>

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -68,9 +68,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
 
   const MyMemberUI = (
     <div className="w-full flex flex-col gap-2 cursor-pointer bg-white p-4 rounded-2xl shadow-md">
-      <div className="flex">
-        <h3 className="font-bold">내 기도제목</h3>
-      </div>
+      <h3 className="flex font-bold">내 기도제목</h3>
       <div className="text-left text-sm text-gray-600">
         {reduceString(inputPrayCardContent, 20)}
       </div>

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -74,11 +74,11 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
       <div className="text-left text-sm text-gray-600">
         {reduceString(inputPrayCardContent, 20)}
       </div>
-      <div className="w-fit flex bg-gray-100 rounded-lg p-2">
+      <div className="w-fit flex bg-gray-100 rounded-lg p-2 gap-3">
         {Object.values(PrayType).map((type) => {
           return (
-            <div key={type} className={`w-[40px] flex gap-1`}>
-              <div className="flex justify-center items-center gap-1 ">
+            <div key={type} className="flex">
+              <div className="flex  gap-1 ">
                 <img
                   src={PrayTypeDatas[type].img}
                   alt={PrayTypeDatas[type].emoji}

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -12,7 +12,7 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer";
 import PrayCardUI from "../prayCard/PrayCardUI";
-import { getDateDistance, getDateDistanceText } from "@toss/date";
+import { getDateDistance } from "@toss/date";
 
 interface OtherMemberProps {
   currentUserId: string;
@@ -32,17 +32,6 @@ const OtherMember: React.FC<OtherMemberProps> = ({
     new Date(getISOTodayDate())
   );
 
-  let dateDistanceText = getDateDistanceText(dateDistance, {
-    days: (t) => 1 <= t.days,
-    hours: () => false,
-    minutes: () => false,
-    seconds: () => false,
-  });
-
-  if (dateDistance.days < 1) {
-    dateDistanceText = "오늘";
-  }
-
   const memberUI = (
     <div className="flex flex-col gap-2 cursor-pointer bg-white p-4 rounded-2xl shadow-md">
       <div className="flex items-center gap-2">
@@ -56,7 +45,7 @@ const OtherMember: React.FC<OtherMemberProps> = ({
         {reduceString(member.pray_summary, 20)}
       </div>
       <div className="text-gray-400 text-left text-xs">
-        {dateDistanceText}전
+        {dateDistance.days < 1 ? "오늘" : `${dateDistance.days}일 전`}
       </div>
     </div>
   );

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -5,12 +5,11 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "../ui/drawer";
-import { PrayType } from "@/Enums/prayType";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import { KakaoShareButton } from "../KakaoShareBtn";
 
 const PrayList: React.FC = () => {
   const prayerList = useBaseStore((state) => state.prayerList);
-  const reactionDatas = useBaseStore((state) => state.reactionDatas);
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
 
   const isPrayerListEmpty = !prayerList || Object.keys(prayerList).length === 0;
@@ -58,8 +57,8 @@ const PrayList: React.FC = () => {
                     <p key={pray.id} className="text-xl text-gray-500">
                       {
                         <img
-                          src={reactionDatas[pray.pray_type as PrayType]?.img}
-                          alt={reactionDatas[pray.pray_type as PrayType]?.emoji}
+                          src={PrayTypeDatas[pray.pray_type as PrayType]?.img}
+                          alt={PrayTypeDatas[pray.pray_type as PrayType]?.emoji}
                         ></img>
                       }
                     </p>

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -4,7 +4,7 @@ import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
 import { Drawer, DrawerTrigger } from "../ui/drawer";
-import { PrayType } from "@/Enums/prayType";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import PrayList from "../pray/PrayList";
 import ReactionWithCalendar from "./ReactionWithCalendar";
 import { getDateDistance } from "@toss/date";
@@ -193,8 +193,8 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
                     >
                       <div className="text-sm w-5 h-5">
                         <img
-                          src={reactionDatas[type]?.img}
-                          alt={reactionDatas[type]?.emoji}
+                          src={PrayTypeDatas[type].img}
+                          alt={PrayTypeDatas[type].emoji}
                           className="w-5 h-5"
                         />
                       </div>

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -25,7 +25,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
   prayCard,
 }) => {
   const prayDataHash = useBaseStore((state) => state.prayDataHash);
-  const reactionDatas = useBaseStore((state) => state.reactionDatas);
+  const reactionCounts = useBaseStore((state) => state.reactionCounts);
   const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
   const inputPrayCardContent = useBaseStore(
     (state) => state.inputPrayCardContent
@@ -184,7 +184,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
             <DrawerTrigger className="w-full focus:outline-none">
               <div className="flex justify-center gap-2">
                 {Object.values(PrayType).map((type) => {
-                  if (!reactionDatas) return null;
+                  if (!reactionCounts) return null;
                   return (
                     <div
                       key={type}
@@ -198,7 +198,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
                           className="w-5 h-5"
                         />
                       </div>
-                      <div className="text-sm">{reactionDatas[type]?.num}</div>
+                      <div className="text-sm">{reactionCounts[type]}</div>
                     </div>
                   );
                 })}

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -1,4 +1,4 @@
-import { PrayType } from "@/Enums/prayType";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import useBaseStore from "@/stores/baseStore";
 import { sleep } from "@/lib/utils";
@@ -16,7 +16,6 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   const createPray = useBaseStore((state) => state.createPray);
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const setIsPrayToday = useBaseStore((state) => state.setIsPrayToday);
-  const reactionDatas = useBaseStore((state) => state.reactionDatas);
   const prayCardCarouselApi = useBaseStore(
     (state) => state.prayCardCarouselApi
   );
@@ -47,7 +46,7 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   return (
     <div className="flex justify-center p-2 space-x-8">
       {Object.values(PrayType).map((type) => {
-        const emojiData = reactionDatas[type];
+        const emojiData = PrayTypeDatas[type];
         if (!emojiData) return null;
 
         return (

--- a/src/components/prayCard/WeeklyCalendar.tsx
+++ b/src/components/prayCard/WeeklyCalendar.tsx
@@ -1,4 +1,4 @@
-import { PrayType } from "@/Enums/prayType";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import { getISODate, getISOToday } from "@/lib/utils";
 import useBaseStore from "@/stores/baseStore";
 import { Pray, PrayCardWithProfiles } from "supabase/types/tables";
@@ -13,13 +13,12 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   prayData,
 }) => {
   const todayPrayTypeHash = useBaseStore((state) => state.todayPrayTypeHash);
-  const reactionDatas = useBaseStore((state) => state.reactionDatas);
 
   const getReactionEmoticon = (prayType: string | null) => {
     return (
       <img
-        src={reactionDatas[prayType as PrayType]?.reactImg}
-        alt={reactionDatas[prayType as PrayType]?.emoji}
+        src={PrayTypeDatas[prayType as PrayType]?.reactImg}
+        alt={PrayTypeDatas[prayType as PrayType]?.emoji}
         className="w-7 h-7"
       ></img>
     );

--- a/src/components/todayPray/TodayPrayStartCard.tsx
+++ b/src/components/todayPray/TodayPrayStartCard.tsx
@@ -1,10 +1,9 @@
 import useBaseStore from "@/stores/baseStore";
 import TodayPrayBtn from "./TodayPrayBtn";
-import { PrayType } from "@/Enums/prayType";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 
 export const TodayPrayStartCard = () => {
   const member = useBaseStore((state) => state.targetMember);
-  const reactionDatas = useBaseStore((state) => state.reactionDatas);
 
   const reactionImages = [
     { type: PrayType.PRAY, opacity: "opacity-40" },
@@ -31,8 +30,8 @@ export const TodayPrayStartCard = () => {
               ) : (
                 <img
                   key={index}
-                  src={reactionDatas[reaction.type!]?.img}
-                  alt={reactionDatas[reaction.type!]?.emoji}
+                  src={PrayTypeDatas[reaction.type!]?.img}
+                  alt={PrayTypeDatas[reaction.type!]?.emoji}
                   className={`w-7 h-7 ${reaction.opacity}`}
                 />
               )

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -35,18 +35,8 @@ import {
 import { PrayType } from "@/Enums/prayType";
 import { getISOToday } from "@/lib/utils";
 import { type CarouselApi } from "@/components/ui/carousel";
-import prayIcon from "@/assets/pray.svg";
-import goodIcon from "@/assets/good.svg";
-import likeIcon from "@/assets/like.svg";
-import prayIconToOther from "@/assets/prayToOther.svg";
-import goodIconToOther from "@/assets/goodToOther.svg";
-import likeIconToOther from "@/assets/likeToOther.svg";
 
 interface EmojiData {
-  img: string;
-  reactImg: string;
-  emoji: string;
-  text: string;
   num: number;
 }
 
@@ -342,24 +332,12 @@ const useBaseStore = create<BaseStore>()(
     isPrayToday: false,
     reactionDatas: {
       [PrayType.PRAY]: {
-        img: prayIcon,
-        reactImg: prayIconToOther,
-        emoji: "🙏",
-        text: "기도해요",
         num: 0,
       },
       [PrayType.GOOD]: {
-        img: goodIcon,
-        reactImg: goodIconToOther,
-        emoji: "👍",
-        text: "힘내세요",
         num: 0,
       },
       [PrayType.LIKE]: {
-        img: likeIcon,
-        reactImg: likeIconToOther,
-        emoji: "❤️",
-        text: "응원해요",
         num: 0,
       },
     },

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -36,10 +36,6 @@ import { PrayType } from "@/Enums/prayType";
 import { getISOToday } from "@/lib/utils";
 import { type CarouselApi } from "@/components/ui/carousel";
 
-interface EmojiData {
-  num: number;
-}
-
 export interface BaseStore {
   // user
   user: User | null;
@@ -118,7 +114,7 @@ export interface BaseStore {
   prayDataHash: PrayDataHash;
   todayPrayTypeHash: TodayPrayTypeHash;
   isPrayToday: boolean;
-  reactionDatas: { [key in PrayType]?: EmojiData };
+  reactionCounts: { [key in PrayType]?: number };
   prayerList: { [key: string]: PrayWithProfiles[] } | null;
   setIsPrayToday: (isPrayToday: boolean) => void;
   fetchIsPrayToday: (
@@ -330,16 +326,10 @@ const useBaseStore = create<BaseStore>()(
     prayDataHash: {},
     todayPrayTypeHash: {},
     isPrayToday: false,
-    reactionDatas: {
-      [PrayType.PRAY]: {
-        num: 0,
-      },
-      [PrayType.GOOD]: {
-        num: 0,
-      },
-      [PrayType.LIKE]: {
-        num: 0,
-      },
+    reactionCounts: {
+      [PrayType.PRAY]: 0,
+      [PrayType.GOOD]: 0,
+      [PrayType.LIKE]: 0,
     },
     prayerList: null,
 
@@ -389,7 +379,7 @@ const useBaseStore = create<BaseStore>()(
         set((state) => {
           state.prayerList = state.groupAndSortByUserId(prayData);
           Object.values(PrayType).forEach((type) => {
-            state.reactionDatas[type]!.num = prayData.filter(
+            state.reactionCounts[type] = prayData.filter(
               (pray) => pray.pray_type === type
             ).length;
           });

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -21,6 +21,7 @@ export interface MemberWithProfiles extends Member {
 
 export interface PrayCardWithProfiles extends PrayCard {
   profiles: Profiles;
+  pray?: Pray[];
 }
 
 export interface PrayWithProfiles extends Pray {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/853d3124-4b78-4255-bad5-93f40f2b9ee4)
![image](https://github.com/user-attachments/assets/10316edf-c00b-4aac-9916-ea5fb17f5355)

- [x]  PrayCard에서 엮인 Pray datas 가져오기
- [x]  baseStore에서 불필요하게 관리되던 반응 데이터(아이콘 등) 분리
- [x] 오늘 말고 오늘 전이라고 뜨는 오류 수정 

https://www.notion.so/mmyeong/feat-35d765e263db416a88ad1854078f7de3?pvs=4
