### PR TITLE
refactor: OtherMemberDrawer 전역 사용

### DIFF
--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -39,7 +39,7 @@ const GroupBody: React.FC<GroupBodyProps> = ({
   );
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
 
-  const member = useBaseStore((state) => state.targetMember);
+  const member = useBaseStore((state) => state.myMember);
   const memberLoading = useBaseStore((state) => state.memberLoading);
   const getMember = useBaseStore((state) => state.getMember);
 

--- a/src/components/member/MemberInviteCard.tsx
+++ b/src/components/member/MemberInviteCard.tsx
@@ -3,7 +3,7 @@ import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 import OpenShareDrawerBtn from "../share/OpenShareDrawerBtn";
 
 export const MemberInviteCard = () => {
-  const member = useBaseStore((state) => state.targetMember);
+  const myMember = useBaseStore((state) => state.myMember);
 
   const reactionImages = [
     { type: PrayType.PRAY, opacity: "opacity-40" },
@@ -21,7 +21,7 @@ export const MemberInviteCard = () => {
           reaction.profile ? (
             <img
               key={index}
-              src={member?.profiles.avatar_url || ""}
+              src={myMember?.profiles.avatar_url || ""}
               className="w-14 h-14 rounded-full ring-2 ring-[#FFBFBD]/50 drop-shadow-[0_0_10px_rgb(255,148,146,0.8)]"
             />
           ) : (

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -19,7 +19,7 @@ interface MemberProps {
 }
 
 const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
-  const member = useBaseStore((state) => state.targetMember);
+  const member = useBaseStore((state) => state.myMember);
   const getMember = useBaseStore((state) => state.getMember);
   const fetchUserPrayCardListByGroupId = useBaseStore(
     (state) => state.fetchUserPrayCardListByGroupId

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -1,24 +1,18 @@
 import { MemberWithProfiles } from "supabase/types/tables";
 import { getISOOnlyDate, getISOTodayDate } from "../../lib/utils";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
 import { getDateDistance } from "@toss/date";
 import { analyticsTrack } from "@/analytics/analytics";
-import ExpiredPrayCardUI from "../prayCard/ExpiredPrayCardUI";
+import useBaseStore from "@/stores/baseStore";
 
 interface OtherMemberProps {
-  currentUserId: string;
   member: MemberWithProfiles;
 }
 
-const OtherMember: React.FC<OtherMemberProps> = ({ currentUserId, member }) => {
+const OtherMember: React.FC<OtherMemberProps> = ({ member }) => {
+  const setOtherMember = useBaseStore((state) => state.setOtherMember);
+  const setIsOpenOtherMemberDrawer = useBaseStore(
+    (state) => state.setIsOpenOtherMemberDrawer
+  );
   const dateDistance = getDateDistance(
     new Date(getISOOnlyDate(member.updated_at)),
     new Date(getISOTodayDate())
@@ -26,10 +20,15 @@ const OtherMember: React.FC<OtherMemberProps> = ({ currentUserId, member }) => {
 
   const onClickOtherMember = () => {
     analyticsTrack("클릭_멤버_구성원", { member: member.user_id });
+    setOtherMember(member);
+    setIsOpenOtherMemberDrawer(true);
   };
 
-  const memberUI = (
-    <div className="flex flex-col gap-[10px] cursor-pointer bg-white p-5 rounded-2xl shadow-member">
+  return (
+    <div
+      className="flex flex-col gap-[10px] cursor-pointer bg-white p-5 rounded-2xl shadow-member"
+      onClick={() => onClickOtherMember()}
+    >
       <div className="flex items-center gap-2">
         <img
           src={member.profiles.avatar_url || ""}
@@ -44,34 +43,6 @@ const OtherMember: React.FC<OtherMemberProps> = ({ currentUserId, member }) => {
         {dateDistance.days < 1 ? "오늘" : `${dateDistance.days}일 전`}
       </div>
     </div>
-  );
-
-  return (
-    <Drawer>
-      <DrawerTrigger
-        className="focus:outline-none"
-        onClick={() => onClickOtherMember()}
-      >
-        {memberUI}
-      </DrawerTrigger>
-      <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-10 focus:outline-none">
-        <DrawerHeader className="p-2">
-          <DrawerTitle></DrawerTitle>
-          <DrawerDescription></DrawerDescription>
-        </DrawerHeader>
-        {/* PrayCard */}
-        {dateDistance.days > 7 ? (
-          <ExpiredPrayCardUI member={member} />
-        ) : (
-          <OtherPrayCardUI
-            currentUserId={currentUserId}
-            member={member}
-            eventOption={{ where: "OtherMember" }}
-          />
-        )}
-        {/* PrayCard */}
-      </DrawerContent>
-    </Drawer>
   );
 };
 

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -1,3 +1,11 @@
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
 import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
 import OtherMember from "./OtherMember";
@@ -5,6 +13,7 @@ import MemberInviteCard from "./MemberInviteCard";
 import TodayPrayBtn from "../todayPray/TodayPrayBtn";
 import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
 import { getISOTodayDate } from "@/lib/utils";
+import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
 
 interface OtherMembersProps {
   currentUserId: string;
@@ -18,6 +27,12 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const fetchIsPrayToday = useBaseStore((state) => state.fetchIsPrayToday);
   const memberList = useBaseStore((state) => state.memberList);
+  const isOpenOtherMemberDrawer = useBaseStore(
+    (state) => state.isOpenOtherMemberDrawer
+  );
+  const setIsOpenOtherMemberDrawer = useBaseStore(
+    (state) => state.setIsOpenOtherMemberDrawer
+  );
 
   useEffect(() => {
     fetchIsPrayToday(currentUserId, groupId);
@@ -36,21 +51,36 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   if (!isPrayToday && !isExpiredAllMember) return <TodayPrayStartCard />;
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="text-sm text-gray-500 p-2">기도 구성원</div>
-      <div className="flex flex-col gap-4">
-        {otherMemberList.map((member) => (
-          <OtherMember
-            key={member.id}
+    <>
+      <div className="flex flex-col gap-2">
+        <div className="text-sm text-gray-500 p-2">기도 구성원</div>
+        <div className="flex flex-col gap-4">
+          {otherMemberList.map((member) => (
+            <OtherMember key={member.id} member={member}></OtherMember>
+          ))}
+        </div>
+        <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
+          <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />
+        </div>
+      </div>
+      <Drawer
+        open={isOpenOtherMemberDrawer}
+        onOpenChange={setIsOpenOtherMemberDrawer}
+      >
+        <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-10 focus:outline-none">
+          <DrawerHeader className="p-2">
+            <DrawerTitle></DrawerTitle>
+            <DrawerDescription></DrawerDescription>
+          </DrawerHeader>
+          {/* PrayCard */}
+          <OtherPrayCardUI
             currentUserId={currentUserId}
-            member={member}
-          ></OtherMember>
-        ))}
-      </div>
-      <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
-        <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />
-      </div>
-    </div>
+            eventOption={{ where: "OtherMember" }}
+          />
+          {/* PrayCard */}
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 };
 

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -4,7 +4,6 @@ import {
   DrawerDescription,
   DrawerHeader,
   DrawerTitle,
-  DrawerTrigger,
 } from "@/components/ui/drawer";
 import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -1,16 +1,16 @@
-import { MemberWithProfiles } from "supabase/types/tables";
 import { Textarea } from "../ui/textarea";
 import { getDateDistance } from "@toss/date";
 import { getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
 import { KakaoShareButton } from "../share/KakaoShareBtn";
+import useBaseStore from "@/stores/baseStore";
 
-interface ExpiredPrayCardProps {
-  member: MemberWithProfiles;
-}
+const ExpiredPrayCardUI: React.FC = () => {
+  const otherMember = useBaseStore((state) => state.otherMember);
 
-const ExpiredPrayCardUI: React.FC<ExpiredPrayCardProps> = ({ member }) => {
+  if (!otherMember) return null;
+
   const dateDistance = getDateDistance(
-    new Date(getISOOnlyDate(member.updated_at)),
+    new Date(getISOOnlyDate(otherMember.updated_at)),
     new Date(getISOTodayDate())
   );
 
@@ -20,19 +20,21 @@ const ExpiredPrayCardUI: React.FC<ExpiredPrayCardProps> = ({ member }) => {
         <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 rounded-t-2xl p-5">
           <div className="flex items-center gap-2">
             <img
-              src={member.profiles.avatar_url || ""}
+              src={otherMember.profiles.avatar_url || ""}
               className="w-7 h-7 rounded-full"
             />
-            <p className="text-white text-lg">{member?.profiles.full_name}</p>
+            <p className="text-white text-lg">
+              {otherMember.profiles.full_name}
+            </p>
           </div>
           <p className="text-sm text-white w-full text-left">
-            시작일 : {member.updated_at.split("T")[0]}
+            시작일 : {otherMember.updated_at.split("T")[0]}
           </p>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
           <Textarea
             className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={member.pray_summary || ""}
+            value={otherMember.pray_summary || ""}
             disabled={true}
           />
         </div>

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
-import { MemberWithProfiles } from "supabase/types/tables";
 import { ClipLoader } from "react-spinners";
 import ReactionWithCalendar from "./ReactionWithCalendar";
 import { Textarea } from "../ui/textarea";
+import { getISOTodayDate } from "@/lib/utils";
+import ExpiredPrayCardUI from "./ExpiredPrayCardUI";
 
 interface EventOption {
   where: string;
@@ -11,27 +12,26 @@ interface EventOption {
 
 interface OtherPrayCardProps {
   currentUserId: string;
-  member: MemberWithProfiles;
   eventOption: EventOption;
 }
 
 const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
   currentUserId,
-  member,
   eventOption,
 }) => {
   const otherPrayCardList = useBaseStore((state) => state.otherPrayCardList);
   const fetchOtherPrayCardListByGroupId = useBaseStore(
     (state) => state.fetchOtherPrayCardListByGroupId
   );
+  const otherMember = useBaseStore((state) => state.otherMember);
 
   useEffect(() => {
     fetchOtherPrayCardListByGroupId(
       currentUserId,
-      member.user_id!,
-      member.group_id!
+      otherMember!.user_id!,
+      otherMember!.group_id!
     );
-  }, [fetchOtherPrayCardListByGroupId, currentUserId, member]);
+  }, [fetchOtherPrayCardListByGroupId, currentUserId, otherMember]);
 
   if (!otherPrayCardList) {
     return (
@@ -47,8 +47,9 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
   }
 
   const prayCard = otherPrayCardList[0];
+  const isExpiredOtherMember = otherMember!.updated_at < getISOTodayDate(-6);
 
-  return (
+  const PrayCardUI = () => (
     <div className="flex flex-col gap-6 min-h-[80vh] max-h-[80vh]">
       <div className="flex flex-col flex-grow min-h-full max-h-full bg-white rounded-2xl shadow-prayCard">
         <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start/60 via-middle/60 via-30% to-end/60 rounded-t-2xl p-5">
@@ -74,6 +75,8 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
       <ReactionWithCalendar prayCard={prayCard} eventOption={eventOption} />
     </div>
   );
+
+  return isExpiredOtherMember ? <ExpiredPrayCardUI /> : <PrayCardUI />;
 };
 
 export default OtherPrayCardUI;

--- a/src/components/todayPray/TodayPrayStartCard.tsx
+++ b/src/components/todayPray/TodayPrayStartCard.tsx
@@ -3,7 +3,7 @@ import TodayPrayBtn from "./TodayPrayBtn";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
 
 export const TodayPrayStartCard = () => {
-  const member = useBaseStore((state) => state.targetMember);
+  const member = useBaseStore((state) => state.myMember);
 
   const reactionImages = [
     { type: PrayType.PRAY, opacity: "opacity-40" },

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -355,9 +355,6 @@ const useBaseStore = create<BaseStore>()(
       startDt: string,
       endDt: string
     ) => {
-      set((state) => {
-        state.groupPrayCardList = [];
-      });
       const groupPrayCardList = await fetchGroupPrayCardList(
         groupId,
         currentUserId,
@@ -388,10 +385,6 @@ const useBaseStore = create<BaseStore>()(
       userId: string,
       groupId: string
     ) => {
-      set((state) => {
-        state.otherPrayCardList = [];
-      });
-
       const otherPrayCardList = await fetchOtherPrayCardListByGroupId(
         currentUserId,
         userId,

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -69,7 +69,7 @@ export interface BaseStore {
   // member
   memberList: MemberWithProfiles[] | null;
   memberLoading: boolean;
-  targetMember: MemberWithProfiles | null;
+  myMember: MemberWithProfiles | null;
   fetchMemberListByGroupId: (groupId: string) => Promise<void>;
   createMember: (
     groupId: string,
@@ -270,7 +270,7 @@ const useBaseStore = create<BaseStore>()(
     //member
     memberList: null,
     memberLoading: true,
-    targetMember: null,
+    myMember: null,
     fetchMemberListByGroupId: async (groupId: string) => {
       const memberList = await fetchMemberListByGroupId(groupId);
       set((state) => {
@@ -297,7 +297,7 @@ const useBaseStore = create<BaseStore>()(
     getMember: async (userId: string, groupId: string) => {
       const member = await getMember(userId, groupId);
       set((state) => {
-        state.targetMember = member;
+        state.myMember = member;
         state.memberLoading = false;
       });
       return member;

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -70,6 +70,9 @@ export interface BaseStore {
   memberList: MemberWithProfiles[] | null;
   memberLoading: boolean;
   myMember: MemberWithProfiles | null;
+  otherMember: MemberWithProfiles | null;
+  isOpenOtherMemberDrawer: boolean;
+  setIsOpenOtherMemberDrawer: (isOpenOtherMemberDrawer: boolean) => void;
   fetchMemberListByGroupId: (groupId: string) => Promise<void>;
   createMember: (
     groupId: string,
@@ -85,6 +88,7 @@ export interface BaseStore {
     userId: string,
     groupId: string
   ) => Promise<MemberWithProfiles | null>;
+  setOtherMember: (member: MemberWithProfiles) => void;
   isOpenMyMemberDrawer: boolean;
   setIsOpenMyMemberDrawer: (isOpenMyMemberDrawer: boolean) => void;
   deleteMemberbyGroupId: (
@@ -271,6 +275,13 @@ const useBaseStore = create<BaseStore>()(
     memberList: null,
     memberLoading: true,
     myMember: null,
+    otherMember: null,
+    isOpenOtherMemberDrawer: false,
+    setIsOpenOtherMemberDrawer: (isOpenOtherMemberDrawer: boolean) => {
+      set((state) => {
+        state.isOpenOtherMemberDrawer = isOpenOtherMemberDrawer;
+      });
+    },
     fetchMemberListByGroupId: async (groupId: string) => {
       const memberList = await fetchMemberListByGroupId(groupId);
       set((state) => {
@@ -301,6 +312,11 @@ const useBaseStore = create<BaseStore>()(
         state.memberLoading = false;
       });
       return member;
+    },
+    setOtherMember: (member: MemberWithProfiles) => {
+      set((state) => {
+        state.otherMember = member;
+      });
     },
     isOpenMyMemberDrawer: false,
     setIsOpenMyMemberDrawer: (isOpenMyMemberDrawer: boolean) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b86febe5-c63a-40c4-8f4e-c2df3719ab5f)


### 작업 설명

OtherMember에 Drawer 가 포함되어 있어서 Member 수만큼 Drawer 가 생성되고 있던 부분을 수정합니다.
OtherMemberList 에서  Drawer 를 생성하고 OtherMember 가 클릭될 때 올라오도록 합니다.
클릭 될 때 otherMember 전역변수를 바꿔주면서 내부 컨텐츠가 동적으로 변하도록합니다.

### 체크리스트

- [x]  OtherMember 내에 있는 Drawer 를 OtherMemberList 로 빼기
- [x]  OtherMember 가 클릭 될 때 otherMember 전역변수 업데이트
- [x]  OtherMemberList 내에 있는 Drawer 가 otherMember 전역변수를 사용하도록 하기

### 테스트
- [x] MemberList 뷰 확인
- [x] 기도카드 디테일 확인
- [x] TodayPrayCardList 확인
- [x] 만료된 기도카드 확인

https://www.notion.so/mmyeong/refactor-otherMember-Drawer-c84f85dd01a64cafae6b717b7e3a30ad?pvs=4

