### PR TITLE
refactor: PrayCardUI >  MyPrayCard 분리 + 기도제목 잘림 이슈 해결

### DIFF
--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -36,18 +36,28 @@ export const fetchUserPrayCardListByGroupId = async (
     .select(
       `*, 
       profiles (id, full_name, avatar_url),
-      pray (id, pray_card_id, user_id, pray_type, created_at, updated_at)`
+      pray (id, pray_card_id, user_id, pray_type, created_at, updated_at, profiles (id, full_name, avatar_url))`
     )
     .eq("user_id", userId)
     .eq("group_id", groupId)
     .is("deleted_at", null)
     .order("created_at", { ascending: false })
     .range(offset, offset + limit - 1);
+
   if (error) {
     console.error("error", error);
     return null;
   }
-  return data as PrayCardWithProfiles[];
+
+  const sortedData = data.map((data) => ({
+    ...data,
+    pray: data.pray.sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    ),
+  }));
+
+  return sortedData as PrayCardWithProfiles[];
 };
 
 export const createPrayCard = async (

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -7,11 +7,11 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
-import PrayCardUI from "../prayCard/PrayCardUI";
 import useBaseStore from "@/stores/baseStore";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
+import MyPrayCardUI from "../prayCard/MyPrayCardUI";
 
 interface MemberProps {
   currentUserId: string;
@@ -99,11 +99,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
           <DrawerDescription></DrawerDescription>
         </DrawerHeader>
         {/* PrayCard */}
-        <PrayCardUI
-          currentUserId={currentUserId}
-          member={member}
-          prayCard={prayCard}
-        />
+        <MyPrayCardUI member={member} prayCard={prayCard} />
         {/* PrayCard */}
       </DrawerContent>
     </Drawer>

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -1,0 +1,178 @@
+import useBaseStore from "@/stores/baseStore";
+import { useEffect, useState, useRef } from "react";
+import { PrayCardWithProfiles } from "supabase/types/tables";
+import { MemberWithProfiles } from "supabase/types/tables";
+import { ClipLoader } from "react-spinners";
+import { Drawer, DrawerTrigger } from "../ui/drawer";
+import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
+import PrayList from "../pray/PrayList";
+import { getDateDistance } from "@toss/date";
+import { getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
+import { Textarea } from "../ui/textarea";
+import { FaEdit, FaSave } from "react-icons/fa";
+import iconUserMono from "@/assets/icon-user-mono.svg";
+
+interface PrayCardProps {
+  prayCard: PrayCardWithProfiles | null;
+  member?: MemberWithProfiles | null;
+}
+
+const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
+  const prayDataHash = useBaseStore((state) => state.prayDataHash);
+  const reactionCounts = useBaseStore((state) => state.reactionCounts);
+  const inputPrayCardContent = useBaseStore(
+    (state) => state.inputPrayCardContent
+  );
+  const isEditingPrayCard = useBaseStore((state) => state.isEditingPrayCard);
+
+  const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
+  const setIsEditingPrayCard = useBaseStore(
+    (state) => state.setIsEditingPrayCard
+  );
+  const updateMember = useBaseStore((state) => state.updateMember);
+  const updatePrayCardContent = useBaseStore(
+    (state) => state.updatePrayCardContent
+  );
+  const fetchPrayDataByUserId = useBaseStore(
+    (state) => state.fetchPrayDataByUserId
+  );
+
+  const [isScrollable, setIsScrollable] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const dateDistance = getDateDistance(
+    new Date(
+      getISOOnlyDate(
+        prayCard?.created_at ?? member?.updated_at ?? getISOTodayDate()
+      )
+    ),
+    new Date(getISOTodayDate())
+  );
+
+  const handleSaveClick = (
+    prayCardId: string,
+    content: string,
+    memberId: string | undefined
+  ) => {
+    updatePrayCardContent(prayCardId, content);
+    updateMember(memberId, content);
+  };
+
+  useEffect(() => {
+    fetchPrayDataByUserId(prayCard?.id, undefined);
+  }, [fetchPrayDataByUserId, prayCard?.id, prayCard?.user_id]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      setIsScrollable(textarea.scrollHeight > textarea.clientHeight);
+    }
+  }, [inputPrayCardContent]);
+
+  if (!prayDataHash) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={50} color={"#123abc"} loading={true} />
+      </div>
+    );
+  }
+
+  const PrayCardBody = (
+    <>
+      <div className="relative flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
+        <div className="bg-gradient-to-r from-start/60 via-middle/60 h-15vh via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
+          <div className="flex items-center gap-2 w-full">
+            <div className="flex gap-2 items-center">
+              <p className="text-xl text-white">
+                기도 {dateDistance.days + 1}일차
+              </p>
+            </div>
+          </div>
+          <p className="text-xs text-white w-full text-left">
+            시작일 :{" "}
+            {prayCard?.created_at.split("T")[0] ||
+              member?.updated_at.split("T")[0]}
+          </p>
+        </div>
+        <div
+          className={`p-2 flex justify-center h-full overflow-y-auto no-scrollbar ${
+            isScrollable ? "items-start" : "items-center"
+          }`}
+        >
+          {isEditingPrayCard ? (
+            <Textarea
+              ref={textareaRef}
+              className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
+              value={inputPrayCardContent}
+              onChange={(e) => setPrayCardContent(e.target.value)}
+              maxLength={400}
+            />
+          ) : (
+            <p className="whitespace-pre-line">{inputPrayCardContent}</p>
+          )}
+        </div>
+        <div className="absolute bottom-4 right-4">
+          {isEditingPrayCard ? (
+            <button
+              className={`text-white rounded-full bg-middle/90 w-10 h-10 flex justify-center items-center ${
+                !inputPrayCardContent ? " opacity-50 cursor-not-allowed" : ""
+              }`}
+              onClick={() =>
+                handleSaveClick(prayCard!.id, inputPrayCardContent, member?.id)
+              }
+              disabled={!inputPrayCardContent}
+            >
+              <FaSave className="text-white w-5 h-5" />
+            </button>
+          ) : (
+            <button
+              className="text-white rounded-full bg-end/90 w-10 h-10 flex justify-center items-center"
+              onClick={() => setIsEditingPrayCard(true)}
+            >
+              <FaEdit className="text-white w-5 h-5" />
+            </button>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {PrayCardBody}
+      <div className="flex flex-col gap-5">
+        <Drawer>
+          <DrawerTrigger className="w-full focus:outline-none">
+            <div className="flex justify-center gap-2">
+              {Object.values(PrayType).map((type) => {
+                if (!reactionCounts) return null;
+                return (
+                  <div
+                    key={type}
+                    className={`w-[60px] py-1 px-2 flex rounded-lg bg-white text-black gap-2
+                      }`}
+                  >
+                    <div className="text-sm w-5 h-5">
+                      <img
+                        src={PrayTypeDatas[type].img}
+                        alt={PrayTypeDatas[type].emoji}
+                        className="w-5 h-5"
+                      />
+                    </div>
+                    <div className="text-sm">{reactionCounts[type]}</div>
+                  </div>
+                );
+              })}
+              <div className="bg-white rounded-lg flex justify-center items-center p-1">
+                <img className="w-5" src={iconUserMono} alt="user-icon" />
+              </div>
+            </div>
+          </DrawerTrigger>
+          <PrayList />
+        </Drawer>
+      </div>
+    </div>
+  );
+};
+
+export default MyPrayCardUI;

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -1,5 +1,5 @@
+import { useState, useRef, useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
-import { useEffect, useState, useRef } from "react";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
@@ -37,8 +37,11 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     (state) => state.setReactionDatasForMe
   );
 
-  const [isScrollable, setIsScrollable] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [displayedContent, setDisplayedContent] =
+    useState(inputPrayCardContent);
+  const [isOverflow, setIsOverflow] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
   const prayDatas = prayCard.pray;
 
   const dateDistance = getDateDistance(
@@ -57,17 +60,24 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   ) => {
     updatePrayCardContent(prayCardId, content);
     updateMember(memberId, content);
+    setDisplayedContent(content);
+    setIsEditingPrayCard(false);
   };
 
   useEffect(() => {
-    const textarea = textareaRef.current;
     if (prayDatas) {
       setReactionDatasForMe(prayDatas);
     }
-    if (textarea) {
-      setIsScrollable(textarea.scrollHeight > textarea.clientHeight);
+  }, [prayDatas, setReactionDatasForMe]);
+
+  useEffect(() => {
+    const contentElement = contentRef.current;
+    if (contentElement) {
+      const isContentOverflowing =
+        contentElement.scrollHeight > contentElement.clientHeight;
+      setIsOverflow(isContentOverflowing);
     }
-  }, [inputPrayCardContent, prayDatas, setReactionDatasForMe]);
+  }, [inputPrayCardContent, displayedContent]);
 
   if (!prayDataHash) {
     return (
@@ -94,20 +104,20 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
         </p>
       </div>
       <div
-        className={`p-2 flex justify-center h-full overflow-y-auto no-scrollbar ${
-          isScrollable ? "items-start" : "items-center"
+        ref={contentRef}
+        className={`p-2 flex h-full overflow-y-auto no-scrollbar justify-center ${
+          isOverflow ? "items-start" : "items-center"
         }`}
       >
         {isEditingPrayCard ? (
           <Textarea
-            ref={textareaRef}
             className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
             value={inputPrayCardContent}
             onChange={(e) => setPrayCardContent(e.target.value)}
             maxLength={400}
           />
         ) : (
-          <p className="whitespace-pre-line">{inputPrayCardContent}</p>
+          <p className="whitespace-pre-line">{displayedContent}</p>
         )}
       </div>
       <div className="absolute bottom-4 right-4">

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -13,7 +13,7 @@ import { FaEdit, FaSave } from "react-icons/fa";
 import iconUserMono from "@/assets/icon-user-mono.svg";
 
 interface PrayCardProps {
-  prayCard: PrayCardWithProfiles | null;
+  prayCard: PrayCardWithProfiles;
   member?: MemberWithProfiles | null;
 }
 
@@ -33,12 +33,13 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   const updatePrayCardContent = useBaseStore(
     (state) => state.updatePrayCardContent
   );
-  const fetchPrayDataByUserId = useBaseStore(
-    (state) => state.fetchPrayDataByUserId
+  const setReactionDatasForMe = useBaseStore(
+    (state) => state.setReactionDatasForMe
   );
 
   const [isScrollable, setIsScrollable] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const prayDatas = prayCard.pray;
 
   const dateDistance = getDateDistance(
     new Date(
@@ -59,15 +60,14 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   };
 
   useEffect(() => {
-    fetchPrayDataByUserId(prayCard?.id, undefined);
-  }, [fetchPrayDataByUserId, prayCard?.id, prayCard?.user_id]);
-
-  useEffect(() => {
     const textarea = textareaRef.current;
+    if (prayDatas) {
+      setReactionDatasForMe(prayDatas);
+    }
     if (textarea) {
       setIsScrollable(textarea.scrollHeight > textarea.clientHeight);
     }
-  }, [inputPrayCardContent]);
+  }, [inputPrayCardContent, prayDatas, setReactionDatasForMe]);
 
   if (!prayDataHash) {
     return (
@@ -77,69 +77,67 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     );
   }
 
-  const PrayCardBody = (
-    <>
-      <div className="relative flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
-        <div className="bg-gradient-to-r from-start/60 via-middle/60 h-15vh via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
-          <div className="flex items-center gap-2 w-full">
-            <div className="flex gap-2 items-center">
-              <p className="text-xl text-white">
-                기도 {dateDistance.days + 1}일차
-              </p>
-            </div>
+  const MyPrayCardBody = (
+    <div className="relative flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
+      <div className="bg-gradient-to-r from-start/60 via-middle/60 h-15vh via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
+        <div className="flex items-center gap-2 w-full">
+          <div className="flex gap-2 items-center">
+            <p className="text-xl text-white">
+              기도 {dateDistance.days + 1}일차
+            </p>
           </div>
-          <p className="text-xs text-white w-full text-left">
-            시작일 :{" "}
-            {prayCard?.created_at.split("T")[0] ||
-              member?.updated_at.split("T")[0]}
-          </p>
         </div>
-        <div
-          className={`p-2 flex justify-center h-full overflow-y-auto no-scrollbar ${
-            isScrollable ? "items-start" : "items-center"
-          }`}
-        >
-          {isEditingPrayCard ? (
-            <Textarea
-              ref={textareaRef}
-              className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
-              value={inputPrayCardContent}
-              onChange={(e) => setPrayCardContent(e.target.value)}
-              maxLength={400}
-            />
-          ) : (
-            <p className="whitespace-pre-line">{inputPrayCardContent}</p>
-          )}
-        </div>
-        <div className="absolute bottom-4 right-4">
-          {isEditingPrayCard ? (
-            <button
-              className={`text-white rounded-full bg-middle/90 w-10 h-10 flex justify-center items-center ${
-                !inputPrayCardContent ? " opacity-50 cursor-not-allowed" : ""
-              }`}
-              onClick={() =>
-                handleSaveClick(prayCard!.id, inputPrayCardContent, member?.id)
-              }
-              disabled={!inputPrayCardContent}
-            >
-              <FaSave className="text-white w-5 h-5" />
-            </button>
-          ) : (
-            <button
-              className="text-white rounded-full bg-end/90 w-10 h-10 flex justify-center items-center"
-              onClick={() => setIsEditingPrayCard(true)}
-            >
-              <FaEdit className="text-white w-5 h-5" />
-            </button>
-          )}
-        </div>
+        <p className="text-xs text-white w-full text-left">
+          시작일 :{" "}
+          {prayCard?.created_at.split("T")[0] ||
+            member?.updated_at.split("T")[0]}
+        </p>
       </div>
-    </>
+      <div
+        className={`p-2 flex justify-center h-full overflow-y-auto no-scrollbar ${
+          isScrollable ? "items-start" : "items-center"
+        }`}
+      >
+        {isEditingPrayCard ? (
+          <Textarea
+            ref={textareaRef}
+            className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
+            value={inputPrayCardContent}
+            onChange={(e) => setPrayCardContent(e.target.value)}
+            maxLength={400}
+          />
+        ) : (
+          <p className="whitespace-pre-line">{inputPrayCardContent}</p>
+        )}
+      </div>
+      <div className="absolute bottom-4 right-4">
+        {isEditingPrayCard ? (
+          <button
+            className={`text-white rounded-full bg-middle/90 w-10 h-10 flex justify-center items-center ${
+              !inputPrayCardContent ? " opacity-50 cursor-not-allowed" : ""
+            }`}
+            onClick={() =>
+              handleSaveClick(prayCard!.id, inputPrayCardContent, member?.id)
+            }
+            disabled={!inputPrayCardContent}
+          >
+            <FaSave className="text-white w-5 h-5" />
+          </button>
+        ) : (
+          <button
+            className="text-white rounded-full bg-end/90 w-10 h-10 flex justify-center items-center"
+            onClick={() => setIsEditingPrayCard(true)}
+          >
+            <FaEdit className="text-white w-5 h-5" />
+          </button>
+        )}
+      </div>
+    </div>
   );
 
   return (
     <div className="flex flex-col gap-6">
-      {PrayCardBody}
+      {MyPrayCardBody}
       <div className="flex flex-col gap-5">
         <Drawer>
           <DrawerTrigger className="w-full focus:outline-none">

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,5 +1,5 @@
+import { useState, useRef, useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
-import { useEffect } from "react";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
@@ -21,11 +21,23 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
     fetchPrayDataByUserId: state.fetchPrayDataByUserId,
   }));
 
+  const [isOverflow, setIsOverflow] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (prayCard?.id) {
       fetchPrayDataByUserId(prayCard.id, currentUserId);
     }
   }, [currentUserId, fetchPrayDataByUserId, prayCard?.id]);
