### PR TITLE
build: analytics-amplitude setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "prayu-web",
       "version": "0.0.0",
       "dependencies": {
+        "@analytics/amplitude": "^0.1.3",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
@@ -17,6 +18,7 @@
         "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/supabase-js": "^2.44.4",
         "@toss/date": "^1.2.0",
+        "analytics": "^0.8.14",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "embla-carousel-react": "^8.1.6",
@@ -73,6 +75,76 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@analytics/amplitude": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@analytics/amplitude/-/amplitude-0.1.3.tgz",
+      "integrity": "sha512-o+mgne1zPNeXkvV7UqlGa7NPrgobIVIIcT+yPBtIXcp3x70uOp/ehxhdxX/NLDTYRw0HscyLBnDa2SZ4+/tezw=="
+    },
+    "node_modules/@analytics/cookie-utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@analytics/cookie-utils/-/cookie-utils-0.2.12.tgz",
+      "integrity": "sha512-2h/yuIu3kmu+ZJlKmlT6GoRvUEY2k1BbQBezEv5kGhnn9KpmzPz715Y3GmM2i+m7Y0QmBdVUoA260dQZkofs2A==",
+      "dependencies": {
+        "@analytics/global-storage-utils": "^0.1.7"
+      }
+    },
+    "node_modules/@analytics/core": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@analytics/core/-/core-0.12.15.tgz",
+      "integrity": "sha512-Y+zxTNIbONXKxeEUOtcXs4b3uuiGjF5sy1zHl8ZNkIBwrOpTM8ZGNhi0xGL8ZhaQLGbi03BrT6DaoNNG3sBQOg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/davidwells"
+        }
+      ],
+      "dependencies": {
+        "@analytics/global-storage-utils": "^0.1.7",
+        "@analytics/type-utils": "^0.6.2",
+        "analytics-utils": "^1.0.12"
+      }
+    },
+    "node_modules/@analytics/global-storage-utils": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@analytics/global-storage-utils/-/global-storage-utils-0.1.7.tgz",
+      "integrity": "sha512-V+spzGLZYm4biZT4uefaylm80SrLXf8WOTv9hCgA46cLcyxx3LD4GCpssp1lj+RcWLl/uXJQBRO4Mnn/o1x6Gw==",
+      "dependencies": {
+        "@analytics/type-utils": "^0.6.2"
+      }
+    },
+    "node_modules/@analytics/localstorage-utils": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@analytics/localstorage-utils/-/localstorage-utils-0.1.10.tgz",
+      "integrity": "sha512-uJS+Jp1yLG5VFCgA5T82ZODYBS0xuDQx0NtAZrgbqt9j51BX3TcgmOez5LVkrUNu/lpbxjCLq35I4TKj78VmOQ==",
+      "dependencies": {
+        "@analytics/global-storage-utils": "^0.1.7"
+      }
+    },
+    "node_modules/@analytics/session-storage-utils": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@analytics/session-storage-utils/-/session-storage-utils-0.0.7.tgz",
+      "integrity": "sha512-PSv40UxG96HVcjY15e3zOqU2n8IqXnH8XvTkg1X43uXNTKVSebiI2kUjA3Q7ESFbw5DPwcLbJhV7GforpuBLDw==",
+      "dependencies": {
+        "@analytics/global-storage-utils": "^0.1.7"
+      }
+    },
+    "node_modules/@analytics/storage-utils": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@analytics/storage-utils/-/storage-utils-0.4.2.tgz",
+      "integrity": "sha512-AXObwyVQw9h2uJh1t2hUgabtVxzYpW+7uKVbdHQK80vr3Td5rrmCxrCxarh7HUuAgSDZ0bZWqmYxVgmwKceaLg==",
+      "dependencies": {
+        "@analytics/cookie-utils": "^0.2.12",
+        "@analytics/global-storage-utils": "^0.1.7",
+        "@analytics/localstorage-utils": "^0.1.10",
+        "@analytics/session-storage-utils": "^0.0.7",
+        "@analytics/type-utils": "^0.6.2"
+      }
+    },
+    "node_modules/@analytics/type-utils": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@analytics/type-utils/-/type-utils-0.6.2.tgz",
+      "integrity": "sha512-TD+xbmsBLyYy/IxFimW/YL/9L2IEnM7/EoV9Aeh56U64Ify8o27HJcKjo38XY9Tcn0uOq1AX3thkKgvtWvwFQg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -2178,6 +2250,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/dlv": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/dlv/-/dlv-1.1.4.tgz",
+      "integrity": "sha512-m8KmImw4Jt+4rIgupwfivrWEOnj1LzkmKkqbh075uG13eTQ1ZxHWT6T0vIdSQhLIjQCiR0n0lZdtyDOPO1x2Mw==",
+      "peer": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -2492,6 +2570,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/analytics": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/analytics/-/analytics-0.8.14.tgz",
+      "integrity": "sha512-ZKpqWHEHBrN0lvIsrUKmt0fcXNyQuKa0JUWDRAz7LgJ+Sf4ZX+a66/ai28W4H8kJJlLeItCrhIi/xvdbV08RlA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/davidwells"
+        }
+      ],
+      "dependencies": {
+        "@analytics/core": "^0.12.15",
+        "@analytics/storage-utils": "^0.4.2"
+      }
+    },
+    "node_modules/analytics-utils": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/analytics-utils/-/analytics-utils-1.0.12.tgz",
+      "integrity": "sha512-WvV2YWgsnXLxaY0QYux0crpBAg/0JA763NmbMVz22jKhMPo7dpTBet8G2IlF7ixTjLDzGlkHk1ZaKqqQmjJ+4w==",
+      "dependencies": {
+        "@analytics/type-utils": "^0.6.2",
+        "dlv": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/dlv": "^1.0.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "supabase-sync": "supabase gen types --lang=typescript --linked > supabase/types/database.ts"
   },
   "dependencies": {
+    "@analytics/amplitude": "^0.1.3",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
@@ -20,6 +21,7 @@
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/supabase-js": "^2.44.4",
     "@toss/date": "^1.2.0",
+    "analytics": "^0.8.14",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.1.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,17 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useLocation,
+  useParams,
+} from "react-router-dom";
+import { useEffect } from "react";
 import { AuthProvider } from "./components/auth/AuthProvider";
 import PrivateRoute from "./components/auth/PrivateRoute";
 import MainPage from "./pages/MainPage";
 import GroupPage from "./pages/GroupPage";
 import GroupCreatePage from "./pages/GroupCreatePage";
