### PR TITLE
refactor: prayCardList 기도 필요카드만 노출

### DIFF
--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -29,7 +29,6 @@ export const fetchGroupPrayCardList = async (
     console.error("error", error);
     return null;
   }
-  console.log("data", data);
   return data as PrayCardWithProfiles[];
 };
 

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -4,23 +4,32 @@ import { PrayCard, PrayCardWithProfiles } from "../../supabase/types/tables";
 
 export const fetchGroupPrayCardList = async (
   groupId: string | undefined,
+  currentUserId: string,
   startDt: string,
   endDt: string
 ): Promise<PrayCardWithProfiles[] | null> => {
   if (!groupId) return null;
   const { data, error } = await supabase
     .from("pray_card")
-    .select(`*, profiles (id, full_name, avatar_url)`)
+    .select(
+      `*,
+      profiles (id, full_name, avatar_url),
+      pray (*, 
+        profiles (id, full_name, avatar_url)
+      )`
+    )
     .eq("group_id", groupId)
+    .eq("pray.user_id", currentUserId)
     .gte("created_at", startDt)
     .lt("created_at", endDt)
     .is("deleted_at", null)
-    .order("created_at", { ascending: false });
+    .order("updated_at", { ascending: false });
 
   if (error) {
     console.error("error", error);
     return null;
   }
+  console.log("data", data);
   return data as PrayCardWithProfiles[];
 };
 
@@ -34,9 +43,11 @@ export const fetchUserPrayCardListByGroupId = async (
   const { data, error } = await supabase
     .from("pray_card")
     .select(
-      `*, 
+      `*,
       profiles (id, full_name, avatar_url),
-      pray (id, pray_card_id, user_id, pray_type, created_at, updated_at, profiles (id, full_name, avatar_url))`
+      pray (*, 
+        profiles (id, full_name, avatar_url)
+      )`
     )
     .eq("user_id", userId)
     .eq("group_id", groupId)

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -28,13 +28,15 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   const startDt = getISOTodayDate(-6);
   const endDt = getISOTodayDate(1);
 
+  // PrayCardList 멤버리스트에서는 PrayCardList 불러오지 않기
   useEffect(() => {
-    fetchGroupPrayCardList(groupId, startDt, endDt);
+    fetchGroupPrayCardList(groupId, currentUserId, startDt, endDt);
     fetchMemberListByGroupId(groupId);
   }, [
     fetchGroupPrayCardList,
     fetchMemberListByGroupId,
     groupId,
+    currentUserId,
     startDt,
     endDt,
   ]);
@@ -51,6 +53,7 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
     (member) => member.user_id !== currentUserId
   );
 
