### PR TITLE
refactor: prayData 제거 및 PrayCard.pray 사용

### DIFF
--- a/src/apis/pray.ts
+++ b/src/apis/pray.ts
@@ -4,27 +4,6 @@ import { Pray, PrayWithProfiles } from "../../supabase/types/tables";
 import { PrayType } from "../Enums/prayType";
 import * as Sentry from "@sentry/react";
 
-export const fetchPrayData = async (
-  prayCardId: string | undefined
-): Promise<Pray[] | null> => {
-  try {
-    if (!prayCardId) return null;
-    const { data, error } = await supabase
-      .from("pray")
-      .select("*")
-      .eq("pray_card_id", prayCardId)
-      .is("deleted_at", null);
-    if (error) {
-      Sentry.captureException(error.message);
-      return null;
-    }
-    return data as Pray[];
-  } catch (error) {
-    Sentry.captureException(error);
-    return null;
-  }
-};
-
 export const fetchIsPrayToday = async (
   userId: string | undefined,
   groupId: string | undefined
@@ -54,34 +33,6 @@ export const fetchIsPrayToday = async (
   } catch (error) {
     Sentry.captureException(error);
     return false;
-  }
-};
-
-export const fetchPrayDataByUserId = async (
-  prayCardId: string | undefined,
-  userId: string | undefined
-): Promise<PrayWithProfiles[] | null> => {
-  try {
-    if (!prayCardId) return null;
-    let query = supabase
-      .from("pray")
-      .select("*, profiles (id, full_name, avatar_url)")
-      .eq("pray_card_id", prayCardId)
-      .is("deleted_at", null)
-      .order("created_at", { ascending: false });
-
-    if (userId) query = query.eq("user_id", userId);
-
-    const { data, error } = await query;
-
-    if (error) {
-      Sentry.captureException(error.message);
-      return null;
-    }
-    return data as PrayWithProfiles[];
-  } catch (error) {
-    Sentry.captureException(error);
-    return null;
   }
 };
 

--- a/src/apis/pray.ts
+++ b/src/apis/pray.ts
@@ -1,6 +1,6 @@
 import { getISOTodayDate } from "@/lib/utils";
 import { supabase } from "../../supabase/client";
-import { Pray, PrayWithProfiles } from "../../supabase/types/tables";
+import { Pray } from "../../supabase/types/tables";
 import { PrayType } from "../Enums/prayType";
 import * as Sentry from "@sentry/react";
 

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -38,7 +38,8 @@ export const fetchGroupPrayCardList = async (
   }
 };
 
