### PR TITLE
fix: MainPage Btn 수정 && 기도카드 생성 재시도 환경

### DIFF
--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -1,7 +1,7 @@
 import { Textarea } from "../ui/textarea";
 import { Button } from "../ui/button";
 import useBaseStore from "@/stores/baseStore";
-import { MemberWithProfiles } from "supabase/types/tables";
+import { Member, MemberWithProfiles } from "supabase/types/tables";
 import { useEffect } from "react";
 import { analyticsTrack } from "@/analytics/analytics";
 import { getISOTodayDate } from "@/lib/utils";
@@ -37,12 +37,33 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
   ) => {
     setIsDisabledPrayCardCreateBtn(true);
     analyticsTrack("클릭_기도카드_생성", { group_id: groupId });
+    let updatedMember: Member | null;
     if (!member) {
-      await createMember(groupId, currentUserId, inputPrayCardContent);
+      updatedMember = await createMember(
+        groupId,
+        currentUserId,
+        inputPrayCardContent
+      );
     } else {
-      await updateMember(member.id, inputPrayCardContent, getISOTodayDate());
+      updatedMember = await updateMember(
+        member.id,
+        inputPrayCardContent,
+        getISOTodayDate()
+      );
     }
-    await createPrayCard(groupId, currentUserId, inputPrayCardContent);
+    if (!updatedMember) {
+      setIsDisabledPrayCardCreateBtn(false);
+      return;
+    }
+    const newPrayCard = await createPrayCard(
+      groupId,
+      currentUserId,
+      inputPrayCardContent
+    );
+    if (!newPrayCard) {
+      setIsDisabledPrayCardCreateBtn(false);
+      return;
+    }
     window.location.reload();
   };
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,7 +3,6 @@ import { Auth } from "@supabase/auth-ui-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { supabase } from "../../supabase/client";
-import useAuth from "../hooks/useAuth";
 import { getDomainUrl } from "@/lib/utils";
 import {
   Carousel,
@@ -12,9 +11,11 @@ import {
   CarouselItem,
 } from "@/components/ui/carousel";
 import { Button } from "@/components/ui/button";
+import useBaseStore from "@/stores/baseStore";
 
 const MainPage: React.FC = () => {
-  const { user } = useAuth();
+  const user = useBaseStore((state) => state.user);
+  const userLoading = useBaseStore((state) => state.userLoading);
 
   const [api, setApi] = useState<CarouselApi>();
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -26,6 +27,10 @@ const MainPage: React.FC = () => {
       setCurrentIndex(api.selectedScrollSnap());
     });
   }, [api]);
+
+  if (userLoading) {
+    return null;
+  }
 
   const handleDotsClick = (index: number) => {
     if (!api) return;


### PR DESCRIPTION
### 체크리스트
- [x] 메인페이지에 카카오톡 버튼과 PrayU 시작하기 버튼이 깜빡이면서 노출되는 문제를 해결합니다.
- [x] 멤버 생성(업데이트) - 기도카드 생성 로직이 실패하는 경우를 대비하여 버튼을 통해 재시도 할 수 있도록 처리합니다.