+  // TODO: 이것도 제거하기
   const userIdPrayCardListHash = memberList.reduce((hash, member) => {
     const prayCardList = groupPrayCardList.filter(
       (prayCard) => prayCard.user_id === member.user_id

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -47,14 +47,21 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
 
   useEffect(() => {
     // TODO: 초기화 이후에 재랜더링 필요(useEffect 무한 로딩 고려)
-    fetchGroupPrayCardList(groupId, startDt, endDt);
+    fetchGroupPrayCardList(groupId, currentUserId, startDt, endDt);
     prayCardCarouselApi?.on("select", () => {
       const currentIndex = prayCardCarouselApi.selectedScrollSnap();
       const carouselLength = prayCardCarouselApi.scrollSnapList().length;
       if (currentIndex === 0) prayCardCarouselApi.scrollNext();
       if (currentIndex === carouselLength - 1) prayCardCarouselApi.scrollPrev();
     });
-  }, [prayCardCarouselApi, fetchGroupPrayCardList, groupId, startDt, endDt]);
+  }, [
+    prayCardCarouselApi,
+    fetchGroupPrayCardList,
+    groupId,
+    currentUserId,
+    startDt,
+    endDt,
+  ]);
 
   if (!groupPrayCardList) {
     return (
@@ -64,6 +71,7 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
     );
   }
 
+  // TODO: member 가 아예 없는 경우와 기도카드가 올라오지 않은 경우
   if (groupPrayCardList.length == 1) {
     return (
       <div className="flex flex-col justify-center items-center p-10 gap-4">
@@ -88,6 +96,7 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
     );
   }
 
+  const todayDt = getISOTodayDate();
   return (
     <Carousel
       setApi={setPrayCardCarouselApi}
@@ -98,7 +107,12 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
       <CarouselContent>
         <CarouselItem className="basis-5/6"></CarouselItem>
         {groupPrayCardList
-          ?.filter((prayCard) => prayCard.user_id !== currentUserId)
+          ?.filter(
+            (prayCard) =>
+              prayCard.user_id !== currentUserId &&
+              prayCard.pray?.filter((pray) => pray.created_at >= todayDt)
+                .length === 0
+          )
           .map((prayCard) => (
             <CarouselItem key={prayCard.id} className="basis-5/6 h-screen">
               <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -24,6 +24,7 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
   const fetchGroupPrayCardList = useBaseStore(
     (state) => state.fetchGroupPrayCardList
   );
+
   const prayCardCarouselApi = useBaseStore(
     (state) => state.prayCardCarouselApi
   );
@@ -97,6 +98,11 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
   }
 
   const todayDt = getISOTodayDate();
+  const filterdGroupPrayCardList = groupPrayCardList?.filter(
+    (prayCard) =>
+      prayCard.user_id !== currentUserId &&
+      prayCard.pray?.filter((pray) => pray.created_at >= todayDt).length === 0
+  );
   return (
     <Carousel
       setApi={setPrayCardCarouselApi}
@@ -106,18 +112,11 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
     >
       <CarouselContent>
         <CarouselItem className="basis-5/6"></CarouselItem>
-        {groupPrayCardList
-          ?.filter(
-            (prayCard) =>
-              prayCard.user_id !== currentUserId &&
-              prayCard.pray?.filter((pray) => pray.created_at >= todayDt)
-                .length === 0
-          )
-          .map((prayCard) => (
-            <CarouselItem key={prayCard.id} className="basis-5/6 h-screen">
-              <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
-            </CarouselItem>
-          ))}
+        {filterdGroupPrayCardList.map((prayCard) => (
+          <CarouselItem key={prayCard.id} className="basis-5/6 h-screen">
+            <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
+          </CarouselItem>
+        ))}
         <CarouselItem className="basis-5/6">{completedItem}</CarouselItem>
         <CarouselItem className="basis-5/6"></CarouselItem>
       </CarouselContent>

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -10,6 +10,7 @@ import { ClipLoader } from "react-spinners";
 import { getISOTodayDate } from "@/lib/utils";
 import { KakaoShareButton } from "../KakaoShareBtn";
 import MyMemberBtn from "../todayPray/MyMemberBtn";
+import { PrayTypeDatas } from "@/Enums/prayType";
 
 interface PrayCardListProps {
   currentUserId: string;
@@ -37,10 +38,15 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
 
   const completedItem = (
     <div className="flex flex-col gap-4 justify-center items-center pt-10">
-      <h1 className="font-bold text-xl">기도 완료</h1>
-      <div className="text-grayText text-center">
-        <h1>당신의 기도제목을</h1>
-        <h1>확인하세요</h1>
+      <img
+        src={PrayTypeDatas["pray"].img}
+        alt={PrayTypeDatas["pray"].emoji}
+        className="w-16 h-16 opacity-100"
+      />
+      <h1 className="font-bold text-xl">오늘의 기도 완료</h1>
+      <div className="text-gray-400 text-center">
+        <h1>당신을 위해 기도한</h1>
+        <h1>사람들을 확인해보세요</h1>
       </div>
       <MyMemberBtn />
     </div>

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -91,6 +91,7 @@ export interface BaseStore {
   prayCardCarouselApi: CarouselApi | null;
   fetchGroupPrayCardList: (
     groupId: string | undefined,
+    currentUserId: string,
     startDt: string,
     endDt: string
   ) => Promise<void>;
@@ -269,11 +270,13 @@ const useBaseStore = create<BaseStore>()(
     },
     fetchGroupPrayCardList: async (
       groupId: string | undefined,
+      currentUserId: string,
       startDt: string,
       endDt: string
     ) => {
       const groupPrayCardList = await fetchGroupPrayCardList(
         groupId,
+        currentUserId,
         startDt,
         endDt
       );


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/e420be52-ad08-45b5-a478-f8ba37fe500a" width="150">
<img src="https://github.com/user-attachments/assets/c671bdea-185c-4702-b361-bb16ebd51676" width="150">

### 작업 내용
기도를 완료한 카드는 오늘의 기도에서 노출되지 않도록 하였습니다.

### 체크리스트
- [x] fetchGroupPrayCardList 결과에 prayData 추가
- [x] 오늘의 기도 카드 필터링
- [x] 오늘의 기도 update 순으로 정렬
- [x] 기도 완료 이미지 삽입 

### 노션 링크

https://www.notion.so/mmyeong/fix-PrayCardList-16949caca1094311ba2e4442cfb9cbd0?pvs=4