-export const fetchUserPrayCardListByGroupId = async (
+export const fetchOtherPrayCardListByGroupId = async (
+  currentUserId: string,
   userId: string | undefined,
   groupId: string | undefined,
   limit: number = 10,
@@ -46,7 +47,7 @@ export const fetchUserPrayCardListByGroupId = async (
 ): Promise<PrayCardWithProfiles[] | null> => {
   try {
     if (!userId || !groupId) return null;
-    const { data, error } = await supabase
+    const query = supabase
       .from("pray_card")
       .select(
         `*,
@@ -57,10 +58,47 @@ export const fetchUserPrayCardListByGroupId = async (
       )
       .eq("user_id", userId)
       .eq("group_id", groupId)
+      .eq("pray.user_id", currentUserId)
       .is("deleted_at", null)
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
+    const { data, error } = await query;
+    if (error) {
+      Sentry.captureException(error.message);
+      return null;
+    }
+    return data as PrayCardWithProfiles[];
+  } catch (error) {
+    Sentry.captureException(error);
+    return null;
+  }
+};
+
+export const fetchUserPrayCardListByGroupId = async (
+  currentUserId: string,
+  groupId: string | undefined,
+  limit: number = 10,
+  offset: number = 0
+): Promise<PrayCardWithProfiles[] | null> => {
+  try {
+    if (!groupId) return null;
+    const query = supabase
+      .from("pray_card")
+      .select(
+        `*,
+      profiles (id, full_name, avatar_url),
+      pray (*, 
+        profiles (id, full_name, avatar_url)
+      )`
+      )
+      .eq("user_id", currentUserId)
+      .eq("group_id", groupId)
+      .is("deleted_at", null)
+      .order("created_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    const { data, error } = await query;
     if (error) {
       Sentry.captureException(error.message);
       return null;
@@ -73,7 +111,6 @@ export const fetchUserPrayCardListByGroupId = async (
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       ),
     }));
-
     return sortedData as PrayCardWithProfiles[];
   } catch (error) {
     Sentry.captureException(error);

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -47,7 +47,7 @@ export const fetchOtherPrayCardListByGroupId = async (
 ): Promise<PrayCardWithProfiles[] | null> => {
   try {
     if (!userId || !groupId) return null;
-    const query = supabase
+    const { data, error } = await supabase
       .from("pray_card")
       .select(
         `*,
@@ -63,7 +63,6 @@ export const fetchOtherPrayCardListByGroupId = async (
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
-    const { data, error } = await query;
     if (error) {
       Sentry.captureException(error.message);
       return null;

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -83,7 +83,7 @@ export const fetchUserPrayCardListByGroupId = async (
 ): Promise<PrayCardWithProfiles[] | null> => {
   try {
     if (!groupId) return null;
-    const query = supabase
+    const { data, error } = await supabase
       .from("pray_card")
       .select(
         `*,
@@ -98,7 +98,6 @@ export const fetchUserPrayCardListByGroupId = async (
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
-    const { data, error } = await query;
     if (error) {
       Sentry.captureException(error.message);
       return null;

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -54,11 +54,11 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   useEffect(() => {
     getMember(currentUserId, groupId);
     fetchUserPrayCardListByGroupId(currentUserId, groupId);
-  }, [currentUserId, fetchUserPrayCardListByGroupId, getMember, groupId]);
+  }, [getMember, fetchUserPrayCardListByGroupId, currentUserId, groupId]);
 
   useEffect(() => {
-    setPrayCardContent(member?.pray_summary || "");
-  }, [member, setPrayCardContent]);
+    if (member) setPrayCardContent(member.pray_summary || "");
+  }, [setPrayCardContent, member]);
 
   const prayCard = userPrayCardList?.[0] || null;
   const prayDatasForMe = prayCard?.pray;

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -7,11 +7,19 @@ import {
 } from "../ui/drawer";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import { KakaoShareButton } from "../share/KakaoShareBtn";
+import { PrayWithProfiles } from "supabase/types/tables";
 
-const PrayList: React.FC = () => {
-  const prayerList = useBaseStore((state) => state.prayerList);
+interface PrayListProps {
+  prayData: PrayWithProfiles[];
+}
+
+const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
+  const groupAndSortByUserId = useBaseStore(
+    (state) => state.groupAndSortByUserId
+  );
 
+  const prayerList = groupAndSortByUserId(prayData);
   const isPrayerListEmpty = !prayerList || Object.keys(prayerList).length === 0;
 
   return (

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -20,28 +20,20 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
   member,
   eventOption,
 }) => {
-  const userPrayCardList = useBaseStore((state) => state.userPrayCardList);
-  const fetchUserPrayCardListByGroupId = useBaseStore(
-    (state) => state.fetchUserPrayCardListByGroupId
-  );
-
-  const prayDataHash = useBaseStore((state) => state.prayDataHash);
-  const fetchPrayDataByUserId = useBaseStore(
-    (state) => state.fetchPrayDataByUserId
+  const otherPrayCardList = useBaseStore((state) => state.otherPrayCardList);
+  const fetchOtherPrayCardListByGroupId = useBaseStore(
+    (state) => state.fetchOtherPrayCardListByGroupId
   );
 
   useEffect(() => {
-    fetchUserPrayCardListByGroupId(member.user_id!, member.group_id!);
-  }, [fetchUserPrayCardListByGroupId, member]);
+    fetchOtherPrayCardListByGroupId(
+      currentUserId,
+      member.user_id!,
+      member.group_id!
+    );
+  }, [fetchOtherPrayCardListByGroupId, currentUserId, member]);
 
-  // TODO: 제거 예정. PrayCard.pray 로 사용 예정
-  useEffect(() => {
-    if (userPrayCardList && userPrayCardList.length > 0) {
-      fetchPrayDataByUserId(userPrayCardList[0].id, currentUserId);
-    }
-  }, [currentUserId, fetchPrayDataByUserId, userPrayCardList]);
-
-  if (!userPrayCardList || !prayDataHash) {
+  if (!otherPrayCardList) {
     return (
       <div className="flex justify-center items-center h-screen">
         <ClipLoader size={50} color={"#123abc"} loading={true} />
@@ -50,11 +42,11 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
   }
 
   // TODO: PrayCardCreateModal 로 반환하기 ( 이미 GroupBody 에서 member.updated_at 으로 처리중 )
-  if (userPrayCardList.length === 0) {
+  if (otherPrayCardList.length === 0) {
     return null;
   }
 
-  const prayCard = userPrayCardList[0];
+  const prayCard = otherPrayCardList[0];
 
   return (
     <div className="flex flex-col gap-6 min-h-[80vh] max-h-[80vh]">

--- a/src/components/prayCard/PrayCardList.tsx
+++ b/src/components/prayCard/PrayCardList.tsx
@@ -122,7 +122,6 @@ const PrayCardList: React.FC<PrayCardListProps> = ({
         {filterdGroupPrayCardList.map((prayCard) => (
           <CarouselItem key={prayCard.id} className="basis-5/6">
             <PrayCardUI
-              currentUserId={currentUserId}
               prayCard={prayCard}
               eventOption={{ where: "PrayCardList" }}
             />

--- a/src/components/prayCard/PrayCardUI.tsx
+++ b/src/components/prayCard/PrayCardUI.tsx
@@ -1,7 +1,4 @@
-import { useEffect } from "react";
-import useBaseStore from "@/stores/baseStore";
 import { PrayCardWithProfiles } from "supabase/types/tables";
-import { ClipLoader } from "react-spinners";
 import ReactionWithCalendar from "./ReactionWithCalendar";
 import { Textarea } from "../ui/textarea";
 
@@ -10,37 +7,12 @@ interface EventOption {
 }
 
 interface PrayCardProps {
-  currentUserId: string;
   prayCard: PrayCardWithProfiles;
   eventOption: EventOption;
 }
 
 // TODO: 현재 TodayPray 에서의 PrayCard 를 위한 컴포넌트로 사용중, 이후 이름 수정 및 폴더링 예정
-const PrayCardUI: React.FC<PrayCardProps> = ({
-  currentUserId,
-  prayCard,
-  eventOption,
-}) => {
-  const { prayDataHash, fetchPrayDataByUserId } = useBaseStore((state) => ({
-    prayDataHash: state.prayDataHash,
-    fetchPrayDataByUserId: state.fetchPrayDataByUserId,
-  }));
-
-  // TODO: 제거 예정. PrayCard.pray 로 사용 예정
-  useEffect(() => {
-    if (prayCard) {
-      fetchPrayDataByUserId(prayCard.id, currentUserId);
-    }
-  }, [currentUserId, fetchPrayDataByUserId, prayCard]);
-
-  if (!prayDataHash) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <ClipLoader size={50} color={"#123abc"} loading={true} />
-      </div>
-    );
-  }
-
+const PrayCardUI: React.FC<PrayCardProps> = ({ prayCard, eventOption }) => {
   return (
     <div className="flex flex-col gap-6 min-h-[80vh] max-h-[80vh]">
       <div className="flex flex-col flex-grow min-h-full max-h-full bg-white rounded-2xl shadow-prayCard">

--- a/src/components/prayCard/ReactionWithCalendar.tsx
+++ b/src/components/prayCard/ReactionWithCalendar.tsx
@@ -16,15 +16,11 @@ const ReactionWithCalendar: React.FC<PrayCardProps> = ({
   prayCard,
   eventOption,
 }) => {
-  const prayDataHash = useBaseStore((state) => state.prayDataHash);
   const currentUserId = useBaseStore((state) => state.user?.id);
 
   return (
     <div className="flex flex-col gap-[33px] p-2">
-      <WeeklyCalendar
-        prayCard={prayCard}
-        prayData={prayDataHash[prayCard.id] || []}
-      />
+      <WeeklyCalendar prayCard={prayCard} prayData={prayCard.pray} />
       <ReactionBtn
         currentUserId={currentUserId!}
         prayCard={prayCard}

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -28,18 +28,6 @@ export interface PrayWithProfiles extends Pray {
   profiles: Profiles;
 }
 
-export interface UserIdMemberHash {
-  [key: string]: MemberWithProfiles;
-}
-
-export interface userIdPrayCardListHash {
-  [key: string]: PrayCardWithProfiles[];
-}
-
 export interface TodayPrayTypeHash {
   [prayCardId: string]: PrayType | null;
-}
-
-export interface PrayDataHash {
-  [prayCardId: string]: Pray[] | null;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f8aaab97-286a-45b8-90da-d4ce3b7289a3)

## 작업내용

중복 패칭 부분과 null 관련 부분을 해결합니다.

PrayData 를 직접 Fetch 하던 부분을 제거하고

PrayCard.pray 를 통해 prayData를 사용합니다.

## 체크리스트

- [x]  FetchPrayData 부분 제거 및 PrayCard.pray 로 대체
- [x]  FetchPrayData 를 제거하면서 관련된 전역변수 제거
    - [x]  reactionCounts, reactionDataForMe, prayerList 제거
- [x]  null 타입 전환

## 테스트

- [x]  내 기도카드 눌렀을 때 새로고침 안한 상태로 반응 최신화 확인
- [x]  오늘의 기도, otherMember 를 통한 기도카드 반응 동기화 확인

## 노션 링크
https://www.notion.so/mmyeong/refactor-PrayCard-pray-8c120ab3f1f34cbfb2cb7e7da0c8f509?pvs=4