### PR TITLE
fix: 안드로이드 drawer rendering 해결

### DIFF
--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -93,7 +93,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
         <div className="flex flex-col items-start gap-2">{MyMemberUI}</div>
       </DrawerTrigger>
 
-      <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] px-10 pb-20 focus:outline-none">
+      <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-20 focus:outline-none">
         <DrawerHeader>
           <DrawerTitle></DrawerTitle>
           <DrawerDescription></DrawerDescription>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/22b0d1b7-1d9b-460b-a5b5-6a588f35bf1e" width="200" alt="KakaoTalk_Photo_2024-07-31-18-09-52 001">
<img src="https://github.com/user-attachments/assets/4494f0f5-457c-4cf9-8947-6307e607670b" width="200" alt="KakaoTalk_Photo_2024-07-31-18-09-53 002">

안드로이드 카카오 인앱 브라우저에서 기도제목 수정에서 화면 렌더링이 원활하지 않던 부분을 수정했습니다.


https://www.notion.so/mmyeong/fix-2356e07cb2c5433c9c1c0225a3504fd2?pvs=4