+
+  useEffect(() => {
+    const contentElement = contentRef.current;
+    if (contentElement) {
+      const isContentOverflowing =
+        contentElement.scrollHeight > contentElement.clientHeight;
+      setIsOverflow(isContentOverflowing);
+    }
+  }, [prayCard?.content, member?.pray_summary]);
 
   if (!prayDataHash) {
     return (
@@ -58,7 +70,12 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
               member?.updated_at.split("T")[0]}
           </p>
         </div>
-        <div className="p-2 flex justify-center h-full overflow-y-auto no-scrollbar items-center">
+        <div
+          ref={contentRef}
+          className={`p-2 flex ${
+            isOverflow ? "items-start" : "items-center"
+          } h-full overflow-y-auto no-scrollbar`}
+        >
           <p className="whitespace-pre-line">
             {prayCard?.content || member?.pray_summary}
           </p>

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,17 +1,9 @@
 import useBaseStore from "@/stores/baseStore";
-import { useEffect, useState, useRef } from "react";
+import { useEffect } from "react";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
-import { Drawer, DrawerTrigger } from "../ui/drawer";
-import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
-import PrayList from "../pray/PrayList";
 import ReactionWithCalendar from "./ReactionWithCalendar";
-import { getDateDistance } from "@toss/date";
-import { getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
-import { Textarea } from "../ui/textarea";
-import { FaEdit, FaSave } from "react-icons/fa";
-import iconUserMono from "@/assets/icon-user-mono.svg";
 
 interface PrayCardProps {
   currentUserId: string;
@@ -24,58 +16,16 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
   member,
   prayCard,
 }) => {
-  const prayDataHash = useBaseStore((state) => state.prayDataHash);
-  const reactionCounts = useBaseStore((state) => state.reactionCounts);
-  const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
-  const inputPrayCardContent = useBaseStore(
-    (state) => state.inputPrayCardContent
-  );
-  const isEditingPrayCard = useBaseStore((state) => state.isEditingPrayCard);
-  const setIsEditingPrayCard = useBaseStore(
-    (state) => state.setIsEditingPrayCard
-  );
-  const updateMember = useBaseStore((state) => state.updateMember);
-  const updatePrayCardContent = useBaseStore(
-    (state) => state.updatePrayCardContent
-  );
-  const fetchPrayDataByUserId = useBaseStore(
-    (state) => state.fetchPrayDataByUserId
-  );
-
-  const [isScrollable, setIsScrollable] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-  const dateDistance = getDateDistance(
-    new Date(
-      getISOOnlyDate(
-        prayCard?.created_at ?? member?.updated_at ?? getISOTodayDate()
-      )
-    ),
-    new Date(getISOTodayDate())
-  );
-
-  const handleSaveClick = (
-    prayCardId: string,
-    content: string,
-    memberId: string | undefined
-  ) => {
-    updatePrayCardContent(prayCardId, content);
-    updateMember(memberId, content);
-  };
+  const { prayDataHash, fetchPrayDataByUserId } = useBaseStore((state) => ({
+    prayDataHash: state.prayDataHash,
+    fetchPrayDataByUserId: state.fetchPrayDataByUserId,
+  }));
 
   useEffect(() => {
-    fetchPrayDataByUserId(
-      prayCard?.id,
-      prayCard?.user_id == currentUserId ? undefined : currentUserId
-    );
-  }, [currentUserId, fetchPrayDataByUserId, prayCard?.id, prayCard?.user_id]);
-
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      setIsScrollable(textarea.scrollHeight > textarea.clientHeight);
+    if (prayCard?.id) {
+      fetchPrayDataByUserId(prayCard.id, currentUserId);
     }
-  }, [inputPrayCardContent]);
+  }, [currentUserId, fetchPrayDataByUserId, prayCard?.id]);
 
   if (!prayDataHash) {
     return (
@@ -85,34 +35,22 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
     );
   }
 
