### PR TITLE
fix: 그룹 생성후 시트 에러 및 이미지 개선

### DIFF
--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -49,7 +49,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
 
   const handleClickCreateGroup = () => {
     if (userGroupList.length < maxGroupCount || userPlan === "Premium") {
-      navigate("/group/new");
+      window.location.href = "/group/new";
       analyticsTrack("클릭_그룹_추가", { group_length: userGroupList.length });
     } else {
       toast({

--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -10,7 +10,6 @@ import {
 import { useToast } from "../ui/use-toast";
 import menuIcon from "@/assets/menuIcon.svg";
 import { Group } from "supabase/types/tables";
-import { useNavigate } from "react-router-dom";
 import useBaseStore from "@/stores/baseStore";
 import { analyticsTrack } from "@/analytics/analytics";
 import OpenShareDrawerBtn from "../share/OpenShareDrawerBtn";
@@ -32,7 +31,6 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
     (state) => state.deletePrayCardByGroupId
   );
   const setAlertData = useBaseStore((state) => state.setAlertData);
-  const navigate = useNavigate();
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
   const { toast } = useToast();
   const signOut = useBaseStore((state) => state.signOut);

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -63,10 +63,7 @@ const GroupCreatePage: React.FC = () => {
     <div className="flex flex-col gap-6 items-center">
       <div className="text-lg font-bold">PrayU 그룹 만들기</div>
       <div className="flex justify-center h-[300px] w-max">
-        <img
-          className="h-full object-cover"
-          src="/images/PrayCardListLarge.png"
-        />
+        <img className="h-full object-cover" src="/images/intro_square.png" />
       </div>
       <div className="flex flex-col items-center gap-4 w-full ">
         <Input


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e8b1e6a0-9888-4627-9408-a7f62498c9b6)


1. 그룹 생성 후 기도제목 작성으로 이동 중 sheet가 사라지지 않는 문제.
useNavigate -> window.location.href 로 페이지 이동 함수를 바꿔 해결.

2. 그룹 생성 페이지 이미지 개선

https://www.notion.so/mmyeong/fix-sheet-a7c7812fd191447c86ca7f182b1f40c6?pvs=4

fix: sheet navigae error solved

fix: useNavigate import delete in GroupMenuBtn.tsx