+import { analytics } from "@/analytics/analytics";
 
 const App = () => {
   return (
@@ -11,8 +19,9 @@ const App = () => {
       <div className="mx-auto max-w-[480px] p-5 overflow-hidden">
         <BrowserRouter>
           <AuthProvider>
+            <AnalyticsTracker />
             <Routes>
-              <Route path="/" element={<MainPage />}></Route>
+              <Route path="/" element={<MainPage />} />
               <Route
                 path="/group"
                 element={
@@ -20,7 +29,7 @@ const App = () => {
                     <GroupPage />
                   </PrivateRoute>
                 }
-              ></Route>
+              />
               <Route
                 path="/group/new"
                 element={
@@ -28,7 +37,7 @@ const App = () => {
                     <GroupCreatePage />
                   </PrivateRoute>
                 }
-              ></Route>
+              />
               <Route
                 path="/group/:groupId"
                 element={
@@ -36,14 +45,40 @@ const App = () => {
                     <GroupPage />
                   </PrivateRoute>
                 }
-              ></Route>
-              {/* <Route path="*" element={<NotFound />}></Route> */}
+              />
+              {/* <Route path="*" element={<NotFound />} /> */}
             </Routes>
           </AuthProvider>
         </BrowserRouter>
       </div>
     </div>
   );
+};
+
+const AnalyticsTracker = () => {
+  const location = useLocation();
+  const { groupId } = useParams();
+
+  useEffect(() => {
+    switch (location.pathname) {
+      case "/":
+        analytics.track("페이지_메인", { title: "Main Page" });
+        break;
+      case "/group/new":
+        analytics.track("페이지_그룹_생성", { title: "Group Create Page" });
+        break;
+      default:
+        if (location.pathname.startsWith("/group/")) {
+          analytics.track("페이지_그룹_홈", {
+            title: "Group Page",
+            groupId: groupId,
+          });
+        }
+        break;
+    }
+  }, [location, groupId]);
+
+  return null;
 };
 
 export default App;

--- a/src/analytics/amplitude.d.ts
+++ b/src/analytics/amplitude.d.ts
@@ -1,0 +1,10 @@
+declare module "@analytics/amplitude" {
+  import { AnalyticsPlugin } from "analytics";
+
+  function amplitudePlugin(options: {
+    apiKey: string;
+    options?: object;
+  }): AnalyticsPlugin;
+
+  export default amplitudePlugin;
+}

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -16,7 +16,6 @@ export const analytics = Analytics({
 });
 
 export function analyticsTrack(eventName: string, eventProperties: object) {
-  // TODO: 얘가 dev가 아닐 때로 바꿔줘야 함!
   if (
     import.meta.env.VITE_ENV == "staging" ||
     import.meta.env.VITE_ENV == "prod"

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -1,0 +1,26 @@
+import Analytics from "analytics";
+import amplitudePlugin from "@analytics/amplitude";
+
+export const analytics = Analytics({
+  app: "awesome-app",
+  plugins: [
+    amplitudePlugin({
+      apiKey: "3045d3fe56e7bc3e11793d51ce1da755",
+      options: {
+        trackingOptions: {
+          ip_address: false,
+        },
+      },
+    }),
+  ],
+});
+
+export function analyticsTrack(eventName: string, eventProperties: object) {
+  // TODO: 얘가 dev가 아닐 때로 바꿔줘야 함!
+  if (
+    import.meta.env.VITE_ENV == "staging" ||
+    import.meta.env.VITE_ENV == "prod"
+  ) {
+    analytics.track(eventName, eventProperties);
+  }
+}

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -1,11 +1,13 @@
 import Analytics from "analytics";
 import amplitudePlugin from "@analytics/amplitude";
 
+const apiKey = import.meta.env.VITE_AMPLITUDE_API_KEY;
+
 export const analytics = Analytics({
   app: "awesome-app",
   plugins: [
     amplitudePlugin({
-      apiKey: "3045d3fe56e7bc3e11793d51ce1da755",
+      apiKey: apiKey,
       options: {
         trackingOptions: {
           ip_address: false,

--- a/src/components/GroupMenuBtn.tsx
+++ b/src/components/GroupMenuBtn.tsx
@@ -17,13 +17,11 @@ import { analyticsTrack } from "@/analytics/analytics";
 interface GroupManuBtnProps {
   userGroupList: Group[];
   targetGroup: Group | null;
-  onClick: () => void;
 }
 
 const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
   userGroupList,
   targetGroup,
-  onClick,
 }) => {
   const navigate = useNavigate();
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
@@ -49,11 +47,18 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
     analyticsTrack("클릭_문의", {});
   };
 
+  const onClickSheetTrigeer = () => {
+    analyticsTrack("클릭_그룹_메뉴", {
+      group_id: targetGroup?.id,
+      group_name: targetGroup?.name,
+    });
+  };
+
   return (
     <Sheet>
       <SheetTrigger
         className="flex flex-col items-end focus:outline-none"
-        onClick={() => onClick()}
+        onClick={() => onClickSheetTrigeer()}
       >
         <img src={menuIcon} className="w-8 h-8" />
       </SheetTrigger>

--- a/src/components/GroupMenuBtn.tsx
+++ b/src/components/GroupMenuBtn.tsx
@@ -12,15 +12,18 @@ import menuIcon from "@/assets/menuIcon.svg";
 import { Group } from "supabase/types/tables";
 import { useNavigate } from "react-router-dom";
 import useBaseStore from "@/stores/baseStore";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface GroupManuBtnProps {
   userGroupList: Group[];
   targetGroup: Group | null;
+  onClick: () => void;
 }
 
 const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
   userGroupList,
   targetGroup,
+  onClick,
 }) => {
   const navigate = useNavigate();
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
@@ -30,6 +33,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
   const handleClick = () => {
     if (userGroupList.length < maxGroupCount) {
       navigate("/group/new");
+      analyticsTrack("클릭_그룹_추가", { group_length: userGroupList.length });
     } else {
       toast({
         description: `최대 ${maxGroupCount}개의 그룹만 참여할 수 있어요`,
@@ -37,9 +41,20 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
     }
   };
 
+  const onClickOtherGroup = (groupId: string) => {
+    analyticsTrack("클릭_그룹_전환", { group_id: groupId });
+  };
+
+  const onClickContactUs = () => {
+    analyticsTrack("클릭_문의", {});
+  };
+
   return (
     <Sheet>
-      <SheetTrigger className="flex flex-col items-end focus:outline-none">
+      <SheetTrigger
+        className="flex flex-col items-end focus:outline-none"
+        onClick={() => onClick()}
+      >
         <img src={menuIcon} className="w-8 h-8" />
       </SheetTrigger>
       <SheetContent className="max-w-[288px] mx-auto w-[60%] px-5 py-16 flex flex-col items-end">
@@ -54,6 +69,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
                 <a
                   key={group.id}
                   href={`/group/${group.id}`}
+                  onClick={() => onClickOtherGroup(group.id)}
                   className={`${
                     group.id === targetGroup?.id
                       ? "text-black font-bold underline"
@@ -69,7 +85,10 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
           </a>
           <hr />
           <a href="/">홈 화면</a>
-          <a href={`${import.meta.env.VITE_PRAY_KAKAO_CHANNEL_CHAT_URL}`}>
+          <a
+            href={`${import.meta.env.VITE_PRAY_KAKAO_CHANNEL_CHAT_URL}`}
+            onClick={() => onClickContactUs()}
+          >
             문의하기
           </a>
           <a className="cursor-pointer" onClick={() => signOut()}>

--- a/src/components/KakaoShareBtn.tsx
+++ b/src/components/KakaoShareBtn.tsx
@@ -104,11 +104,7 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
     );
   }
   return (
-    <button
-      id={id}
-      onClick={() => console.log("hi")}
-      className="bg-mainBg p-2 rounded-md"
-    >
+    <button id={id} className="bg-mainBg p-2 rounded-md">
       <img src={img ?? kakaoDefaultImage} className="w-5 h-5" />
     </button>
   );

--- a/src/components/KakaoShareBtn.tsx
+++ b/src/components/KakaoShareBtn.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { analyticsTrack } from "@/analytics/analytics";
+import { useEffect, useRef } from "react";
 
 declare global {
   interface Window {
@@ -36,11 +37,16 @@ interface KakaoLinkObject {
   }>;
 }
 
+interface EventOption {
+  where: string;
+}
+
 interface KakaoShareButtonProps {
   groupPageUrl: string;
   message?: string;
   id: string;
   img?: string;
+  eventOption: EventOption;
 }
 
 export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
@@ -48,6 +54,7 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
   message,
   id,
   img,
+  eventOption,
 }) => {
   useEffect(() => {
     const script = document.createElement("script");
@@ -93,19 +100,45 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
     };
   }, [groupPageUrl, id]);
 
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
   const kakaoDefaultImage =
     "https://developers.kakao.com/assets/img/about/logos/kakaotalksharing/kakaotalk_sharing_btn_medium.png";
 
   if (message) {
     return (
-      <button id={id} className="bg-yellow-300 px-10 py-2 rounded-md text-sm">
-        <p className="text-black">{message}</p>
-      </button>
+      <div className="relative">
+        <div
+          className="absolute w-full h-full "
+          onClick={() => {
+            analyticsTrack("클릭_카카오_공유", {
+              where: eventOption.where,
+            });
+            buttonRef.current?.click();
+          }}
+        ></div>
+        <button
+          ref={buttonRef}
+          id={id}
+          className="bg-yellow-300 px-10 py-2 rounded-md text-sm"
+        >
+          <p className="text-black">{message}</p>
+        </button>
+      </div>
     );
   }
   return (
-    <button id={id} className="bg-mainBg p-2 rounded-md">
-      <img src={img ?? kakaoDefaultImage} className="w-5 h-5" />
-    </button>
+    <div className="relative">
+      <div
+        className="absolute w-full h-full "
+        onClick={() => {
+          analyticsTrack("클릭_카카오_공유", { where: eventOption.where });
+          buttonRef.current?.click();
+        }}
+      ></div>
+      <button ref={buttonRef} id={id} className="bg-mainBg p-2 rounded-md">
+        <img src={img ?? kakaoDefaultImage} className="w-5 h-5" />
+      </button>
+    </div>
   );
 };

--- a/src/components/KakaoShareBtn.tsx
+++ b/src/components/KakaoShareBtn.tsx
@@ -104,7 +104,11 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
     );
   }
   return (
-    <button id={id} className="bg-mainBg p-2 rounded-md">
+    <button
+      id={id}
+      onClick={() => console.log("hi")}
+      className="bg-mainBg p-2 rounded-md"
+    >
       <img src={img ?? kakaoDefaultImage} className="w-5 h-5" />
     </button>
   );

--- a/src/components/member/MemberInviteCard.tsx
+++ b/src/components/member/MemberInviteCard.tsx
@@ -20,6 +20,7 @@ export const MemberInviteCard = () => {
           groupPageUrl={window.location.href}
           id="paryTodayIntro"
           message="카카오톡으로 초대하기"
+          eventOption={{ where: "MemberInviteCard" }}
         ></KakaoShareButton>
       </div>
     </div>

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import MyPrayCardUI from "../prayCard/MyPrayCardUI";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface MemberProps {
   currentUserId: string;
@@ -87,9 +88,19 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
     </div>
   );
 
+  const onClickMyMember = () => {
+    analyticsTrack("클릭_멤버_본인", {
+      group_id: groupId,
+      where: "MyMember",
+    });
+  };
+
   return (
     <Drawer open={isOpenMyMemberDrawer} onOpenChange={setIsOpenMyMemberDrawer}>
-      <DrawerTrigger className="focus:outline-none">
+      <DrawerTrigger
+        className="focus:outline-none"
+        onClick={() => onClickMyMember()}
+      >
         <div className="flex flex-col items-start gap-2">{MyMemberUI}</div>
       </DrawerTrigger>
 

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/drawer";
 import PrayCardUI from "../prayCard/PrayCardUI";
 import { getDateDistance } from "@toss/date";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface OtherMemberProps {
   currentUserId: string;
@@ -31,6 +32,10 @@ const OtherMember: React.FC<OtherMemberProps> = ({
     new Date(getISOOnlyDate(member?.updated_at ?? null)),
     new Date(getISOTodayDate())
   );
+
+  const onClickOtherMember = () => {
+    analyticsTrack("클릭_멤버_구성원", { member: member.user_id });
+  };
 
   const memberUI = (
     <div className="flex flex-col gap-2 cursor-pointer bg-white p-4 rounded-2xl shadow-md">
@@ -52,7 +57,12 @@ const OtherMember: React.FC<OtherMemberProps> = ({
 
   return (
     <Drawer>
-      <DrawerTrigger className="focus:outline-none">{memberUI}</DrawerTrigger>
+      <DrawerTrigger
+        className="focus:outline-none"
+        onClick={() => onClickOtherMember()}
+      >
+        {memberUI}
+      </DrawerTrigger>
       <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] px-10 pb-20 focus:outline-none">
         <DrawerHeader>
           <DrawerTitle></DrawerTitle>
@@ -63,6 +73,7 @@ const OtherMember: React.FC<OtherMemberProps> = ({
           currentUserId={currentUserId}
           member={member}
           prayCard={prayCard}
+          where="OtherMember"
         />
         {/* PrayCard */}
       </DrawerContent>

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -73,7 +73,7 @@ const OtherMember: React.FC<OtherMemberProps> = ({
           currentUserId={currentUserId}
           member={member}
           prayCard={prayCard}
-          where="OtherMember"
+          eventOption={{ where: "OtherMember" }}
         />
         {/* PrayCard */}
       </DrawerContent>

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -77,7 +77,7 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
         ))}
       </div>
       <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
-        <TodayPrayBtn where="OtherMemberList" />
+        <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />
       </div>
     </div>
   );

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -77,7 +77,7 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
         ))}
       </div>
       <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
-        <TodayPrayBtn />
+        <TodayPrayBtn where="OtherMemberList" />
       </div>
     </div>
   );

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -37,6 +37,7 @@ const PrayList: React.FC = () => {
               groupPageUrl={window.location.href}
               message="카카오톡 링크 공유"
               id="prayList"
+              eventOption={{ where: "PrayList" }}
             />
           </div>
         ) : (

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -11,6 +11,7 @@ import { getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
 import { Textarea } from "../ui/textarea";
 import { FaEdit, FaSave } from "react-icons/fa";
 import iconUserMono from "@/assets/icon-user-mono.svg";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface PrayCardProps {
   prayCard: PrayCardWithProfiles;
@@ -53,6 +54,15 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     new Date(getISOTodayDate())
   );
 
+  const onClickPrayerList = () => {
+    analyticsTrack("클릭_기도카드_반응리스트", {});
+  };
+
+  const handleEditClick = () => {
+    setIsEditingPrayCard(true);
+    analyticsTrack("클릭_기도카드_수정", {});
+  };
+
   const handleSaveClick = (
     prayCardId: string,
     content: string,
@@ -62,6 +72,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     updateMember(memberId, content);
     setDisplayedContent(content);
     setIsEditingPrayCard(false);
+    analyticsTrack("클릭_기도카드_저장", {});
   };
 
   useEffect(() => {
@@ -125,7 +136,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
         ) : (
           <button
             className="text-white rounded-full bg-end/90 w-10 h-10 flex justify-center items-center"
-            onClick={() => setIsEditingPrayCard(true)}
+            onClick={() => handleEditClick()}
           >
             <FaEdit className="text-white w-5 h-5" />
           </button>
@@ -139,7 +150,10 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
       {MyPrayCardBody}
       <div className="flex flex-col gap-5">
         <Drawer>
-          <DrawerTrigger className="w-full focus:outline-none">
+          <DrawerTrigger
+            className="w-full focus:outline-none"
+            onClick={() => onClickPrayerList()}
+          >
             <div className="flex justify-center gap-2">
               {Object.values(PrayType).map((type) => {
                 if (!reactionCounts) return null;

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -55,7 +55,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   );
 
   const onClickPrayerList = () => {
-    analyticsTrack("클릭_기도카드_반응리스트", {});
+    analyticsTrack("클릭_기도카드_반응결과", {});
   };
 
   const handleEditClick = () => {

--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -3,6 +3,7 @@ import { Button } from "../ui/button";
 import useBaseStore from "@/stores/baseStore";
 import { MemberWithProfiles } from "supabase/types/tables";
 import { useEffect } from "react";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface PrayCardCreateModalProps {
   currentUserId: string | undefined;
@@ -34,6 +35,7 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
     groupId: string | undefined
   ) => {
     setIsDisabledPrayCardCreateBtn(true);
+    analyticsTrack("클릭_기도카드_생성", { group_id: groupId });
     if (!member) {
       const newMember = await createMember(groupId, currentUserId);
       await updateMember(newMember?.id, inputPrayCardContent);

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -11,6 +11,7 @@ import { getISOTodayDate } from "@/lib/utils";
 import { KakaoShareButton } from "../KakaoShareBtn";
 import MyMemberBtn from "../todayPray/MyMemberBtn";
 import { PrayTypeDatas } from "@/Enums/prayType";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface PrayCardListProps {
   currentUserId: string;
@@ -58,8 +59,17 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
     prayCardCarouselApi?.on("select", () => {
       const currentIndex = prayCardCarouselApi.selectedScrollSnap();
       const carouselLength = prayCardCarouselApi.scrollSnapList().length;
+
       if (currentIndex === 0) prayCardCarouselApi.scrollNext();
-      if (currentIndex === carouselLength - 1) prayCardCarouselApi.scrollPrev();
+      if (currentIndex === carouselLength - 2) {
+        analyticsTrack("클릭_오늘의기도_완료", {
+          group_id: groupId,
+          index: currentIndex,
+        });
+      }
+      if (currentIndex === carouselLength - 1) {
+        prayCardCarouselApi.scrollPrev();
+      }
     });
   }, [
     prayCardCarouselApi,
@@ -120,7 +130,11 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
         <CarouselItem className="basis-5/6"></CarouselItem>
         {filterdGroupPrayCardList.map((prayCard) => (
           <CarouselItem key={prayCard.id} className="basis-5/6 h-screen">
-            <PrayCardUI currentUserId={currentUserId} prayCard={prayCard} />
+            <PrayCardUI
+              currentUserId={currentUserId}
+              prayCard={prayCard}
+              where="PrayCardList"
+            />
           </CarouselItem>
         ))}
         <CarouselItem className="basis-5/6">{completedItem}</CarouselItem>

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -101,6 +101,7 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
           groupPageUrl={window.location.href}
           id="paryTodayIntro"
           message="카카오톡으로 초대하기"
+          eventOption={{ where: "PrayCardList" }}
         ></KakaoShareButton>
       </div>
     );

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -126,7 +126,7 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
             <PrayCardUI
               currentUserId={currentUserId}
               prayCard={prayCard}
-              where="PrayCardList"
+              eventOption={{ where: "PrayCardList" }}
             />
           </CarouselItem>
         ))}

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -11,7 +11,6 @@ import { getISOTodayDate } from "@/lib/utils";
 import { KakaoShareButton } from "../KakaoShareBtn";
 import MyMemberBtn from "../todayPray/MyMemberBtn";
 import { PrayTypeDatas } from "@/Enums/prayType";
-import { analyticsTrack } from "@/analytics/analytics";
 
 interface PrayCardListProps {
   currentUserId: string;
@@ -61,12 +60,6 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
       const carouselLength = prayCardCarouselApi.scrollSnapList().length;
 
       if (currentIndex === 0) prayCardCarouselApi.scrollNext();
-      if (currentIndex === carouselLength - 2) {
-        analyticsTrack("클릭_오늘의기도_완료", {
-          group_id: groupId,
-          index: currentIndex,
-        });
-      }
       if (currentIndex === carouselLength - 1) {
         prayCardCarouselApi.scrollPrev();
       }

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -5,18 +5,22 @@ import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
 import ReactionWithCalendar from "./ReactionWithCalendar";
 
+interface EventOption {
+  where: string;
+}
+
 interface PrayCardProps {
   currentUserId: string;
   prayCard: PrayCardWithProfiles | null;
   member?: MemberWithProfiles | null;
-  where: string;
+  eventOption: EventOption;
 }
 
 const PrayCardUI: React.FC<PrayCardProps> = ({
   currentUserId,
   member,
   prayCard,
-  where,
+  eventOption,
 }) => {
   const { prayDataHash, fetchPrayDataByUserId } = useBaseStore((state) => ({
     prayDataHash: state.prayDataHash,
@@ -71,7 +75,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
           </p>
         </div>
       </div>
-      <ReactionWithCalendar prayCard={prayCard} where={where} />
+      <ReactionWithCalendar prayCard={prayCard} eventOption={eventOption} />
     </div>
   );
 };

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -9,12 +9,14 @@ interface PrayCardProps {
   currentUserId: string;
   prayCard: PrayCardWithProfiles | null;
   member?: MemberWithProfiles | null;
+  where: string;
 }
 
 const PrayCardUI: React.FC<PrayCardProps> = ({
   currentUserId,
   member,
   prayCard,
+  where,
 }) => {
   const { prayDataHash, fetchPrayDataByUserId } = useBaseStore((state) => ({
     prayDataHash: state.prayDataHash,
@@ -69,7 +71,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
           </p>
         </div>
       </div>
-      <ReactionWithCalendar prayCard={prayCard} />
+      <ReactionWithCalendar prayCard={prayCard} where={where} />
     </div>
   );
 };

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -2,15 +2,18 @@ import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import useBaseStore from "@/stores/baseStore";
 import { sleep } from "@/lib/utils";
+import { analyticsTrack } from "@/analytics/analytics";
 
 interface ReactionBtnProps {
   currentUserId: string;
   prayCard: PrayCardWithProfiles | null;
+  where: string;
 }
 
 const ReactionBtn: React.FC<ReactionBtnProps> = ({
   currentUserId,
   prayCard,
+  where,
 }) => {
   const todayPrayTypeHash = useBaseStore((state) => state.todayPrayTypeHash);
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
@@ -29,6 +32,7 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   const handleClick = (prayType: PrayType) => () => {
     createPray(prayCard?.id, currentUserId, prayType);
     if (!isPrayToday) setIsPrayToday(true);
+    analyticsTrack("클릭_기도카드_반응", { pray_type: prayType, where: where });
     if (prayCardCarouselApi) {
       sleep(500).then(() => {
         if (

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -4,16 +4,20 @@ import useBaseStore from "@/stores/baseStore";
 import { sleep } from "@/lib/utils";
 import { analyticsTrack } from "@/analytics/analytics";
 
+interface EventOption {
+  where: string;
+}
+
 interface ReactionBtnProps {
   currentUserId: string;
   prayCard: PrayCardWithProfiles | null;
-  where: string;
+  eventOption: EventOption;
 }
 
 const ReactionBtn: React.FC<ReactionBtnProps> = ({
   currentUserId,
   prayCard,
-  where,
+  eventOption,
 }) => {
   const todayPrayTypeHash = useBaseStore((state) => state.todayPrayTypeHash);
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
@@ -32,7 +36,10 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   const handleClick = (prayType: PrayType) => () => {
     createPray(prayCard?.id, currentUserId, prayType);
     if (!isPrayToday) setIsPrayToday(true);
-    analyticsTrack("클릭_기도카드_반응", { pray_type: prayType, where: where });
+    analyticsTrack("클릭_기도카드_반응", {
+      pray_type: prayType,
+      where: eventOption.where,
+    });
     if (prayCardCarouselApi) {
       sleep(500).then(() => {
         if (

--- a/src/components/prayCard/ReactionWithCalendar.tsx
+++ b/src/components/prayCard/ReactionWithCalendar.tsx
@@ -4,12 +4,19 @@ import { PrayCardWithProfiles } from "supabase/types/tables";
 import ReactionBtn from "./ReactionBtn";
 import { KakaoShareButton } from "../KakaoShareBtn";
 
-interface PrayCardProps {
-  prayCard: PrayCardWithProfiles | null;
+interface EventOption {
   where: string;
 }
 
-const ReactionWithCalendar: React.FC<PrayCardProps> = ({ prayCard, where }) => {
+interface PrayCardProps {
+  prayCard: PrayCardWithProfiles | null;
+  eventOption: EventOption;
+}
+
+const ReactionWithCalendar: React.FC<PrayCardProps> = ({
+  prayCard,
+  eventOption,
+}) => {
   const prayDataHash = useBaseStore((state) => state.prayDataHash);
   const currentUserId = useBaseStore((state) => state.user?.id);
 
@@ -35,7 +42,7 @@ const ReactionWithCalendar: React.FC<PrayCardProps> = ({ prayCard, where }) => {
       <ReactionBtn
         currentUserId={currentUserId!}
         prayCard={prayCard}
-        where={where}
+        eventOption={eventOption}
       />
     </div>
   );

--- a/src/components/prayCard/ReactionWithCalendar.tsx
+++ b/src/components/prayCard/ReactionWithCalendar.tsx
@@ -28,6 +28,7 @@ const ReactionWithCalendar: React.FC<PrayCardProps> = ({
           groupPageUrl={window.location.href}
           message="기도제목 요청하기"
           id="prayCardUIToOther"
+          eventOption={{ where: "ReactionWithCalendar" }}
         ></KakaoShareButton>
       </div>
     );

--- a/src/components/prayCard/ReactionWithCalendar.tsx
+++ b/src/components/prayCard/ReactionWithCalendar.tsx
@@ -6,9 +6,10 @@ import { KakaoShareButton } from "../KakaoShareBtn";
 
 interface PrayCardProps {
   prayCard: PrayCardWithProfiles | null;
+  where: string;
 }
 
-const ReactionWithCalendar: React.FC<PrayCardProps> = ({ prayCard }) => {
+const ReactionWithCalendar: React.FC<PrayCardProps> = ({ prayCard, where }) => {
   const prayDataHash = useBaseStore((state) => state.prayDataHash);
   const currentUserId = useBaseStore((state) => state.user?.id);
 
@@ -31,7 +32,11 @@ const ReactionWithCalendar: React.FC<PrayCardProps> = ({ prayCard }) => {
         prayCard={prayCard}
         prayData={prayDataHash[prayCard?.id || ""] || []}
       />
-      <ReactionBtn currentUserId={currentUserId!} prayCard={prayCard} />
+      <ReactionBtn
+        currentUserId={currentUserId!}
+        prayCard={prayCard}
+        where={where}
+      />
     </div>
   );
 };

--- a/src/components/todayPray/MyMemberBtn.tsx
+++ b/src/components/todayPray/MyMemberBtn.tsx
@@ -1,5 +1,6 @@
 import useBaseStore from "@/stores/baseStore";
 import { Button } from "../ui/button";
+import { analyticsTrack } from "@/analytics/analytics";
 
 const MyMemberBtn: React.FC = () => {
   const setIsOpenMyMemberDrawer = useBaseStore(
@@ -9,13 +10,18 @@ const MyMemberBtn: React.FC = () => {
     (state) => state.setIsOpenTodayPrayDrawer
   );
 
+  const onClickMyMemberBtn = () => {
+    setIsOpenTodayPrayDrawer(false);
+    setIsOpenMyMemberDrawer(true);
+    analyticsTrack("클릭_멤버_본인", { where: "PrayCardList" });
+  };
+
   return (
     <Button
       variant="primary"
       className="w-32"
       onClick={() => {
-        setIsOpenTodayPrayDrawer(false);
-        setIsOpenMyMemberDrawer(true);
+        onClickMyMemberBtn();
       }}
     >
       내 기도 확인하기

--- a/src/components/todayPray/MyMemberBtn.tsx
+++ b/src/components/todayPray/MyMemberBtn.tsx
@@ -14,6 +14,7 @@ const MyMemberBtn: React.FC = () => {
     setIsOpenTodayPrayDrawer(false);
     setIsOpenMyMemberDrawer(true);
     analyticsTrack("클릭_멤버_본인", { where: "PrayCardList" });
+    analyticsTrack("클릭_오늘의기도_완료", {});
   };
 
   return (

--- a/src/components/todayPray/TodayPrayBtn.tsx
+++ b/src/components/todayPray/TodayPrayBtn.tsx
@@ -1,16 +1,25 @@
 import useBaseStore from "@/stores/baseStore";
 import { Button } from "../ui/button";
+import { analyticsTrack } from "@/analytics/analytics";
 
-const TodayPrayBtn: React.FC = () => {
+interface TodayPrayBtnProps {
+  where: string;
+}
+
+const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ where }) => {
   const setIsOpenTodayPrayDrawer = useBaseStore(
     (state) => state.setIsOpenTodayPrayDrawer
   );
+  const onClickTodayPrayBtn = () => {
+    setIsOpenTodayPrayDrawer(true);
+    analyticsTrack("클릭_오늘의기도_시작", { where: where });
+  };
 
   return (
     <Button
       variant="primary"
       className="w-32"
-      onClick={() => setIsOpenTodayPrayDrawer(true)}
+      onClick={() => onClickTodayPrayBtn()}
     >
       기도 시작하기
     </Button>

--- a/src/components/todayPray/TodayPrayBtn.tsx
+++ b/src/components/todayPray/TodayPrayBtn.tsx
@@ -2,17 +2,20 @@ import useBaseStore from "@/stores/baseStore";
 import { Button } from "../ui/button";
 import { analyticsTrack } from "@/analytics/analytics";
 
-interface TodayPrayBtnProps {
+interface EventOption {
   where: string;
 }
+interface TodayPrayBtnProps {
+  eventOption: EventOption;
+}
 
-const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ where }) => {
+const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ eventOption }) => {
   const setIsOpenTodayPrayDrawer = useBaseStore(
     (state) => state.setIsOpenTodayPrayDrawer
   );
   const onClickTodayPrayBtn = () => {
     setIsOpenTodayPrayDrawer(true);
-    analyticsTrack("클릭_오늘의기도_시작", { where: where });
+    analyticsTrack("클릭_오늘의기도_시작", { where: eventOption.where });
   };
 
   return (

--- a/src/components/todayPray/TodayPrayStartCard.tsx
+++ b/src/components/todayPray/TodayPrayStartCard.tsx
@@ -45,7 +45,7 @@ export const TodayPrayStartCard = () => {
             </div>
           </div>
         </div>
-        <TodayPrayBtn />
+        <TodayPrayBtn where="TodayPrayStartCard" />
       </div>
     </>
   );

--- a/src/components/todayPray/TodayPrayStartCard.tsx
+++ b/src/components/todayPray/TodayPrayStartCard.tsx
@@ -45,7 +45,7 @@ export const TodayPrayStartCard = () => {
             </div>
           </div>
         </div>
-        <TodayPrayBtn where="TodayPrayStartCard" />
+        <TodayPrayBtn eventOption={{ where: "TodayPrayStartCard" }} />
       </div>
     </>
   );

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "../components/ui/use-toast";
 import { ClipLoader } from "react-spinners";
+import { analyticsTrack } from "@/analytics/analytics";
 
 const GroupCreatePage: React.FC = () => {
   const { user } = useAuth();
@@ -38,6 +39,7 @@ const GroupCreatePage: React.FC = () => {
       return;
     }
     setIsDisabledGroupCreateBtn(true);
+    analyticsTrack("클릭_그룹_생성", { group_name: inputGroupName });
     const targetGroup = await createGroup(userId, inputGroupName, "intro");
     targetGroup && navigate("/group/" + targetGroup.id, { replace: true });
   };

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -66,6 +66,7 @@ const GroupPage: React.FC = () => {
           groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
           id="groupPage"
           img={inviteMemberIcon}
+          eventOption={{ where: "GroupPage" }}
         />
 
         <div className="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center gap-1">

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -3,12 +3,11 @@ import { useParams, useNavigate } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
 import useBaseStore from "@/stores/baseStore";
 import { KakaoShareButton } from "@/components/KakaoShareBtn";
-
 import GroupMenuBtn from "../components/GroupMenuBtn";
 import { getDomainUrl } from "@/lib/utils";
-
 import inviteMemberIcon from "@/assets/inviteMemberIcon.svg";
 import GroupBody from "@/components/group/GroupBody";
+import { analytics, analyticsTrack } from "@/analytics/analytics";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
@@ -61,21 +60,46 @@ const GroupPage: React.FC = () => {
 
   const domainUrl = getDomainUrl();
 
+  // TODO: 카톡 공유 클릭이 안돼서 알아봐야함!
+  const handleShareClick = () => {
+    // TODO: 얘를 함수화 시켜서 env가 dev일 때는 동작안하게 해야돼!
+    analytics.track("클릭_카카오_공유", {
+      groupId: targetGroup?.id,
+      groupName: targetGroup?.name,
+      where: "GroupPage",
+    });
+  };
+
+  const handleMenuButtonClick = () => {
+    analyticsTrack("클릭_그룹_메뉴", {
+      group_id: targetGroup?.id,
+      group_name: targetGroup?.name,
+    });
+  };
+
   return (
     <div className="flex flex-col gap-5">
       <div className="relative flex justify-between items-center">
-        <KakaoShareButton
-          groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
-          id="groupPage"
-          img={inviteMemberIcon}
-        ></KakaoShareButton>
+        <div onClick={() => handleShareClick()}>
+          <KakaoShareButton
+            groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
+            id="groupPage"
+            img={inviteMemberIcon}
+          />
+        </div>
+
         <div className="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center gap-1">
           <div className="text-lg font-bold flex items-center gap-1">
             {targetGroup?.name}
             <span className="text-sm text-gray-500">{memberList?.length}</span>
           </div>
         </div>
-        <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
+
+        <GroupMenuBtn
+          userGroupList={groupList}
+          targetGroup={targetGroup}
+          onClick={handleMenuButtonClick}
+        />
       </div>
 
       <GroupBody

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -7,7 +7,7 @@ import GroupMenuBtn from "../components/GroupMenuBtn";
 import { getDomainUrl } from "@/lib/utils";
 import inviteMemberIcon from "@/assets/inviteMemberIcon.svg";
 import GroupBody from "@/components/group/GroupBody";
-import { analytics, analyticsTrack } from "@/analytics/analytics";
+import { analyticsTrack } from "@/analytics/analytics";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
@@ -60,16 +60,6 @@ const GroupPage: React.FC = () => {
 
   const domainUrl = getDomainUrl();
 
-  // TODO: 카톡 공유 클릭이 안돼서 알아봐야함!
-  const handleShareClick = () => {
-    // TODO: 얘를 함수화 시켜서 env가 dev일 때는 동작안하게 해야돼!
-    analytics.track("클릭_카카오_공유", {
-      groupId: targetGroup?.id,
-      groupName: targetGroup?.name,
-      where: "GroupPage",
-    });
-  };
-
   const handleMenuButtonClick = () => {
     analyticsTrack("클릭_그룹_메뉴", {
       group_id: targetGroup?.id,
@@ -80,13 +70,11 @@ const GroupPage: React.FC = () => {
   return (
     <div className="flex flex-col gap-5">
       <div className="relative flex justify-between items-center">
-        <div onClick={() => handleShareClick()}>
-          <KakaoShareButton
-            groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
-            id="groupPage"
-            img={inviteMemberIcon}
-          />
-        </div>
+        <KakaoShareButton
+          groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
+          id="groupPage"
+          img={inviteMemberIcon}
+        />
 
         <div className="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center gap-1">
           <div className="text-lg font-bold flex items-center gap-1">

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -7,7 +7,6 @@ import GroupMenuBtn from "../components/GroupMenuBtn";
 import { getDomainUrl } from "@/lib/utils";
 import inviteMemberIcon from "@/assets/inviteMemberIcon.svg";
 import GroupBody from "@/components/group/GroupBody";
-import { analyticsTrack } from "@/analytics/analytics";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
@@ -60,13 +59,6 @@ const GroupPage: React.FC = () => {
 
   const domainUrl = getDomainUrl();
 
-  const handleMenuButtonClick = () => {
-    analyticsTrack("클릭_그룹_메뉴", {
-      group_id: targetGroup?.id,
-      group_name: targetGroup?.name,
-    });
-  };
-
   return (
     <div className="flex flex-col gap-5">
       <div className="relative flex justify-between items-center">
@@ -83,11 +75,7 @@ const GroupPage: React.FC = () => {
           </div>
         </div>
 
-        <GroupMenuBtn
-          userGroupList={groupList}
-          targetGroup={targetGroup}
-          onClick={handleMenuButtonClick}
-        />
+        <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
       </div>
 
       <GroupBody

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -35,11 +35,8 @@ import {
 import { PrayType } from "@/Enums/prayType";
 import { getISOToday } from "@/lib/utils";
 import { type CarouselApi } from "@/components/ui/carousel";
-<<<<<<< HEAD
 import * as Sentry from "@sentry/react";
-=======
 import { analytics } from "@/analytics/analytics";
->>>>>>> 4e2c569 (build: analytics-amplitude setting)
 
 export interface BaseStore {
   // user

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -35,7 +35,11 @@ import {
 import { PrayType } from "@/Enums/prayType";
 import { getISOToday } from "@/lib/utils";
 import { type CarouselApi } from "@/components/ui/carousel";
+<<<<<<< HEAD
 import * as Sentry from "@sentry/react";
+=======
+import { analytics } from "@/analytics/analytics";
+>>>>>>> 4e2c569 (build: analytics-amplitude setting)
 
 export interface BaseStore {
   // user
@@ -152,6 +156,13 @@ const useBaseStore = create<BaseStore>()(
       set((state) => {
         state.user = session?.user || null;
         state.userLoading = false;
+        if (state.user) {
+          analytics.identify(state.user?.id, {
+            email: state.user?.user_metadata?.email,
+            full_name: state.user?.user_metadata?.full_name,
+            user_name: state.user?.user_metadata?.user_name,
+          });
+        }
       });
 
       const {

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -170,6 +170,13 @@ const useBaseStore = create<BaseStore>()(
       } = supabase.auth.onAuthStateChange((_event, session) => {
         set((state) => {
           state.user = session?.user || null;
+          if (state.user) {
+            analytics.identify(state.user?.id, {
+              email: state.user?.user_metadata?.email,
+              full_name: state.user?.user_metadata?.full_name,
+              user_name: state.user?.user_metadata?.user_name,
+            });
+          }
         });
         // Sentry 설정
         if (

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,5 +27,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "supabase"]
+  "include": ["src", "supabase", "analytics", "analytics/amplitude.d.ts"]
 }


### PR DESCRIPTION
.env에 VITE_AMPLITUDE_API_KEY 추가했습니다!

# 페이지
- [x]  페이지_메인
- [x]  페이지_그룹_홈
- [x]  페이지_그룹_생성

# 클릭
### 그룹
- [x]  클릭_그룹_메뉴
- [x]  클릭_그룹_생성
- [x]  클릭_그룹_추가
- [x]  클릭_그룹_전환
### 기도카드
- [x]  클릭_기도카드_생성
- [x]  클릭_기도카드_수정
- [x]  클릭_기도카드_저장
- [x]  클릭_기도카드_반응
- [x]  클릭_기도카드_반응리스트
### 멤버
- [x]  클릭_멤버_본인
- [x]  클릭_멤버_구성원
### 오늘의기도
- [x]  클릭_오늘의기도_시작
- [x]  클릭_오늘의기도_완료 (사실상 클릭은 아니다.)
### 기타
- [x]  클릭_문의
- [x] 클릭_카카오_공유 

- 언더바(_) 검색 가능이 가능해서 사용하였습니다.
- 각 이벤트 별 들어가는  property는 노션에 정리하였습니다.
- property 이름은 카멜 대신에 _ 사용하였습니다.
- 카카오톡과 관련된 로그인, 로그아웃, 공유 버튼 이벤트는 아직 없습니다!

https://www.notion.so/mmyeong/build-amplitude-4db5ced08d274574a1fda2afcb1b969f?pvs=4

