### PR TITLE
fix: 카톡 프사 비율 수정 + 캐러셀 온보딩 잘 보이게

### DIFF
--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -143,7 +143,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
 
           <hr />
           <a href="/" onClick={() => analyticsTrack("클릭_공유_도메인", {})}>
-            PrayU 공유하기
+            PrayU 홈
           </a>
           <a
             href={`${import.meta.env.VITE_PRAY_KAKAO_CHANNEL_CHAT_URL}`}

--- a/src/components/member/MemberInviteCard.tsx
+++ b/src/components/member/MemberInviteCard.tsx
@@ -22,7 +22,7 @@ export const MemberInviteCard = () => {
             <img
               key={index}
               src={myMember?.profiles.avatar_url || ""}
-              className="w-14 h-14 rounded-full ring-2 ring-[#FFBFBD]/50 drop-shadow-[0_0_10px_rgb(255,148,146,0.8)]"
+              className="w-14 h-14 rounded-full ring-2 ring-[#FFBFBD]/50 drop-shadow-[0_0_10px_rgb(255,148,146,0.8)] object-cover"
             />
           ) : (
             <img

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -33,7 +33,7 @@ const OtherMember: React.FC<OtherMemberProps> = ({ member }) => {
       <div className="flex items-center gap-2">
         <img
           src={member.profiles.avatar_url || ""}
-          className="w-8 h-8 rounded-full"
+          className="w-8 h-8 rounded-full object-cover"
         />
         <h3>{member.profiles.full_name}</h3>
       </div>

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -84,7 +84,7 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
               >
                 <div className="flex items-center gap-2">
                   <img
-                    className="w-8 h-8 rounded-full border"
+                    className="w-8 h-8 rounded-full border object-cover"
                     src={prayerList[user_id][0].profiles.avatar_url ?? ""}
                     alt={`${prayerList[user_id][0].profiles.full_name} avatar`}
                   />

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -24,7 +24,7 @@ const ExpiredPrayCardUI: React.FC = () => {
           <div className="flex items-center gap-2">
             <img
               src={otherMember.profiles.avatar_url || ""}
-              className="w-7 h-7 rounded-full"
+              className="w-7 h-7 rounded-full object-cover"
             />
             <p className="text-white text-lg">
               {otherMember.profiles.full_name}

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -57,7 +57,7 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
           <div className="flex items-center gap-2">
             <img
               src={prayCard.profiles.avatar_url || ""}
-              className="w-7 h-7 rounded-full"
+              className="w-7 h-7 rounded-full object-cover"
             />
             <p className="text-white text-lg">{prayCard.profiles.full_name}</p>
           </div>

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -60,14 +60,14 @@ const ShareDrawer: React.FC = () => {
   };
 
   const CarouselDots = () => (
-    <div className="flex justify-center items-center mt-4">
+    <div className="flex justify-center items-center mt-6">
       {Array.from({ length: 2 }, (_, index) => (
         <span
           key={index}
           className={` mx-1 rounded-full cursor-pointer transition-colors duration-300 ${
             currentIndex === index
-              ? "w-[6px] h-[6px] bg-mainBtn"
-              : "h-[4px] w-[4px] bg-gray-300"
+              ? "w-[8px] h-[8px] bg-mainBtn"
+              : "h-[6px] w-[6px] bg-gray-400"
           }`}
           onClick={() => handleDotsClick(index)}
         ></span>

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -61,7 +61,7 @@ const ShareDrawer: React.FC = () => {
 
   const CarouselDots = () => (
     <div className="flex justify-center items-center mt-4">
-      {Array.from({ length: 3 }, (_, index) => (
+      {Array.from({ length: 2 }, (_, index) => (
         <span
           key={index}
           className={` mx-1 rounded-full cursor-pointer transition-colors duration-300 ${
@@ -78,7 +78,7 @@ const ShareDrawer: React.FC = () => {
   const ImageCerousel = (
     <Carousel setApi={setApi}>
       <CarouselContent>
-        <CarouselItem className="flex flex-col items-center gap-4">
+        {/* <CarouselItem className="flex flex-col items-center gap-4">
           <div className="h-[200px]  flex flex-col  items-center ">
             <img className="h-full" src="/images/intro_square.png" />
           </div>
@@ -88,6 +88,23 @@ const ShareDrawer: React.FC = () => {
               <p className="text-sm text-gray-500">그룹원들과 함께</p>
               <p className="text-sm text-gray-500">
                 오늘의 기도를 진행해 보아요
+              </p>
+            </div>
+          </div>
+        </CarouselItem> */}
+        <CarouselItem className="flex flex-col items-center gap-4">
+          <div className="h-[200px] flex flex-col  items-center">
+            <img
+              className="h-full rounded-md shadow-prayCard"
+              src="/images/KakaoNotification.png"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <p className="text-base font-bold">그룹 링크 공지</p>
+            <div>
+              <p className="text-sm text-gray-500">링크를 공지에 등록하고</p>
+              <p className="text-sm text-gray-500">
+                채팅방에서 편하게 접근해요
               </p>
             </div>
           </div>
@@ -105,23 +122,6 @@ const ShareDrawer: React.FC = () => {
               <p className="text-sm text-gray-500">카카오톡 초대하기를 통해</p>
               <p className="text-sm text-gray-500">
                 그룹 입장 카드를 전송할 수 있어요
-              </p>
-            </div>
-          </div>
-        </CarouselItem>
-        <CarouselItem className="flex flex-col items-center gap-4">
-          <div className="h-[200px] flex flex-col  items-center">
-            <img
-              className="h-full rounded-md shadow-prayCard"
-              src="/images/KakaoNotification.png"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <p className="text-base font-bold">그룹 링크 공지</p>
-            <div>
-              <p className="text-sm text-gray-500">링크를 공지에 등록하고</p>
-              <p className="text-sm text-gray-500">
-                채팅방에서 편하게 접근해요
               </p>
             </div>
           </div>

--- a/src/components/todayPray/TodayPrayCardUI.tsx
+++ b/src/components/todayPray/TodayPrayCardUI.tsx
@@ -23,7 +23,7 @@ const PrayCardUI: React.FC<PrayCardProps> = ({ prayCard, eventOption }) => {
           <div className="flex items-center gap-2">
             <img
               src={prayCard.profiles.avatar_url || ""}
-              className="w-7 h-7 rounded-full"
+              className="w-7 h-7 rounded-full object-cover"
             />
             <p className="text-white text-lg">{prayCard.profiles.full_name}</p>
           </div>

--- a/src/components/todayPray/TodayPrayStartCard.tsx
+++ b/src/components/todayPray/TodayPrayStartCard.tsx
@@ -23,7 +23,7 @@ export const TodayPrayStartCard = () => {
             <img
               key={index}
               src={member?.profiles.avatar_url || ""}
-              className="w-14 h-14 rounded-full ring-2 ring-[#FFBFBD]/50 drop-shadow-[0_0_10px_rgb(255,148,146,0.8)]"
+              className="w-14 h-14 rounded-full ring-2 ring-[#FFBFBD]/50 drop-shadow-[0_0_10px_rgb(255,148,146,0.8)] object-cover"
             />
           ) : (
             <img

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -39,14 +39,14 @@ const MainPage: React.FC = () => {
   };
 
   const CarouselDots = () => (
-    <div className="flex justify-center items-center mt-4">
+    <div className="flex justify-center items-center mt-6">
       {Array.from({ length: 4 }, (_, index) => (
         <span
           key={index}
           className={` mx-1 rounded-full cursor-pointer transition-colors duration-300 ${
             currentIndex === index
-              ? "w-[6px] h-[6px] bg-mainBtn"
-              : "h-[4px] w-[4px] bg-gray-300"
+              ? "w-[8px] h-[8px] bg-mainBtn"
+              : "h-[6px] w-[6px] bg-gray-400"
           }`}
           onClick={() => handleDotsClick(index)}
         ></span>


### PR DESCRIPTION
# Result
![image](https://github.com/user-attachments/assets/0126d829-55ac-4959-b979-b12593e66a0f)
![image](https://github.com/user-attachments/assets/155052ca-a9f0-488c-971b-88f136e4da3f)


# Done
- [x]  img 태그에서 shadcn avatar 컴포넌트 사용해보기 → 똑같음!
- [x]  초대 드로워 사진 수정
- [x]  “PrayU 공유하기” 이게 뭔지 모르겠다.
    - [x]  PrayU vs 홈 화면
- [x]  그룹 링크 공지 걸어놓는거를 잘 모르는것 같아서 바로 알려주기
- [x]  캐러셀이 잘보이도록 크기 확대 + 색상 좀 더 진하게

https://www.notion.so/mmyeong/fix-ea072dfaac1542649152187220b5cb7d?pvs=4