-  const PrayCardBody = (
-    <>
+  return (
+    <div className="flex flex-col gap-6">
       <div className="relative flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
         <div className="bg-gradient-to-r from-start/60 via-middle/60 h-15vh via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
           <div className="flex items-center gap-2 w-full">
-            {currentUserId == prayCard?.user_id ? (
-              <div className="flex gap-2 items-center">
-                <p className="text-xl text-white">
-                  기도 {dateDistance.days + 1}일차
-                </p>
-              </div>
-            ) : (
-              <>
-                <img
-                  src={
-                    prayCard?.profiles.avatar_url ||
-                    member?.profiles.avatar_url ||
-                    ""
-                  }
-                  className="w-6 h-6 rounded-full"
-                />
-                <div className="">
-                  <p className="text-white text-lg">
-                    {prayCard?.profiles.full_name || member?.profiles.full_name}
-                  </p>
-                </div>
-              </>
-            )}
+            <img
+              src={
+                prayCard?.profiles.avatar_url ||
+                member?.profiles.avatar_url ||
+                ""
+              }
+              className="w-6 h-6 rounded-full"
+            />
+            <p className="text-white text-lg">
+              {prayCard?.profiles.full_name || member?.profiles.full_name}
+            </p>
           </div>
           <p className="text-xs text-white w-full text-left">
             시작일 :{" "}
@@ -120,97 +58,13 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
               member?.updated_at.split("T")[0]}
           </p>
         </div>
-        <div
-          className={`p-2 flex justify-center h-full overflow-y-auto no-scrollbar ${
-            isScrollable ? "items-start" : "items-center"
-          }`}
-        >
-          {prayCard?.user_id !== currentUserId ? (
-            <p className="whitespace-pre-line">
-              {prayCard?.content || member?.pray_summary}
-            </p>
-          ) : isEditingPrayCard ? (
-            <Textarea
-              ref={textareaRef}
-              className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
-              value={inputPrayCardContent}
-              onChange={(e) => setPrayCardContent(e.target.value)}
-              maxLength={400}
-            />
-          ) : (
-            <p className="whitespace-pre-line">{inputPrayCardContent}</p>
-          )}
+        <div className="p-2 flex justify-center h-full overflow-y-auto no-scrollbar items-center">
+          <p className="whitespace-pre-line">
+            {prayCard?.content || member?.pray_summary}
+          </p>
         </div>
-        {prayCard?.user_id === currentUserId && (
-          <div className="absolute bottom-4 right-4 w-10 h-10 bg-end rounded-full flex justify-center items-center">
-            {isEditingPrayCard ? (
-              <button
-                className={`text-white rounded-full ${
-                  !inputPrayCardContent ? " opacity-50 cursor-not-allowed" : ""
-                }`}
-                onClick={() =>
-                  handleSaveClick(
-                    prayCard!.id,
-                    inputPrayCardContent,
-                    member?.id
-                  )
-                }
-                disabled={!inputPrayCardContent}
-              >
-                <FaSave className="text-white w-5 h-5" />
-              </button>
-            ) : (
-              <button
-                className="text-white rounded-full"
-                onClick={() => setIsEditingPrayCard(true)}
-              >
-                <FaEdit className="text-white w-5 h-5" />
-              </button>
-            )}
-          </div>
-        )}
       </div>
-    </>
-  );
-
-  return (
-    <div className="flex flex-col gap-6">
-      {PrayCardBody}
-      {currentUserId != prayCard?.user_id ? (
-        <ReactionWithCalendar prayCard={prayCard} />
-      ) : (
-        <div className="flex flex-col gap-5">
-          <Drawer>
-            <DrawerTrigger className="w-full focus:outline-none">
-              <div className="flex justify-center gap-2">
-                {Object.values(PrayType).map((type) => {
-                  if (!reactionCounts) return null;
-                  return (
-                    <div
-                      key={type}
-                      className={`w-[60px] py-1 px-2 flex rounded-lg bg-white text-black gap-2
-                      }`}
-                    >
-                      <div className="text-sm w-5 h-5">
-                        <img
-                          src={PrayTypeDatas[type].img}
-                          alt={PrayTypeDatas[type].emoji}
-                          className="w-5 h-5"
-                        />
-                      </div>
-                      <div className="text-sm">{reactionCounts[type]}</div>
-                    </div>
-                  );
-                })}
-                <div className="bg-white rounded-lg flex justify-center items-center p-1">
-                  <img className="w-5" src={iconUserMono} alt="user-icon" />
-                </div>
-              </div>
-            </DrawerTrigger>
-            <PrayList />
-          </Drawer>
-        </div>
-      )}
+      <ReactionWithCalendar prayCard={prayCard} />
     </div>
   );
 };

