### PR TITLE
fix: 오늘의 기도 예외처리

### DIFF
--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -4,6 +4,7 @@ import OtherMember from "./OtherMember";
 import MemberInviteCard from "./MemberInviteCard";
 import TodayPrayBtn from "../todayPray/TodayPrayBtn";
 import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
+import { getISOTodayDate } from "@/lib/utils";
 
 interface OtherMembersProps {
   currentUserId: string;
@@ -23,23 +24,28 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   }, [currentUserId, fetchIsPrayToday, groupId]);
 
   if (isPrayToday == null || !memberList) return null;
-  if (memberList.length === 1) return <MemberInviteCard />;
-  if (!isPrayToday) return <TodayPrayStartCard />;
+
+  const otherMemberList = memberList.filter(
+    (member) => member.user_id !== currentUserId
+  );
+  const isExpiredAllMember = otherMemberList.every(
+    (member) => member.updated_at < getISOTodayDate(-6)
+  );
+
+  if (otherMemberList.length === 0) return <MemberInviteCard />;
+  if (!isPrayToday && !isExpiredAllMember) return <TodayPrayStartCard />;
 
   return (
     <div className="flex flex-col gap-2">
       <div className="text-sm text-gray-500 p-2">기도 구성원</div>
       <div className="flex flex-col gap-4">
-        {memberList.map((member) => {
-          if (member.user_id !== currentUserId)
-            return (
-              <OtherMember
-                key={member.id}
-                currentUserId={currentUserId}
-                member={member}
-              ></OtherMember>
-            );
-        })}
+        {otherMemberList.map((member) => (
+          <OtherMember
+            key={member.id}
+            currentUserId={currentUserId}
+            member={member}
+          ></OtherMember>
+        ))}
       </div>
       <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
         <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />


### PR DESCRIPTION
### 기존

모든 멤버의 기도카드가 만료되어도 오늘의기도 노출(오늘의 기도 안한 상태). 막상 들어가면 초대하라고 뜸(오늘의 기도 진행 불가)
<img src="https://github.com/user-attachments/assets/50862a30-b46c-412d-a39c-ac0fd8b6875d" width="300" />


### 변경

모든 맴버의 기도카드가 만료되었을 때는 멤버리스트로 보여줌
<img src="https://github.com/user-attachments/assets/74cc087a-1f33-42de-9141-6a8e2a788122" width="300" />
