### PR TITLE
refactor: PrayCardUI 분리

### DIFF
--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -1,7 +1,4 @@
-import {
-  MemberWithProfiles,
-  PrayCardWithProfiles,
-} from "supabase/types/tables";
+import { MemberWithProfiles } from "supabase/types/tables";
 import { getISOOnlyDate, getISOTodayDate } from "../../lib/utils";
 import {
   Drawer,
@@ -11,25 +8,19 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
-import PrayCardUI from "../prayCard/PrayCardUI";
+import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
 import { getDateDistance } from "@toss/date";
 import { analyticsTrack } from "@/analytics/analytics";
+import ExpiredPrayCardUI from "../prayCard/ExpiredPrayCardUI";
 
 interface OtherMemberProps {
   currentUserId: string;
   member: MemberWithProfiles;
-  prayCardList: PrayCardWithProfiles[];
 }
 
-const OtherMember: React.FC<OtherMemberProps> = ({
-  currentUserId,
-  member,
-  prayCardList,
-}) => {
-  const prayCard = prayCardList[0] || null;
-
+const OtherMember: React.FC<OtherMemberProps> = ({ currentUserId, member }) => {
   const dateDistance = getDateDistance(
-    new Date(getISOOnlyDate(member?.updated_at ?? null)),
+    new Date(getISOOnlyDate(member.updated_at)),
     new Date(getISOTodayDate())
   );
 
@@ -69,12 +60,15 @@ const OtherMember: React.FC<OtherMemberProps> = ({
           <DrawerDescription></DrawerDescription>
         </DrawerHeader>
         {/* PrayCard */}
-        <PrayCardUI
-          currentUserId={currentUserId}
-          member={member}
-          prayCard={prayCard}
-          eventOption={{ where: "OtherMember" }}
-        />
+        {dateDistance.days > 7 ? (
+          <ExpiredPrayCardUI member={member} />
+        ) : (
+          <OtherPrayCardUI
+            currentUserId={currentUserId}
+            member={member}
+            eventOption={{ where: "OtherMember" }}
+          />
+        )}
         {/* PrayCard */}
       </DrawerContent>
     </Drawer>

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -1,9 +1,6 @@
 import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
-import { ClipLoader } from "react-spinners";
-import { userIdPrayCardListHash } from "../../../supabase/types/tables";
 import OtherMember from "./OtherMember";
-import { getISOTodayDate } from "@/lib/utils";
 import MemberInviteCard from "./MemberInviteCard";
 import TodayPrayBtn from "../todayPray/TodayPrayBtn";
 import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
@@ -20,62 +17,29 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const fetchIsPrayToday = useBaseStore((state) => state.fetchIsPrayToday);
   const memberList = useBaseStore((state) => state.memberList);
-  const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
-  const fetchGroupPrayCardList = useBaseStore(
-    (state) => state.fetchGroupPrayCardList
-  );
-
-  const startDt = getISOTodayDate(-6);
-  const endDt = getISOTodayDate(1);
 
   useEffect(() => {
-    fetchGroupPrayCardList(groupId, currentUserId, startDt, endDt);
     fetchIsPrayToday(currentUserId, groupId);
-  }, [
-    currentUserId,
-    endDt,
-    fetchGroupPrayCardList,
-    fetchIsPrayToday,
-    groupId,
-    startDt,
-  ]);
+  }, [currentUserId, fetchIsPrayToday, groupId]);
 
-  if (isPrayToday == null || !memberList || !groupPrayCardList) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <ClipLoader size={50} color={"#123abc"} loading={true} />
-      </div>
-    );
-  }
-
-  const otherMembers = memberList.filter(
-    (member) => member.user_id !== currentUserId
-  );
-
-  // TODO: 이것도 제거하기
-  const userIdPrayCardListHash = memberList.reduce((hash, member) => {
-    const prayCardList = groupPrayCardList.filter(
-      (prayCard) => prayCard.user_id === member.user_id
-    );
-    hash[member.user_id || "deletedUser"] = prayCardList;
-    return hash;
-  }, {} as userIdPrayCardListHash);
-
-  if (otherMembers.length === 0) return <MemberInviteCard />;
+  if (isPrayToday == null || !memberList) return null;
+  if (memberList.length === 1) return <MemberInviteCard />;
   if (!isPrayToday) return <TodayPrayStartCard />;
 
   return (
     <div className="flex flex-col gap-2">
       <div className="text-sm text-gray-500 p-2">기도 구성원</div>
       <div className="flex flex-col gap-4">
-        {otherMembers.map((member) => (
-          <OtherMember
-            key={member.id}
-            currentUserId={currentUserId}
-            member={member}
-            prayCardList={userIdPrayCardListHash[member.user_id || ""]}
-          ></OtherMember>
-        ))}
+        {memberList.map((member) => {
+          if (member.user_id !== currentUserId)
+            return (
+              <OtherMember
+                key={member.id}
+                currentUserId={currentUserId}
+                member={member}
+              ></OtherMember>
+            );
+        })}
       </div>
       <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
         <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -1,0 +1,59 @@
+import { MemberWithProfiles } from "supabase/types/tables";
+import { Textarea } from "../ui/textarea";
+import { getDateDistance } from "@toss/date";
+import { getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
+import { KakaoShareButton } from "../share/KakaoShareBtn";
+
+interface ExpiredPrayCardProps {
+  member: MemberWithProfiles;
+}
+
+const ExpiredPrayCardUI: React.FC<ExpiredPrayCardProps> = ({ member }) => {
+  const dateDistance = getDateDistance(
+    new Date(getISOOnlyDate(member.updated_at)),
+    new Date(getISOTodayDate())
+  );
+
+  return (
+    <div className="flex flex-col gap-6 min-h-[80vh] max-h-[80vh]">
+      <div className="flex flex-col flex-grow min-h-full max-h-full bg-white rounded-2xl shadow-prayCard">
+        <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 rounded-t-2xl p-5">
+          <div className="flex items-center gap-2">
+            <img
+              src={member.profiles.avatar_url || ""}
+              className="w-7 h-7 rounded-full"
+            />
+            <p className="text-white text-lg">{member?.profiles.full_name}</p>
+          </div>
+          <p className="text-sm text-white w-full text-left">
+            시작일 : {member.updated_at.split("T")[0]}
+          </p>
+        </div>
+        <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
+          <Textarea
+            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
+            value={member.pray_summary || ""}
+            disabled={true}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col items-center justify-center p-4 gap-4">
+        <div className="flex flex-col items-center gap-1">
+          <p className="font-bold">
+            작성 된 지 {dateDistance.days}일이 되었어요 😂
+          </p>
+          <p className="text-sm">기도제목을 요청해봐요!</p>
+        </div>
+
+        <KakaoShareButton
+          groupPageUrl={window.location.href}
+          message="카카오톡으로 요청하기"
+          id="prayCardUIToOther"
+          eventOption={{ where: "ReactionWithCalendar" }}
+        ></KakaoShareButton>
+      </div>
+    </div>
+  );
+};
+
+export default ExpiredPrayCardUI;

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from "react";
+import useBaseStore from "@/stores/baseStore";
+import { MemberWithProfiles } from "supabase/types/tables";
+import { ClipLoader } from "react-spinners";
+import ReactionWithCalendar from "./ReactionWithCalendar";
+import { Textarea } from "../ui/textarea";
+
+interface EventOption {
+  where: string;
+}
+
+interface OtherPrayCardProps {
+  currentUserId: string;
+  member: MemberWithProfiles;
+  eventOption: EventOption;
+}
+
+const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
+  currentUserId,
+  member,
+  eventOption,
+}) => {
+  const userPrayCardList = useBaseStore((state) => state.userPrayCardList);
+  const fetchUserPrayCardListByGroupId = useBaseStore(
+    (state) => state.fetchUserPrayCardListByGroupId
+  );
+
+  const prayDataHash = useBaseStore((state) => state.prayDataHash);
+  const fetchPrayDataByUserId = useBaseStore(
+    (state) => state.fetchPrayDataByUserId
+  );
+
+  useEffect(() => {
+    fetchUserPrayCardListByGroupId(member.user_id!, member.group_id!);
+  }, [fetchUserPrayCardListByGroupId, member]);
+
+  // TODO: 제거 예정. PrayCard.pray 로 사용 예정
+  useEffect(() => {
+    if (userPrayCardList && userPrayCardList.length > 0) {
+      fetchPrayDataByUserId(userPrayCardList[0].id, currentUserId);
+    }
+  }, [currentUserId, fetchPrayDataByUserId, userPrayCardList]);
+
+  if (!userPrayCardList || !prayDataHash) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={50} color={"#123abc"} loading={true} />
+      </div>
+    );
+  }
+
+  // TODO: PrayCardCreateModal 로 반환하기 ( 이미 GroupBody 에서 member.updated_at 으로 처리중 )
+  if (userPrayCardList.length === 0) {
+    return null;
+  }
+
+  const prayCard = userPrayCardList[0];
+
+  return (
+    <div className="flex flex-col gap-6 min-h-[80vh] max-h-[80vh]">
+      <div className="flex flex-col flex-grow min-h-full max-h-full bg-white rounded-2xl shadow-prayCard">
+        <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 rounded-t-2xl p-5">
+          <div className="flex items-center gap-2">
+            <img
+              src={prayCard.profiles.avatar_url || ""}
+              className="w-7 h-7 rounded-full"
+            />
+            <p className="text-white text-lg">{prayCard.profiles.full_name}</p>
+          </div>
+          <p className="text-sm text-white w-full text-left">
+            시작일 : {prayCard.created_at.split("T")[0]}
+          </p>
+        </div>
+        <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
+          <Textarea
+            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
+            value={prayCard.content || ""}
+            disabled={true}
+          />
+        </div>
+      </div>
+      <ReactionWithCalendar prayCard={prayCard} eventOption={eventOption} />
+    </div>
+  );
+};
+
+export default OtherPrayCardUI;

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
 import { PrayCardWithProfiles } from "supabase/types/tables";