--- a/src/components/prayCard/ReactionWithCalendar.tsx
+++ b/src/components/prayCard/ReactionWithCalendar.tsx
@@ -1,5 +1,5 @@
 import useBaseStore from "@/stores/baseStore";
-import PrayCardCalendar from "./WeeklyCalendar";
+import WeeklyCalendar from "./WeeklyCalendar";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import ReactionBtn from "./ReactionBtn";
 import { KakaoShareButton } from "../KakaoShareBtn";
@@ -27,7 +27,7 @@ const ReactionWithCalendar: React.FC<PrayCardProps> = ({ prayCard }) => {
 
   return (
     <div className="flex flex-col gap-6">
-      <PrayCardCalendar
+      <WeeklyCalendar
         prayCard={prayCard}
         prayData={prayDataHash[prayCard?.id || ""] || []}
       />

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -135,6 +135,7 @@ export interface BaseStore {
   groupAndSortByUserId: (data: PrayWithProfiles[]) => {
     [key: string]: PrayWithProfiles[];
   };
+  setReactionDatasForMe: (prayData: PrayWithProfiles[]) => void;
 }
 
 const useBaseStore = create<BaseStore>()(
@@ -420,6 +421,17 @@ const useBaseStore = create<BaseStore>()(
         state.todayPrayTypeHash[prayCardId!] = prayType;
       });
       return pray;
+    },
+    setReactionDatasForMe: (prayData: PrayWithProfiles[]) => {
+      if (prayData)
+        set((state) => {
+          state.prayerList = state.groupAndSortByUserId(prayData);
+          Object.values(PrayType).forEach((type) => {
+            state.reactionCounts[type] = prayData.filter(
+              (pray) => pray.pray_type === type
+            ).length;
+          });
+        });
     },
   }))
 );

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -21,7 +21,7 @@ export interface MemberWithProfiles extends Member {
 
 export interface PrayCardWithProfiles extends PrayCard {
   profiles: Profiles;
-  pray?: Pray[];
+  pray?: PrayWithProfiles[];
 }
 
 export interface PrayWithProfiles extends Pray {


### PR DESCRIPTION
# Why
- PrayCardUI가 너무 복잡합니다.
- 남의 기도제목이 길 때 윗부분이 잘립니다.
- MyMember에서 받은 prayCard 데이터로 불필요한 useEffect를 없애도 되는 상황입니다.

# Result
- [x]  PrayCardUI 분리
    - [x]  MyPrayCardUI 생성
        - [x]  MyMeber의 prayCard 데이터로 prayerList까지 생성하기
        - [x]  item-center : item-start 처리
    - [x]  OtherPrayCardUI
        - [x]  item-center : item-start 처리

https://www.notion.so/mmyeong/refactor-PrayCardUI-b5a32be59f31466ea8433c5d8a526a4a?pvs=4