### PR TITLE
fix: 내 기도반응 클릭 분기처리 && praySummary 동적 한줄 제한 && 토스체(친절, 친구, 보아요, 띄어쓰기)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     />
 
     <link rel="icon" href="./prayuLogo.ico" type="image/x-icon" />
-    <meta property="og:title" content="우리만의 기도제목 기록공간 PrayU" />
+    <meta property="og:title" content="우리만의 기도제목 나눔 공간 PrayU" />
     <meta
       property="og:description"
       content="매일 반응하며 함께 기도하는 공동체를 만들어가요"

--- a/src/components/member/MemberInviteCard.tsx
+++ b/src/components/member/MemberInviteCard.tsx
@@ -10,7 +10,7 @@ export const MemberInviteCard = () => {
       <div className="flex flex-col text-center gap-4">
         <div>
           <p className="text-sm text-gray-500">
-            그룹원을 초대하고 오늘의 기도를 시작해 보아요
+            친구들과 함께 오늘의 기도를 시작해 보아요
           </p>
         </div>
         <KakaoShareButton

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -1,4 +1,3 @@
-import { reduceString } from "../../lib/utils";
 import {
   Drawer,
   DrawerContent,
@@ -69,8 +68,8 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   const MyMemberUI = (
     <div className="w-full flex flex-col gap-2 cursor-pointer bg-white p-4 rounded-2xl shadow-md">
       <h3 className="flex font-bold">내 기도제목</h3>
-      <div className="text-left text-sm text-gray-600">
-        {reduceString(inputPrayCardContent, 20)}
+      <div className="text-left text-sm text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis w-full block">
+        {inputPrayCardContent}
       </div>
       <div className="flex items-center ">
         <div

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -40,9 +40,17 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
     (state) => state.setIsOpenMyPrayDrawer
   );
 
+  const onClickMyMemberPray = () => {
+    analyticsTrack("클릭_멤버_본인반응", {
+      group_id: groupId,
+      where: "MyMember",
+    });
+  };
+
   const handleClick = () => {
     setIsOpenMyMemberDrawer(true);
     setIsOpenMyPrayDrawer(true);
+    onClickMyMemberPray();
   };
 
   useEffect(() => {

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -97,9 +97,11 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
             );
           })}
         </div>
