### PR TITLE
reafactor: 카카오 공유시 그룹명 추가

### DIFF
--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -10,7 +10,6 @@ import { KakaoShareButton } from "../share/KakaoShareBtn";
 import { PrayWithProfiles } from "supabase/types/tables";
 import { Button } from "../ui/button";
 import { analyticsTrack } from "@/analytics/analytics";
-import { getDomainUrl } from "@/lib/utils";
 
 interface PrayListProps {
   prayData: PrayWithProfiles[];

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -10,12 +10,14 @@ import { KakaoShareButton } from "../share/KakaoShareBtn";
 import { PrayWithProfiles } from "supabase/types/tables";
 import { Button } from "../ui/button";
 import { analyticsTrack } from "@/analytics/analytics";
+import { getDomainUrl } from "@/lib/utils";
 
 interface PrayListProps {
   prayData: PrayWithProfiles[];
 }
 
 const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
+  const targetGroup = useBaseStore((state) => state.targetGroup);
   const setIsOpenMyPrayDrawer = useBaseStore(
     (state) => state.setIsOpenMyPrayDrawer
   );
@@ -67,7 +69,7 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
               <p>그룹 채팅방에 오늘의 기도 링크를 공유해 보아요</p>
             </div>
             <KakaoShareButton
-              groupPageUrl={window.location.href}
+              targetGroup={targetGroup}
               message="카카오톡 링크 공유"
               id="prayList"
               eventOption={{ where: "PrayList" }}

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -5,6 +5,7 @@ import { KakaoShareButton } from "../share/KakaoShareBtn";
 import useBaseStore from "@/stores/baseStore";
 
 const ExpiredPrayCardUI: React.FC = () => {
+  const targetGroup = useBaseStore((state) => state.targetGroup);
   const otherMember = useBaseStore((state) => state.otherMember);
 
   if (!otherMember) return null;
@@ -52,7 +53,7 @@ const ExpiredPrayCardUI: React.FC = () => {
         </div>
 
         <KakaoShareButton
-          groupPageUrl={window.location.href}
+          targetGroup={targetGroup}
           message="카카오톡으로 요청하기"
           id="prayCardUIToOther"
           eventOption={{ where: "ReactionWithCalendar" }}

--- a/src/components/share/ContentDrawer.tsx
+++ b/src/components/share/ContentDrawer.tsx
@@ -37,7 +37,7 @@ const ContentDrawer = () => {
         />
       </div>
       <KakaoShareButton
-        groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
+        targetGroup={targetGroup}
         id="ContentDrawer"
         message="카카오톡으로 공유하기"
         eventOption={{ where: "ContentDrawer" }}

--- a/src/components/share/ContentDrawer.tsx
+++ b/src/components/share/ContentDrawer.tsx
@@ -7,7 +7,7 @@ import {
   DrawerTitle,
 } from "../ui/drawer";
 import { KakaoShareButton } from "./KakaoShareBtn";
-import { getDomainUrl, getISOTodayDateYMD } from "@/lib/utils";
+import { getISOTodayDateYMD } from "@/lib/utils";
 
 const ContentDrawer = () => {
   const targetGroup = useBaseStore((state) => state.targetGroup);
@@ -19,7 +19,6 @@ const ContentDrawer = () => {
   );
   const today = getISOTodayDateYMD();
   const contentNumber = parseInt(today.day, 10) % 10;
-  const domainUrl = getDomainUrl();
 
   const DrawerBody = (
     <div className="h-[80vh] flex flex-col items-center gap-6">

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -63,7 +63,7 @@ const getContent = (groupName: string, type: string) => {
     default:
       return {
         title: `PrayU - ${groupName}`,
-        description: "우리만의 기도제목 나눔 공간\nPrayU에서 함께 기도해요!",
+        description: "우리만의 기도제목 나눔 공간\nPrayU에서 함께 기도해요🙏",
         imageUrl:
           "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/introImage.png",
       };
@@ -77,7 +77,7 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
   type = "default",
   eventOption,
 }) => {
-  const groupUrl = `${getDomainUrl()}/${targetGroup!.id}`;
+  const groupUrl = `${getDomainUrl()}/group/${targetGroup!.id}`;
   useEffect(() => {
     const script = document.createElement("script");
     script.src = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js";

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -1,6 +1,7 @@
 import { analyticsTrack } from "@/analytics/analytics";
-import { getISOTodayDateYMD } from "@/lib/utils";
+import { getDomainUrl, getISOTodayDateYMD } from "@/lib/utils";
 import { useEffect, useRef } from "react";
+import { Group } from "supabase/types/tables";
 declare global {
   interface Window {
     Kakao: Kakao;
@@ -42,19 +43,17 @@ interface EventOption {
 }
 
 interface KakaoShareButtonProps {
-  groupPageUrl: string;
-  message?: string;
+  targetGroup: Group | null;
+  message: string;
   id: string;
-  img?: string;
   eventOption: EventOption;
   type?: string;
 }
 
-const today = getISOTodayDateYMD();
-const contentNumber = parseInt(today.day, 10) % 10;
-
-const getContentByOption = (option?: string) => {
-  switch (option) {
+const getContent = (groupName: string, type: string) => {
+  const today = getISOTodayDateYMD();
+  const contentNumber = parseInt(today.day, 10) % 10;
+  switch (type) {
     case "bible":
       return {
         title: `${today.year}.${today.month}.${today.day} 오늘의 말씀`,
@@ -63,8 +62,8 @@ const getContentByOption = (option?: string) => {
       };
     default:
       return {
-        title: "PrayU",
-        description: "우리만의 기도제목 나눔 공간",
+        title: `PrayU - ${groupName}`,
+        description: "우리만의 기도제목 나눔 공간\nPrayU에서 함께 기도해요!",
         imageUrl:
           "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/introImage.png",
       };
@@ -72,13 +71,13 @@ const getContentByOption = (option?: string) => {
 };
 
 export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
-  groupPageUrl,
-  message,
+  targetGroup,
   id,
-  img,
+  message,
+  type = "default",
   eventOption,
-  type,
 }) => {
+  const groupUrl = `${getDomainUrl()}/${targetGroup!.id}`;
   useEffect(() => {
     const script = document.createElement("script");
     script.src = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js";
@@ -91,7 +90,7 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
       if (!window.Kakao.isInitialized()) {
         window.Kakao.init(`${import.meta.env.VITE_KAKAO_JS_KEY}`);
       }
-      const content = getContentByOption(type);
+      const content = getContent(targetGroup!.name!, type);
       window.Kakao.Share.createDefaultButton({
         container: `#${id}`,
         objectType: "feed",
@@ -100,16 +99,16 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
           description: content.description,
           imageUrl: content.imageUrl,
           link: {
-            mobileWebUrl: groupPageUrl,
-            webUrl: groupPageUrl,
+            mobileWebUrl: groupUrl,
+            webUrl: groupUrl,
           },
         },
         buttons: [
           {
             title: "오늘의 기도",
             link: {
-              mobileWebUrl: groupPageUrl,
-              webUrl: groupPageUrl,
+              mobileWebUrl: groupUrl,
+              webUrl: groupUrl,
             },
           },
         ],
@@ -121,45 +120,27 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
     return () => {
       document.body.removeChild(script);
     };
-  }, [groupPageUrl, id, type]);
+  }, [targetGroup, groupUrl, id, type]);
 
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-  const kakaoDefaultImage = "/images/kakaotalk_sharing_btn_medium.png";
-
-  if (message) {
-    return (
-      <div className="relative">
-        <div
-          className="absolute w-full h-full "
-          onClick={() => {
-            analyticsTrack("클릭_카카오_공유", {
-              where: eventOption.where,
-            });
-            buttonRef.current?.click();
-          }}
-        ></div>
-        <button
-          ref={buttonRef}
-          id={id}
-          className="bg-yellow-300 px-10 py-2 rounded-md text-sm"
-        >
-          <p className="text-black">{message}</p>
-        </button>
-      </div>
-    );
-  }
   return (
     <div className="relative">
       <div
         className="absolute w-full h-full "
         onClick={() => {
-          analyticsTrack("클릭_카카오_공유", { where: eventOption.where });
+          analyticsTrack("클릭_카카오_공유", {
+            where: eventOption.where,
+          });
           buttonRef.current?.click();
         }}
       ></div>
-      <button ref={buttonRef} id={id} className="bg-mainBg p-2 rounded-md">
-        <img src={img ?? kakaoDefaultImage} className="w-5 h-5" />
+      <button
+        ref={buttonRef}
+        id={id}
+        className="bg-yellow-300 px-10 py-2 rounded-md text-sm"
+      >
+        <p className="text-black">{message}</p>
       </button>
     </div>
   );

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -140,7 +140,7 @@ const ShareDrawer: React.FC = () => {
       {ImageCerousel}
       <div className="flex flex-col gap-2">
         <KakaoShareButton
-          groupPageUrl={`${domainUrl}/group/${targetGroup?.id}`}
+          targetGroup={targetGroup}
           id="groupPage"
           message="카카오톡으로 초대하기"
           eventOption={{ where: "GroupPage" }}

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -12,7 +12,6 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "../ui/drawer";
-import { getDomainUrl } from "@/lib/utils";
 import { KakaoShareButton } from "./KakaoShareBtn";
 import { Button } from "../ui/button";
 import { toast } from "../ui/use-toast";
@@ -25,7 +24,6 @@ const ShareDrawer: React.FC = () => {
   const setIsOpenShareDrawer = useBaseStore(
     (state) => state.setIsOpenShareDrawer
   );
-  const domainUrl = getDomainUrl();
 
   const onClickCopyLink = () => {
     const currentUrl = window.location.href;

--- a/src/components/todayPray/TodayPrayCardList.tsx
+++ b/src/components/todayPray/TodayPrayCardList.tsx
@@ -29,6 +29,7 @@ const TodayPrayCardList: React.FC<PrayCardListProps> = ({
   currentUserId,
   groupId,
 }) => {
+  const targetGroup = useBaseStore((state) => state.targetGroup);
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
   const fetchGroupPrayCardList = useBaseStore(
     (state) => state.fetchGroupPrayCardList
@@ -101,7 +102,7 @@ const TodayPrayCardList: React.FC<PrayCardListProps> = ({
         </p>
       </div>
       <KakaoShareButton
-        groupPageUrl={window.location.href}
+        targetGroup={targetGroup}
         id="paryTodayIntro"
         message="카카오톡으로 초대하기"
         eventOption={{ where: "PrayCardList" }}


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/7609d0c5-c59c-45f7-9219-b7d9354e3470" width="200" />

### 작업사항
->  카카오톡 공유 메세지의 타이틀에 그룹명을 추가합니다.

### 체크리스트
-> 카카오 공유 확인
-> 초대 및 말씀 공유 동작 확인