### PR TITLE
feat: 기도확인 드로어 바로 연결 && 수정 버튼 우상단 배치

### DIFF
--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -37,6 +37,14 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   const setIsOpenMyMemberDrawer = useBaseStore(
     (state) => state.setIsOpenMyMemberDrawer
   );
+  const setIsOpenMyPrayDrawer = useBaseStore(
+    (state) => state.setIsOpenMyPrayDrawer
+  );
+
+  const handleClick = () => {
+    setIsOpenMyMemberDrawer(true);
+    setIsOpenMyPrayDrawer(true);
+  };
 
   useEffect(() => {
     getMember(currentUserId, groupId);
@@ -64,7 +72,10 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
       <div className="text-left text-sm text-gray-600">
         {reduceString(inputPrayCardContent, 20)}
       </div>
-      <div className="w-fit flex bg-gray-100 rounded-lg p-2 gap-3">
+      <div
+        className="w-fit flex bg-gray-100 rounded-lg p-2 gap-3"
+        onClick={() => handleClick()}
+      >
         {Object.values(PrayType).map((type) => {
           return (
             <div key={type} className="flex">

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -72,29 +72,39 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
       <div className="text-left text-sm text-gray-600">
         {reduceString(inputPrayCardContent, 20)}
       </div>
-      <div
-        className="w-fit flex bg-gray-100 rounded-lg p-2 gap-3"
-        onClick={() => handleClick()}
-      >
-        {Object.values(PrayType).map((type) => {
-          return (
-            <div key={type} className="flex">
-              <div className="flex  gap-1 ">
-                <img
-                  src={PrayTypeDatas[type].img}
-                  alt={PrayTypeDatas[type].emoji}
-                  className="w-4 h-4 opacity-90"
-                />
-                <p className="text-xs text-gray-600">
-                  {
-                    prayDatasForMe?.filter((pray) => pray.pray_type === type)
-                      .length
-                  }
-                </p>
+      <div className="flex items-center ">
+        <div
+          className="w-fit flex bg-gray-100 rounded-lg p-2 gap-3"
+          onClick={() => handleClick()}
+        >
+          {Object.values(PrayType).map((type) => {
+            return (
+              <div key={type} className="flex">
+                <div className="flex  gap-1 ">
+                  <img
+                    src={PrayTypeDatas[type].img}
+                    alt={PrayTypeDatas[type].emoji}
+                    className="w-4 h-4 opacity-90"
+                  />
+                  <p className="text-xs text-gray-600">
+                    {
+                      prayDatasForMe?.filter((pray) => pray.pray_type === type)
+                        .length
+                    }
+                  </p>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
+        <div className="relative ml-1 rounded-lg p-1 text-[8px]">
+          <p className=" flex items-center text-gray-500">
+            누군가 내게 기도했어요{" "}
+            <span role="img" aria-label="smile">
+              😊
+            </span>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -97,14 +97,9 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
             );
           })}
         </div>
-        <div className="relative ml-1 rounded-lg p-1 text-[8px]">
-          <p className=" flex items-center text-gray-500">
-            누군가 내게 기도했어요{" "}
-            <span role="img" aria-label="smile">
-              😊
-            </span>
-          </p>
-        </div>
+        <p className=" flex items-center text-gray-500 text-[8px] p-2">
+          누군가 내게 기도했어요 😊
+        </p>
       </div>
     </div>
   );

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -95,7 +95,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   }
 
   const MyPrayCardBody = (
-    <div className="relative flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
+    <div className="flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
       <div className="bg-gradient-to-r from-start/60 via-middle/60 h-15vh via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
         <div className="flex items-center gap-2 w-full">
           <div className="flex gap-2 items-center">

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -38,6 +38,11 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     (state) => state.setReactionDatasForMe
   );
 
+  const isOpenMyPrayDrawer = useBaseStore((state) => state.isOpenMyPrayDrawer);
+  const setIsOpenMyPrayDrawer = useBaseStore(
+    (state) => state.setIsOpenMyPrayDrawer
+  );
+
   const [displayedContent, setDisplayedContent] =
     useState(inputPrayCardContent);
 
@@ -149,7 +154,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
     <div className="flex flex-col gap-6">
       {MyPrayCardBody}
       <div className="flex flex-col gap-5">
-        <Drawer>
+        <Drawer open={isOpenMyPrayDrawer} onOpenChange={setIsOpenMyPrayDrawer}>
           <DrawerTrigger
             className="w-full focus:outline-none"
             onClick={() => onClickPrayerList()}

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -112,7 +112,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
       </div>
       <div
         ref={contentRef}
-        className="px-[21px] py-[25px] items-start h-full overflow-y-auto no-scrollbar"
+        className="px-[21px] py-[25px] items-start h-full overflow-y-auto no-scrollbar relative"
       >
         {isEditingPrayCard ? (
           <Textarea
@@ -124,28 +124,28 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
         ) : (
           <p className="whitespace-pre-line">{displayedContent}</p>
         )}
-      </div>
-      <div className="absolute bottom-4 right-4">
-        {isEditingPrayCard ? (
-          <button
-            className={`text-white rounded-full bg-middle/90 w-10 h-10 flex justify-center items-center ${
-              !inputPrayCardContent ? " opacity-50 cursor-not-allowed" : ""
-            }`}
-            onClick={() =>
-              handleSaveClick(prayCard!.id, inputPrayCardContent, member?.id)
-            }
-            disabled={!inputPrayCardContent}
-          >
-            <FaSave className="text-white w-5 h-5" />
-          </button>
-        ) : (
-          <button
-            className="text-white rounded-full bg-end/90 w-10 h-10 flex justify-center items-center"
-            onClick={() => handleEditClick()}
-          >
-            <FaEdit className="text-white w-5 h-5" />
-          </button>
-        )}
+        <div className="absolute top-4 right-4">
+          {isEditingPrayCard ? (
+            <button
+              className={`text-white rounded-full bg-middle/90 w-10 h-10 flex justify-center items-center ${
+                !inputPrayCardContent ? " opacity-50 cursor-not-allowed" : ""
+              }`}
+              onClick={() =>
+                handleSaveClick(prayCard!.id, inputPrayCardContent, member?.id)
+              }
+              disabled={!inputPrayCardContent}
+            >
+              <FaSave className="text-white w-5 h-5" />
+            </button>
+          ) : (
+            <button
+              className="text-white rounded-full bg-end/90 w-10 h-10 flex justify-center items-center"
+              onClick={() => handleEditClick()}
+            >
+              <FaEdit className="text-white w-5 h-5" />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -139,6 +139,8 @@ export interface BaseStore {
     [key: string]: PrayWithProfiles[];
   };
   setReactionDatasForMe: (prayData: PrayWithProfiles[]) => void;
+  isOpenMyPrayDrawer: boolean;
+  setIsOpenMyPrayDrawer: (isOpenTodayPrayDrawer: boolean) => void;
 }
 
 const useBaseStore = create<BaseStore>()(
@@ -460,6 +462,12 @@ const useBaseStore = create<BaseStore>()(
             ).length;
           });
         });
+    },
+    isOpenMyPrayDrawer: false,
+    setIsOpenMyPrayDrawer: (isOpenTodayPrayDrawer: boolean) => {
+      set((state) => {
+        state.isOpenMyPrayDrawer = isOpenTodayPrayDrawer;
+      });
     },
   }))
 );


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/6f3ce996-8258-48e3-979d-f6783418f29a" width="160" />
<img src="https://github.com/user-attachments/assets/ece87205-b8ad-4132-a96a-daf73bbdb3d6" width="160" />
<img src="https://github.com/user-attachments/assets/6666bc8b-a99d-4373-b796-c666b0ada7ef" width="160" />

- [x]  내 기도제목 밖에서 기도응답 이모티콘 클릭시 기도제목 확인드로어 → 응답 드로어 연속해서 뜨기
- [x]  기도응답 이모티콘 옆 “← 내게 기도해준 사람이 있어요! ” 토스체로 안내글 넣기(한솔M)
- [x]  안드로이드 이슈 → 수정 버튼 우측 상단으로 위치 수정

https://www.notion.so/mmyeong/feat-f4ad852055c4427a815393b45c7713ff?pvs=4





feat: added MyPrayDrawer direct click

chore: 누군가 내게 기도했어요 added

chore: 수정 버튼 우상단 배치