-        <p className=" flex items-center text-gray-500 text-[8px] p-2">
-          누군가 내게 기도했어요 😊
-        </p>
+        {prayDatasForMe && prayDatasForMe.length > 0 && (
+          <p className=" flex items-center text-gray-500 text-[8px] p-2">
+            누군가 내게 기도했어요 😊
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -40,7 +40,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
     (state) => state.setIsOpenMyPrayDrawer
   );
 
-  const onClickMyMemberPray = () => {
+  const onClickMyMemberReaction = () => {
     analyticsTrack("클릭_멤버_본인반응", {
       group_id: groupId,
       where: "MyMember",
@@ -50,7 +50,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   const handleClick = () => {
     setIsOpenMyMemberDrawer(true);
     setIsOpenMyPrayDrawer(true);
-    onClickMyMemberPray();
+    onClickMyMemberReaction();
   };
 
   useEffect(() => {
@@ -76,7 +76,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   const MyMemberUI = (
     <div className="w-full flex flex-col gap-2 cursor-pointer bg-white p-4 rounded-2xl shadow-md">
       <h3 className="flex font-bold">내 기도제목</h3>
-      <div className="text-left text-sm text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis w-full block">
+      <div className="text-left text-sm text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis ">
         {inputPrayCardContent}
       </div>
       <div className="flex items-center ">

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -2,7 +2,7 @@ import {
   MemberWithProfiles,
   PrayCardWithProfiles,
 } from "supabase/types/tables";
-import { getISOOnlyDate, getISOTodayDate, reduceString } from "../../lib/utils";
+import { getISOOnlyDate, getISOTodayDate } from "../../lib/utils";
 import {
   Drawer,
   DrawerContent,
@@ -46,8 +46,8 @@ const OtherMember: React.FC<OtherMemberProps> = ({
         />
         <h3>{member.profiles.full_name}</h3>
       </div>
-      <div className="text-left text-sm text-gray-600">
-        {reduceString(member.pray_summary, 20)}
+      <div className="text-left text-sm text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis w-full block">
+        {member.pray_summary}
       </div>
       <div className="text-gray-400 text-left text-xs">
         {dateDistance.days < 1 ? "오늘" : `${dateDistance.days}일 전`}

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -17,7 +17,7 @@ const PrayList: React.FC = () => {
   return (
     <DrawerContent className="max-w-[480px] mx-auto w-full h-[400px] focus:outline-none">
       <DrawerHeader>
-        <DrawerTitle>기도해준 사람</DrawerTitle>
+        <DrawerTitle>기도해 준 친구</DrawerTitle>
         <DrawerDescription></DrawerDescription>
       </DrawerHeader>
       <div className="overflow-y-auto justify-center items-center">
@@ -30,8 +30,8 @@ const PrayList: React.FC = () => {
               />
             </div>
             <div className="flex flex-col text-gray-400 text-sm text-center">
-              <p>아직 기도해준 사람이 없어요</p>
-              <p>그룹 채팅방에 오늘의 기도 링크를 전달해주세요</p>
+              <p>아직 기도해 준 친구가 없어요 😭</p>
+              <p>그룹 채팅방에 오늘의 기도 링크를 공유해 보아요</p>
             </div>
             <KakaoShareButton
               groupPageUrl={window.location.href}

--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -58,13 +58,13 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
   return (
     <div className="flex flex-col items-center min-h-screen gap-6">
       <div className="flex flex-col items-center gap-2 p-2">
-        <p className="text-xl font-bold">이번주 기도제목을 알려주세요 😁</p>
-        <p className="text-sm">기도카드는 1주일 동안 유지돼요</p>
+        <p className="text-xl font-bold">이번 주 기도제목을 알려주세요 😁</p>
+        <p className="text-sm">기도카드는 일주일 동안 유지되어요</p>
       </div>
 
       <Textarea
         className="h-80 p-5 text-[16px]"
-        placeholder="기도제목을 작성해주세요"
+        placeholder="기도제목을 작성해 보아요:)"
         value={inputPrayCardContent}
         onChange={(e) => setPrayCardContent(e.target.value)}
       />

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -44,10 +44,10 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
         className="w-16 h-16 opacity-100"
       />
       <h1 className="font-bold text-xl">오늘의 기도 완료!</h1>
-      <h3 className="text-gray-600">내일도 기도해주실거죠? 🤗</h3>
+      <h3 className="text-gray-600">내일도 기도해 주실 거죠? 🤗</h3>
       <div className="text-gray-400 text-center">
         <h1>당신을 위해 기도한</h1>
-        <h1>사람들을 확인해보세요</h1>
+        <h1>친구들을 확인해 보아요</h1>
       </div>
       <MyMemberBtn />
     </div>
@@ -85,13 +85,13 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
   if (groupPrayCardList.length == 1) {
     return (
       <div className="flex flex-col justify-center items-center p-10 gap-4">
-        <p className="text-lg font-bold">아직 올라온 기도카드가 없어요 😭</p>
+        <p className="text-lg font-bold">아직 올라온 기도제목이 없어요 😭</p>
         <div className="h-[300px] flex flex-col items-center">
           <img className="h-full rounded-md" src="/images/KakaoShare.png" />
         </div>
         <div className="text-center">
           <p className="text-sm text-gray-500">
-            그룹원과 같이 오늘의 기도를 시작해 보아요
+            친구들과 함께 오늘의 기도를 시작해 보아요:)
           </p>
         </div>
         <KakaoShareButton

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -72,7 +72,7 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
         container: `#${id}`,
         objectType: "feed",
         content: {
-          title: "PrayU 우리만의 기도제목 기록공간",
+          title: "PrayU 우리만의 기도제목 나눔 공간",
           description: "기도제목을 기록하고\n매일 반응하며 함께 기도해요!",
           imageUrl: "/images/prayCard.png",
           link: {

--- a/src/components/todayPray/TodayPrayStartCard.tsx
+++ b/src/components/todayPray/TodayPrayStartCard.tsx
@@ -38,10 +38,10 @@ export const TodayPrayStartCard = () => {
             )}
           </div>
           <div className="flex flex-col gap-4">
-            <h1 className="font-bold text-xl">오늘의 기도를 시작해보세요</h1>
+            <h1 className="font-bold text-xl">오늘의 기도를 시작해 보아요</h1>
             <div className="text-grayText">
-              <h1>그룹원의 기도제목이</h1>
-              <h1 className="mb-5">당신의 기도를 기다리고 있어요</h1>
+              <h1>친구의 기도제목이</h1>
+              <h1 className="mb-5">당신의 기도를 기다리고 있어요:)</h1>
             </div>
           </div>
         </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,11 +63,3 @@ export const getDomainUrl = () => {
     ? `${protocol}//${hostname}:${port}`
     : `${protocol}//${hostname}`;
 };
-
-export const reduceString = (
-  text: string | null,
-  length: number = 10
-): string => {
-  if (!text) return "";
-  return text.length <= length ? text : `${text.substring(0, length)}...`;
-};

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -60,13 +60,13 @@ const GroupCreatePage: React.FC = () => {
   return (
     <div className="flex flex-col gap-6 items-center">
       <div className="text-lg font-bold">
-        PrayU 그룹
+        PrayU 그룹{" "}
         <button
           onClick={() => {
             throw new Error("버그 테스트");
           }}
         >
-          생성
+          만들기
         </button>
       </div>
 
@@ -81,7 +81,7 @@ const GroupCreatePage: React.FC = () => {
           type="text"
           value={inputGroupName}
           onChange={(e) => setGroupName(e.target.value)}
-          placeholder="그룹 이름을 입력해주세요"
+          placeholder="그룹 이름을 입력해 주세요"
           maxLength={15}
         />
         <Button
@@ -97,7 +97,7 @@ const GroupCreatePage: React.FC = () => {
             기존 그룹에 참여하고 싶은 경우
           </p>
           <p className="text-xs text-gray-500">
-            그룹장에게 초대링크를 요청해 주세요
+            그룹장에게 초대 링크를 요청해 보아요
           </p>
         </div>
       </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -95,7 +95,7 @@ const MainPage: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-6 items-center text-center">
-      <div className="text-lg font-bold">우리만의 기도제목 기록공간 PrayU</div>
+      <div className="text-lg font-bold">우리만의 기도제목 나눔 공간 PrayU</div>
       <Carousel setApi={setApi}>
         <CarouselContent>
           <CarouselItem className="flex flex-col items-center gap-4">
@@ -155,7 +155,7 @@ const MainPage: React.FC = () => {
                   내 기도제목이 오늘의 기도에 있는 동안
                 </p>
                 <p className="text-sm text-gray-500">
-                  내게 기도해준 친구들을 확인할 수 있어요
+                  내게 기도해 준 친구들을 확인할 수 있어요
                 </p>
               </div>
             </div>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/80f94342-5676-4ee4-b7b0-f29e3058e8e3" width="300">
<img  src="https://github.com/user-attachments/assets/3222eb31-4102-4ef3-9be3-7f7e29a94346" width="300">


- [x]  summary 반응형 고려해서 최대 수치 정하기
- [x]  ‘누군가 내게 기도했어요’ 멘트 기도가 0개이면 출력하지 않기
- [x]  멘트 수정( 토스체 )
    - [x]  기도완료 페이지에 매일 할 수 있다는 걸 알려줘야함. 그리고 멘트들을 계속 수정해줘야함. 세뇌시켜야함. ex. ‘내일 또 기도할 수 있어요.’, ‘일주일 기도를 다 채워보아요!
    - [x]  사람 → 친구   로 통일
    - [x]  보세요,주세요 → 보아요
    - [x]   띄어쓰기 검사
- [ ]  사진 좀 안어울리는데? MemberInviteCard.tsx

https://www.notion.so/mmyeong/fix-pray_summary-c00eee558e5a4eadb7f6fc89def3d86e?pvs=4


fix: ‘누군가 내게 기도했어요’ 멘트 기도가 0개이면 출력하지 않기

fix: summary 반응형 고려해서 최대 수치 정하기

fix: 멘트 수정( 토스체 )