### PR TITLE
fix: 그룹명 옆 멤버수 표시 && 기도내용 좌상단 배치

### DIFF
--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -65,9 +65,7 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   if (otherMembers.length === 0) return <MemberInviteCard />;
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-sm text-gray-950 p-2">
-        Members ({otherMembers.length})
-      </div>
+      <div className="text-sm text-gray-500 p-2">기도 구성원</div>
       <div className="flex flex-col gap-4">
         {otherMembers.map((member) => (
           <OtherMember

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -39,7 +39,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
 
   const [displayedContent, setDisplayedContent] =
     useState(inputPrayCardContent);
-  const [isOverflow, setIsOverflow] = useState(false);
+
   const contentRef = useRef<HTMLDivElement>(null);
 
   const prayDatas = prayCard.pray;
@@ -70,15 +70,6 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     }
   }, [prayDatas, setReactionDatasForMe]);
 
-  useEffect(() => {
-    const contentElement = contentRef.current;
-    if (contentElement) {
-      const isContentOverflowing =
-        contentElement.scrollHeight > contentElement.clientHeight;
-      setIsOverflow(isContentOverflowing);
-    }
-  }, [inputPrayCardContent, displayedContent]);
-
   if (!prayDataHash) {
     return (
       <div className="flex justify-center items-center h-screen">
@@ -105,9 +96,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
       </div>
       <div
         ref={contentRef}
-        className={`p-2 flex h-full overflow-y-auto no-scrollbar justify-center ${
-          isOverflow ? "items-start" : "items-center"
-        }`}
+        className="px-[21px] py-[25px] items-start h-full overflow-y-auto no-scrollbar"
       >
         {isEditingPrayCard ? (
           <Textarea

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -72,9 +72,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
         </div>
         <div
           ref={contentRef}
-          className={`p-2 flex ${
-            isOverflow ? "items-start" : "items-center"
-          } h-full overflow-y-auto no-scrollbar`}
+          className={"p-2 items-start h-full overflow-y-auto no-scrollbar"}
         >
           <p className="whitespace-pre-line">
             {prayCard?.content || member?.pray_summary}

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";
@@ -21,7 +21,6 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
     fetchPrayDataByUserId: state.fetchPrayDataByUserId,
   }));
 
-  const [isOverflow, setIsOverflow] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -29,15 +28,6 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
       fetchPrayDataByUserId(prayCard.id, currentUserId);
     }
   }, [currentUserId, fetchPrayDataByUserId, prayCard?.id]);
-
-  useEffect(() => {
-    const contentElement = contentRef.current;
-    if (contentElement) {
-      const isContentOverflowing =
-        contentElement.scrollHeight > contentElement.clientHeight;
-      setIsOverflow(isContentOverflowing);
-    }
-  }, [prayCard?.content, member?.pray_summary]);
 
   if (!prayDataHash) {
     return (

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -62,7 +62,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
         </div>
         <div
           ref={contentRef}
-          className={"p-2 items-start h-full overflow-y-auto no-scrollbar"}
+          className="px-[21px] py-[25px] items-start h-full overflow-y-auto no-scrollbar"
         >
           <p className="whitespace-pre-line">
             {prayCard?.content || member?.pray_summary}

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -18,6 +18,10 @@ const GroupPage: React.FC = () => {
   const groupList = useBaseStore((state) => state.groupList);
   const targetGroup = useBaseStore((state) => state.targetGroup);
   const getGroup = useBaseStore((state) => state.getGroup);
+  const memberList = useBaseStore((state) => state.memberList) || [];
+  const fetchMemberListByGroupId = useBaseStore(
+    (state) => state.fetchMemberListByGroupId
+  );
 
   const fetchGroupListByUserId = useBaseStore(
     (state) => state.fetchGroupListByUserId
@@ -47,6 +51,10 @@ const GroupPage: React.FC = () => {
     if (targetGroup) fetchIsPrayToday(user!.id, targetGroup.id);
   }, [user, targetGroup, fetchIsPrayToday]);
 
+  useEffect(() => {
+    if (targetGroup) fetchMemberListByGroupId(targetGroup.id);
+  }, [fetchMemberListByGroupId, targetGroup]);
+
   if (!groupList || (paramsGroupId && !targetGroup) || isPrayToday == null) {
     return null;
   }
@@ -62,7 +70,10 @@ const GroupPage: React.FC = () => {
           img={inviteMemberIcon}
         ></KakaoShareButton>
         <div className="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center gap-1">
-          <div className="text-lg font-bold">{targetGroup?.name}</div>
+          <div className="text-lg font-bold flex items-center gap-1">
+            {targetGroup?.name}
+            <span className="text-sm text-gray-500">{memberList?.length}</span>
+          </div>
         </div>
         <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
       </div>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/850b7805-09e1-4d73-83bf-478e67af0629" alt="image1" width="200">
<img src="https://github.com/user-attachments/assets/6516b467-8d33-42a1-b85a-039891dc071a" alt="image2" width="200">


https://www.notion.so/mmyeong/fix-920e1c75d42c494486f00e94edfc63e8?pvs=4

fix: prayCardUI content left top

fix: member number added right on group name

fix: delete isOverFlow status