### PR TITLE
fix: Drawer backwardKey 이슈

### DIFF
--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -41,6 +41,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   );
 
   const onClickMyMemberReaction = (event: { stopPropagation: () => void }) => {
+    window.history.pushState(null, "", window.location.pathname);
     setIsOpenMyPrayDrawer(true);
     event.stopPropagation();
     analyticsTrack("클릭_기도카드_반응결과", {
@@ -105,6 +106,8 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
   );
 
   const onClickMyMember = () => {
+    window.history.pushState(null, "", window.location.pathname);
+    setIsOpenMyMemberDrawer(true);
     analyticsTrack("클릭_멤버_본인", {
       group_id: groupId,
       where: "MyMember",
@@ -121,7 +124,7 @@ const MyMember: React.FC<MemberProps> = ({ currentUserId, groupId }) => {
           className="focus:outline-none"
           onClick={() => onClickMyMember()}
         >
-          <div className="flex flex-col items-start gap-2">{MyMemberUI}</div>
+          {MyMemberUI}
         </DrawerTrigger>
 
         <DrawerContent className="bg-mainBg max-w-[480px] mx-auto w-full px-10 pb-20 focus:outline-none">

--- a/src/components/member/MyMemberBtn.tsx
+++ b/src/components/member/MyMemberBtn.tsx
@@ -11,6 +11,7 @@ const MyMemberBtn: React.FC = () => {
   );
 
   const onClickMyMemberBtn = () => {
+    window.history.pushState(null, "", window.location.pathname);
     setIsOpenTodayPrayDrawer(false);
     setIsOpenMyMemberDrawer(true);
     analyticsTrack("클릭_멤버_본인", { where: "PrayCardList" });

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -19,6 +19,7 @@ const OtherMember: React.FC<OtherMemberProps> = ({ member }) => {
   );
 
   const onClickOtherMember = () => {
+    window.history.pushState(null, "", window.location.pathname);
     analyticsTrack("클릭_멤버_구성원", { member: member.user_id });
     setOtherMember(member);
     setIsOpenOtherMemberDrawer(true);

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -35,7 +35,9 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
   const lenPrayerList = Object.keys(prayerList).length;
   const isPrayerListEmpty = !prayerList || lenPrayerList === 0;
 
+  // TODO: TodayPrayBtn 으로 통일하기
   const onClickTodayPrayBtn = () => {
+    window.history.pushState(null, "", window.location.pathname);
     setIsOpenMyPrayDrawer(false);
     setIsOpenMyMemberDrawer(false);
     setIsOpenTodayPrayDrawer(true);

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -49,6 +49,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({
   const [isDivVisible, setIsDivVisible] = useState(true);
 
   const onClickPrayerList = () => {
+    window.history.pushState(null, "", window.location.pathname);
     setIsOpenMyPrayDrawer(true);
     analyticsTrack("클릭_기도카드_반응결과", { where: "MyPrayCard" });
   };

--- a/src/components/prayCard/ReactionBtn.tsx
+++ b/src/components/prayCard/ReactionBtn.tsx
@@ -24,9 +24,6 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   const prayCardCarouselApi = useBaseStore(
     (state) => state.prayCardCarouselApi
   );
-  const setIsOpenTodayPrayDrawer = useBaseStore(
-    (state) => state.setIsOpenTodayPrayDrawer
-  );
 
   const createPray = useBaseStore((state) => state.createPray);
   const updatePray = useBaseStore((state) => state.updatePray);
@@ -35,27 +32,20 @@ const ReactionBtn: React.FC<ReactionBtnProps> = ({
   const hasPrayed = Boolean(todayPrayTypeHash[prayCard.id]);
 
   const handleClick = (prayType: PrayType) => () => {
+    if (!isPrayToday) setIsPrayToday(true);
+
     if (!hasPrayed) createPray(prayCard.id, currentUserId, prayType);
     else updatePray(prayCard.id, currentUserId, prayType);
 
-    if (!isPrayToday) setIsPrayToday(true);
+    if (prayCardCarouselApi) {
+      sleep(500).then(() => {
+        prayCardCarouselApi.scrollNext();
+      });
+    }
     analyticsTrack("클릭_기도카드_반응", {
       pray_type: prayType,
       where: eventOption.where,
     });
-    if (prayCardCarouselApi) {
-      sleep(500).then(() => {
-        if (
-          prayCardCarouselApi.selectedScrollSnap() ==
-          prayCardCarouselApi.scrollSnapList().length - 2
-        ) {
-          setIsOpenTodayPrayDrawer(false);
-          return null;
-        } else {
-          prayCardCarouselApi.scrollNext();
-        }
-      });
-    }
   };
 
   return (

--- a/src/components/share/OpenContentDrawerBtn.tsx
+++ b/src/components/share/OpenContentDrawerBtn.tsx
@@ -10,6 +10,7 @@ const OpenContentDrawerBtn: React.FC = () => {
     (state) => state.setIsOpenTodayPrayDrawer
   );
   const onClickOpenContentDrawerBtn = () => {
+    window.history.pushState(null, "", window.location.pathname);
     setIsOpenTodayPrayDrawer(false);
     setIsOpenContentDrawer(true);
     analyticsTrack("클릭_컨텐츠_오늘의말씀", {

--- a/src/components/share/OpenShareDrawerBtn.tsx
+++ b/src/components/share/OpenShareDrawerBtn.tsx
@@ -22,8 +22,8 @@ const OpenShareDrawerBtn: React.FC<OpenShareDrawerBtnProps> = ({
     (state) => state.setIsOpenShareDrawer
   );
   const handleClickSharBtn = () => {
-    setIsOpenShareDrawer(true);
     window.history.pushState("", "", window.location.pathname);
+    setIsOpenShareDrawer(true);
     analyticsTrack("클릭_공유_그룹초대", { where: eventOption.where });
   };
 
@@ -31,7 +31,7 @@ const OpenShareDrawerBtn: React.FC<OpenShareDrawerBtnProps> = ({
     return (
       <Button
         variant="primary"
-        className="w-[166px] h-[48px] text-md font-bold rounded-[10px]"
+        className="w-[166px] h-[48px] text-md font-bold rounded-[10px] cursor-pointer"
         onClick={() => handleClickSharBtn()}
       >
         {text}
@@ -40,7 +40,7 @@ const OpenShareDrawerBtn: React.FC<OpenShareDrawerBtnProps> = ({
   if (type == "tag")
     return (
       <div
-        className="flex items-center gap-1 text-[12px]"
+        className="flex items-center gap-1 text-[12px] cursor-pointer"
         onClick={() => handleClickSharBtn()}
       >
         <img src={inviteIcon} className="w-[10px] h-[10px]" />

--- a/src/components/share/OpenShareDrawerBtn.tsx
+++ b/src/components/share/OpenShareDrawerBtn.tsx
@@ -23,8 +23,10 @@ const OpenShareDrawerBtn: React.FC<OpenShareDrawerBtnProps> = ({
   );
   const handleClickSharBtn = () => {
     setIsOpenShareDrawer(true);
+    window.history.pushState("", "", window.location.pathname);
     analyticsTrack("클릭_공유_그룹초대", { where: eventOption.where });
   };
+
   if (type == "button")
     return (
       <Button

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -53,17 +53,6 @@ const ShareDrawer: React.FC = () => {
     });
   }, [api]);
 
-  useEffect(() => {
-    const handlePopState = () => {
-      setIsOpenShareDrawer(false);
-    };
-
-    window.addEventListener("popstate", handlePopState);
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
-  }, [isOpenShareDrawer, setIsOpenShareDrawer]);
-
   const handleDotsClick = (index: number) => {
     if (!api) return;
     setCurrentIndex(index);

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -53,6 +53,17 @@ const ShareDrawer: React.FC = () => {
     });
   }, [api]);
 
+  useEffect(() => {
+    const handlePopState = () => {
+      setIsOpenShareDrawer(false);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [isOpenShareDrawer, setIsOpenShareDrawer]);
+
   const handleDotsClick = (index: number) => {
     if (!api) return;
     setCurrentIndex(index);

--- a/src/components/todayPray/TodayPrayBtn.tsx
+++ b/src/components/todayPray/TodayPrayBtn.tsx
@@ -14,6 +14,7 @@ const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ eventOption }) => {
     (state) => state.setIsOpenTodayPrayDrawer
   );
   const onClickTodayPrayBtn = () => {
+    window.history.pushState(null, "", window.location.pathname);
     setIsOpenTodayPrayDrawer(true);
     analyticsTrack("클릭_오늘의기도_시작", { where: eventOption.where });
   };

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -13,9 +13,12 @@ const Drawer = ({
     const handlePopState = () => {
       if (onOpenChange) onOpenChange(false);
     };
+
     window.addEventListener("popstate", handlePopState);
     return () => {
       window.removeEventListener("popstate", handlePopState);
+      const controller = new AbortController();
+      controller.abort();
     };
   }, [onOpenChange]);
   // Drawer Custom End

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -3,6 +3,8 @@ import { Drawer as DrawerPrimitive } from "vaul";
 import { cn } from "@/lib/utils";
 import { useEffect } from "react";
 
+const controller = new AbortController();
+
 const Drawer = ({
   shouldScaleBackground = true,
   ...props
@@ -12,13 +14,12 @@ const Drawer = ({
   useEffect(() => {
     const handlePopState = () => {
       if (onOpenChange) onOpenChange(false);
+      controller.abort();
     };
 
     window.addEventListener("popstate", handlePopState);
     return () => {
       window.removeEventListener("popstate", handlePopState);
-      const controller = new AbortController();
-      controller.abort();
     };
   }, [onOpenChange]);
   // Drawer Custom End

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -3,8 +3,6 @@ import { Drawer as DrawerPrimitive } from "vaul";
 import { cn } from "@/lib/utils";
 import { useEffect } from "react";
 
-const controller = new AbortController();
-
 const Drawer = ({
   shouldScaleBackground = true,
   ...props
@@ -14,7 +12,7 @@ const Drawer = ({
   useEffect(() => {
     const handlePopState = () => {
       if (onOpenChange) onOpenChange(false);
-      controller.abort();
+      window.stop();
     };
 
     window.addEventListener("popstate", handlePopState);

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,18 +1,32 @@
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
-
 import { cn } from "@/lib/utils";
+import { useEffect } from "react";
 
 const Drawer = ({
   shouldScaleBackground = true,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
-  <DrawerPrimitive.Root
-    shouldScaleBackground={shouldScaleBackground}
-    {...props}
-  />
-);
-Drawer.displayName = "Drawer";
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => {
+  // Drawer Custom Start
+  const { onOpenChange } = props;
+  useEffect(() => {
+    const handlePopState = () => {
+      if (onOpenChange) onOpenChange(false);
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [onOpenChange]);
+  // Drawer Custom End
+
+  return (
+    <DrawerPrimitive.Root
+      shouldScaleBackground={shouldScaleBackground}
+      {...props}
+    />
+  );
+};
 
 const DrawerTrigger = DrawerPrimitive.Trigger;
 


### PR DESCRIPTION
history.pushState 를 통해 안드로이드 백키 문제를 해결합니다.

### 체크리스트
- [x] shadcn drawer 컴포넌트에서 popstate 이벤트 헨들링
- [x] drawer open 하는 onclick 함수에 history.pushState 를 통해 더미 URL 추가

### 해결 방법
`드로워 오픈 때`
-> history.pushState 를 통해 url 히스토리에 더미 URL(그룹 페이지 URL) 추가
`뒤로가기 버튼 클릭시 `
-> Draw 내에서 popstate 이벤트 헨들링을 통해 드로워 닫기 ( 기본 뒤로가기는 진행되나 더미 URL 에서 기본 URL 로 돌아가는 식으로 동작)
`스와이프나 딤배경 클릭하여 드로워 닫을 때`
 -> 더미 URL 남은 채로 서비스 이용 ( 오히려 서비스 이탈을 막을 수 있음 )