-import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
 import ReactionWithCalendar from "./ReactionWithCalendar";
 import { Textarea } from "../ui/textarea";
@@ -12,14 +11,13 @@ interface EventOption {
 
 interface PrayCardProps {
   currentUserId: string;
-  prayCard: PrayCardWithProfiles | null;
-  member?: MemberWithProfiles | null;
+  prayCard: PrayCardWithProfiles;
   eventOption: EventOption;
 }
 
+// TODO: 현재 TodayPray 에서의 PrayCard 를 위한 컴포넌트로 사용중, 이후 이름 수정 및 폴더링 예정
 const PrayCardUI: React.FC<PrayCardProps> = ({
   currentUserId,
-  member,
   prayCard,
   eventOption,
 }) => {
@@ -28,11 +26,12 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
     fetchPrayDataByUserId: state.fetchPrayDataByUserId,
   }));
 
+  // TODO: 제거 예정. PrayCard.pray 로 사용 예정
   useEffect(() => {
-    if (prayCard?.id) {
+    if (prayCard) {
       fetchPrayDataByUserId(prayCard.id, currentUserId);
     }
-  }, [currentUserId, fetchPrayDataByUserId, prayCard?.id]);
+  }, [currentUserId, fetchPrayDataByUserId, prayCard]);
 
   if (!prayDataHash) {
     return (
@@ -48,36 +47,24 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
         <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 rounded-t-2xl p-5">
           <div className="flex items-center gap-2">
             <img
-              src={
-                prayCard?.profiles.avatar_url ||
-                member?.profiles.avatar_url ||
-                ""
-              }
+              src={prayCard.profiles.avatar_url || ""}
               className="w-7 h-7 rounded-full"
             />
-            <p className="text-white text-lg">
-              {prayCard?.profiles.full_name || member?.profiles.full_name}
-            </p>
+            <p className="text-white text-lg">{prayCard.profiles.full_name}</p>
           </div>
           <p className="text-sm text-white w-full text-left">
-            시작일 :{" "}
-            {prayCard?.created_at.split("T")[0] ||
-              member?.updated_at.split("T")[0]}
+            시작일 : {prayCard.created_at.split("T")[0]}
           </p>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
           <Textarea
             className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={prayCard?.content || member?.pray_summary || ""}
+            value={prayCard.content || ""}
             disabled={true}
           />
         </div>
       </div>
-      <ReactionWithCalendar
-        prayCard={prayCard}
-        eventOption={eventOption}
-        member={member}
-      />
+      <ReactionWithCalendar prayCard={prayCard} eventOption={eventOption} />
     </div>
   );
 };

