### PR TITLE
fix: height 관련 이슈 처리

### DIFF
--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -89,7 +89,7 @@ const GroupBody: React.FC<GroupBodyProps> = ({
         open={isOpenTodayPrayDrawer}
         onOpenChange={setIsOpenTodayPrayDrawer}
       >
-        <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-10">
+        <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full pb-10">
           <DrawerHeader>
             <DrawerTitle></DrawerTitle>
             <DrawerDescription></DrawerDescription>

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -89,7 +89,7 @@ const GroupBody: React.FC<GroupBodyProps> = ({
         open={isOpenTodayPrayDrawer}
         onOpenChange={setIsOpenTodayPrayDrawer}
       >
-        <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] pb-20">
+        <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-10">
           <DrawerHeader>
             <DrawerTitle></DrawerTitle>
             <DrawerDescription></DrawerDescription>

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -63,7 +63,7 @@ const OtherMember: React.FC<OtherMemberProps> = ({
       >
         {memberUI}
       </DrawerTrigger>
-      <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full h-[90%] px-10 pb-20 focus:outline-none">
+      <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-20 focus:outline-none">
         <DrawerHeader>
           <DrawerTitle></DrawerTitle>
           <DrawerDescription></DrawerDescription>

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -46,8 +46,6 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   const [displayedContent, setDisplayedContent] =
     useState(inputPrayCardContent);
 
-  const contentRef = useRef<HTMLDivElement>(null);
-
   const prayDatas = prayCard.pray;
 
   const dateDistance = getDateDistance(
@@ -95,8 +93,8 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   }
 
   const MyPrayCardBody = (
-    <div className="flex flex-col h-50vh min-h-[300px] bg-white rounded-2xl shadow-md">
-      <div className="bg-gradient-to-r from-start/60 via-middle/60 h-15vh via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
+    <div className="flex flex-col flex-grow max-h-full min-h-full bg-white rounded-2xl shadow-md">
+      <div className="bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
         <div className="flex items-center gap-2 w-full">
           <div className="flex gap-2 items-center">
             <p className="text-xl text-white">
@@ -110,16 +108,12 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
             member?.updated_at.split("T")[0]}
         </p>
       </div>
-      <div
-        ref={contentRef}
-        className="px-[21px] py-[25px] items-start h-full overflow-y-auto no-scrollbar relative"
-      >
+      <div className="flex flex-col flex-grow max-h-full min-h-full px-[21px] py-[25px] items-start overflow-y-auto no-scrollbar relative">
         {isEditingPrayCard ? (
           <Textarea
-            className="w-full h-full p-2 rounded-md border border-gray-300 resize-none overflow-auto"
+            className="flex-grow w-full p-2 rounded-md border border-gray-300 overflow-auto"
             value={inputPrayCardContent}
             onChange={(e) => setPrayCardContent(e.target.value)}
-            maxLength={400}
           />
         ) : (
           <p className="whitespace-pre-line">{displayedContent}</p>
@@ -151,42 +145,40 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({ member, prayCard }) => {
   );
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 min-h-[70vh] max-h-[70vh]">
       {MyPrayCardBody}
-      <div className="flex flex-col gap-5">
-        <Drawer open={isOpenMyPrayDrawer} onOpenChange={setIsOpenMyPrayDrawer}>
-          <DrawerTrigger
-            className="w-full focus:outline-none"
-            onClick={() => onClickPrayerList()}
-          >
-            <div className="flex justify-center gap-2">
-              {Object.values(PrayType).map((type) => {
-                if (!reactionCounts) return null;
-                return (
-                  <div
-                    key={type}
-                    className={`w-[60px] py-1 px-2 flex rounded-lg bg-white text-black gap-2
+      <Drawer open={isOpenMyPrayDrawer} onOpenChange={setIsOpenMyPrayDrawer}>
+        <DrawerTrigger
+          className="w-full focus:outline-none"
+          onClick={() => onClickPrayerList()}
+        >
+          <div className="flex justify-center gap-2">
+            {Object.values(PrayType).map((type) => {
+              if (!reactionCounts) return null;
+              return (
+                <div
+                  key={type}
+                  className={`w-[60px] py-1 px-2 flex rounded-lg bg-white text-black gap-2
                       }`}
-                  >
-                    <div className="text-sm w-5 h-5">
-                      <img
-                        src={PrayTypeDatas[type].img}
-                        alt={PrayTypeDatas[type].emoji}
-                        className="w-5 h-5"
-                      />
-                    </div>
-                    <div className="text-sm">{reactionCounts[type]}</div>
+                >
+                  <div className="text-sm w-5 h-5">
+                    <img
+                      src={PrayTypeDatas[type].img}
+                      alt={PrayTypeDatas[type].emoji}
+                      className="w-5 h-5"
+                    />
                   </div>
-                );
-              })}
-              <div className="bg-white rounded-lg flex justify-center items-center p-1">
-                <img className="w-5" src={iconUserMono} alt="user-icon" />
-              </div>
+                  <div className="text-sm">{reactionCounts[type]}</div>
+                </div>
+              );
+            })}
+            <div className="bg-white rounded-lg flex justify-center items-center p-1">
+              <img className="w-5" src={iconUserMono} alt="user-icon" />
             </div>
-          </DrawerTrigger>
-          <PrayList />
-        </Drawer>
-      </div>
+          </div>
+        </DrawerTrigger>
+        <PrayList />
+      </Drawer>
     </div>
   );
 };

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -120,7 +120,7 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
       <CarouselContent>
         <CarouselItem className="basis-5/6"></CarouselItem>
         {filterdGroupPrayCardList.map((prayCard) => (
-          <CarouselItem key={prayCard.id} className="basis-5/6 h-screen">
+          <CarouselItem key={prayCard.id} className="basis-5/6">
             <PrayCardUI
               currentUserId={currentUserId}
               prayCard={prayCard}

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { MemberWithProfiles } from "supabase/types/tables";
@@ -27,8 +27,6 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
     fetchPrayDataByUserId: state.fetchPrayDataByUserId,
   }));
 
-  const contentRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     if (prayCard?.id) {
       fetchPrayDataByUserId(prayCard.id, currentUserId);
@@ -44,9 +42,9 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
   }
 
   return (
-    <div className="h-full flex flex-col gap-6">
-      <div className="relative flex flex-col h-full min-h-[300px] bg-white rounded-2xl shadow-prayCard">
-        <div className="bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 flex flex-col justify-center items-start gap-1 rounded-t-2xl p-5">
+    <div className="flex flex-col gap-6 min-h-[70vh] max-h-[70vh]">
+      <div className="flex flex-col flex-grow min-h-full max-h-full bg-white rounded-2xl shadow-prayCard">
+        <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 rounded-t-2xl p-5">
           <div className="flex items-center gap-2">
             <img
               src={
@@ -66,10 +64,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
               member?.updated_at.split("T")[0]}
           </p>
         </div>
-        <div
-          ref={contentRef}
-          className="px-[21px] py-[25px] items-start h-full overflow-y-auto no-scrollbar"
-        >
+        <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[21px] py-[25px] overflow-y-auto no-scrollbar">
           <p className="whitespace-pre-line">
             {prayCard?.content || member?.pray_summary}
           </p>


### PR DESCRIPTION

<img src="https://github.com/user-attachments/assets/f90c2cdd-d7b4-476c-b3bb-7a948cb28cb5" width="150" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/adddbeef-9cca-4753-9fed-4fbd37a47b33">

<img src="https://github.com/user-attachments/assets/2b917ca0-ce3a-4f5d-ac46-0a2ed10cf851" width="150" />

<img src="https://github.com/user-attachments/assets/20ae0a48-a46a-48a0-aead-dcaea263477d" width="150" />
<img src="https://github.com/user-attachments/assets/1ade3b76-7931-4b1c-a04f-4e5c4bd13994" width="150" />

height 고정값으로 사용하고 있던 부분 전수조사 후 스크롤 및 깨짐 처리하였습니다.


### 해결방법
1. Drawer 길이를 조정할 때는 내부 첫번째 컨텐츠 길이를 min-h-[0vh], max-h-[0vh] 값으로 조정한다.
	-> 최소가 없으면 줄어들고, 최대가 없으면 스크롤이 안생긴채 늘어납니다.
3. 컨텐츠 내에 있는 컴포넌트들은 flex-grow min-h-full max-h-full 로 관리한다
(h-full 은 부모 컴포넌트에 포함된 것이 하나일 때만 유의미 합니다. 두개 이상일 때는 flex-grow 를 통해서 최대 길이를 맞춥니다.)


### 체크리스트
- [x] 내기도 페이지 수정/기본 뷰 글자 적을 때
- [x] 내기도 페이지 수정/기본 뷰 글자 많을 때
- [x] 친구 기도 페이지 기본뷰 글자 적을때/많을 때