### PR TITLE
hotfix: 그룹명 길이 제한

### DIFF
--- a/src/components/pray/PrayListDrawer.tsx
+++ b/src/components/pray/PrayListDrawer.tsx
@@ -27,7 +27,7 @@ const PrayListDrawer: React.FC<PrayListDrawerProps> = ({
   if (!userPrayCardList) {
     return (
       <div className="flex justify-center items-center h-screen">
-        <ClipLoader size={50} color={"#123abc"} loading={true} />
+        <ClipLoader size={20} color={"#70AAFF"} loading={true} />
       </div>
     );
   }

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -60,17 +60,7 @@ const GroupCreatePage: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-6 items-center">
-      <div className="text-lg font-bold">
-        PrayU 그룹{" "}
-        <button
-          onClick={() => {
-            throw new Error("버그 테스트");
-          }}
-        >
-          만들기
-        </button>
-      </div>
-
+      <div className="text-lg font-bold">PrayU 그룹 만들기</div>
       <div className="flex justify-center h-[300px] w-max">
         <img
           className="h-full object-cover"
@@ -83,7 +73,7 @@ const GroupCreatePage: React.FC = () => {
           value={inputGroupName}
           onChange={(e) => setGroupName(e.target.value)}
           placeholder="그룹 이름을 입력해 주세요"
-          maxLength={15}
+          maxLength={12}
         />
         <Button
           onClick={() => handleCreateGroup(user!.id, inputGroupName)}

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -67,11 +67,11 @@ const GroupPage: React.FC = () => {
           type="tag"
         />
 
-        <div className="absolute left-1/2 transform -translate-x-1/2 flex justify-center items-center gap-1">
-          <div className="text-lg font-bold flex items-center gap-1">
+        <div className="text-lg font-bold flex items-center gap-1">
+          <div className="max-w-52 whitespace-nowrap overflow-hidden text-ellipsis">
             {targetGroup.name}
-            <span className="text-sm text-gray-500">{memberList.length}</span>
           </div>
+          <span className="text-sm text-gray-500">{memberList.length}</span>
         </div>
 
         <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />


### PR DESCRIPTION
<img width="413" alt="image" src="https://github.com/user-attachments/assets/88893ab1-e299-413d-a67f-3dde18125da8">

그룹명 길이를 12자로 제한하고 깨지는 부분 수정합니다.