--- a/src/components/prayCard/ReactionWithCalendar.tsx
+++ b/src/components/prayCard/ReactionWithCalendar.tsx
@@ -1,62 +1,29 @@
 import useBaseStore from "@/stores/baseStore";
 import WeeklyCalendar from "./WeeklyCalendar";
-import {
-  MemberWithProfiles,
-  PrayCardWithProfiles,
-} from "supabase/types/tables";
+import { PrayCardWithProfiles } from "supabase/types/tables";
 import ReactionBtn from "./ReactionBtn";
-import { KakaoShareButton } from "../share/KakaoShareBtn";
-import { getDateDistance } from "@toss/date";
-import { getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
 
 interface EventOption {
   where: string;
 }
 
 interface PrayCardProps {
-  prayCard: PrayCardWithProfiles | null;
+  prayCard: PrayCardWithProfiles;
   eventOption: EventOption;
-  member?: MemberWithProfiles | null;
 }
 
 const ReactionWithCalendar: React.FC<PrayCardProps> = ({
   prayCard,
   eventOption,
-  member,
 }) => {
   const prayDataHash = useBaseStore((state) => state.prayDataHash);
   const currentUserId = useBaseStore((state) => state.user?.id);
-
-  const dateDistance = getDateDistance(
-    new Date(getISOOnlyDate(member?.updated_at ?? null)),
-    new Date(getISOTodayDate())
-  );
-
-  if (!prayCard) {
-    return (
-      <div className="flex flex-col items-center justify-center p-4 gap-4">
-        <div className="flex flex-col items-center gap-1">
-          <p className="font-bold">
-            작성 된 지 {dateDistance.days}일이 되었어요 😂
-          </p>
-          <p className="text-sm">기도제목을 요청해봐요!</p>
-        </div>
-
-        <KakaoShareButton
-          groupPageUrl={window.location.href}
-          message="카카오톡으로 요청하기"
-          id="prayCardUIToOther"
-          eventOption={{ where: "ReactionWithCalendar" }}
-        ></KakaoShareButton>
-      </div>
-    );
-  }
 
   return (
     <div className="flex flex-col gap-[33px] p-2">
       <WeeklyCalendar
         prayCard={prayCard}
-        prayData={prayDataHash[prayCard?.id || ""] || []}
+        prayData={prayDataHash[prayCard.id] || []}
       />
       <ReactionBtn
         currentUserId={currentUserId!}

--- a/src/components/prayCard/WeeklyCalendar.tsx
+++ b/src/components/prayCard/WeeklyCalendar.tsx
@@ -4,7 +4,7 @@ import useBaseStore from "@/stores/baseStore";
 import { Pray, PrayCardWithProfiles } from "supabase/types/tables";
 
 interface WeeklyCalendarProps {
-  prayCard: PrayCardWithProfiles | null;
+  prayCard: PrayCardWithProfiles;
   prayData: Pray[];
 }
 
@@ -45,7 +45,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   };
 
   const currentDate = getISOToday().split("T")[0];
-  const weeklyDays = generateDates(prayCard?.created_at, prayData);
+  const weeklyDays = generateDates(prayCard.created_at, prayData);
 
   return (
     <div className="flex justify-center gap-[13px]">
@@ -67,7 +67,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
               }`}
             >
               {isToday
-                ? getReactionEmoticon(todayPrayTypeHash[prayCard?.id || ""])
+                ? getReactionEmoticon(todayPrayTypeHash[prayCard.id])
                 : date.emoji}
             </div>
           </div>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/c1435d93-a569-4c73-95fd-f02bc81e58da" width="150" />
<img src="https://github.com/user-attachments/assets/7cdac596-ca59-453a-9468-032e83b82fe1" width="150" />
<img src="https://github.com/user-attachments/assets/c5a991ae-9587-4d0a-9c6f-b690ce203155" width="150" />

## 작업내용
null 값으로 넘어오는 데이터들에 대해 디버깅이 되지 않아 null 타입을 최소화 하는 것을 목표합니다.

기존 PrayCardUI 의 사용이 혼재되면서 
	(1) 데이터가 추가로 불러오는 이슈
	(2) null 타입을 같이 들고 오면서 예외사항 발생하는 이슈

를 해결하고자 PrayCardUI 를 분리합니다.


## 기존사항
PrayCardUI 를 (1) 오늘의 기도, (2) 개별 기도카드 에서 사용

## 변경 
PrayCardUI는 오늘의기도에서 사용, 
	OtherPrayCardUI 는 개별 기도카드에서 사용
	ExpiredPrayCardUI 는 만료된 멤버 대상 개별 기도카드로 사용

