### PR TITLE
hotfix: group 생성시 member, prayCard 생성

### DIFF
--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -8,15 +8,16 @@ import {
   SheetClose,
 } from "@/components/ui/sheet";
 import { useToast } from "../ui/use-toast";
-import menuIcon from "@/assets/menuIcon.svg";
 import { Group } from "supabase/types/tables";
 import useBaseStore from "@/stores/baseStore";
 import { analyticsTrack } from "@/analytics/analytics";
+import { SlMenu } from "react-icons/sl";
+
 import OpenShareDrawerBtn from "../share/OpenShareDrawerBtn";
 
 interface GroupManuBtnProps {
   userGroupList: Group[];
-  targetGroup: Group;
+  targetGroup?: Group;
 }
 
 const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
@@ -56,17 +57,17 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
     }
   };
 
-  const handleClickExitGroup = () => {
+  const handleClickExitGroup = (groupId: string, groupName: string | null) => {
     setAlertData({
       title: "그룹 나가기",
-      description: `더 이상 ${targetGroup.name}의\n기도를 받을 수 없게 돼요 :(`,
+      description: `더 이상 ${groupName}의\n기도를 받을 수 없게 돼요 :(`,
       actionText: "나가기",
       cancelText: "취소",
       onAction: async () => {
-        await deleteMemberbyGroupId(user!.id, targetGroup.id);
-        await deletePrayCardByGroupId(user!.id, targetGroup.id);
+        await deleteMemberbyGroupId(user!.id, groupId);
+        await deletePrayCardByGroupId(user!.id, groupId);
         window.location.href = "/";
-        analyticsTrack("클릭_그룹_나가기", { group_id: targetGroup.id });
+        analyticsTrack("클릭_그룹_나가기", { group_id: groupId });
       },
     });
     setIsConfirmAlertOpen(true);
@@ -83,10 +84,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
 
   const onClickSheetTrigeer = () => {
     window.history.pushState(null, "", window.location.pathname);
-    analyticsTrack("클릭_그룹_메뉴", {
-      group_id: targetGroup.id,
-      group_name: targetGroup.name,
-    });
+    analyticsTrack("클릭_그룹_메뉴", {});
   };
 
   return (
@@ -95,7 +93,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
         className="flex flex-col items-end focus:outline-none"
         onClick={() => onClickSheetTrigeer()}
       >
-        <img src={menuIcon} className="w-8 h-8" />
+        <SlMenu size={20} />
       </SheetTrigger>
       <SheetContent className="max-w-[288px] mx-auto w-[60%] px-5 py-16 flex flex-col items-end overflow-y-auto no-scrollbar">
         <SheetHeader>
@@ -104,7 +102,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
         </SheetHeader>
         <div className="flex flex-col gap-4 items-end text-gray-500">
           {userGroupList.map((group) => {
-            if (group.id === targetGroup.id)
+            if (group.id === targetGroup?.id)
               return (
                 <div
                   key={group.id}
@@ -134,18 +132,25 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
               </a>
             );
           })}
-          <a
-            className="cursor-pointer text-green-900"
-            onClick={() => handleClickCreateGroup()}
-          >
-            + 그룹 만들기
-          </a>
-          <a
-            className="cursor-pointer text-red-900"
-            onClick={() => handleClickExitGroup()}
-          >
-            - 그룹 나가기
-          </a>
+          <hr />
+          {targetGroup && (
+            <>
+              <a
+                className="cursor-pointer text-green-900"
+                onClick={() => handleClickCreateGroup()}
+              >
+                + 그룹 만들기
+              </a>
+              <a
+                className="cursor-pointer text-red-900"
+                onClick={() =>
+                  handleClickExitGroup(targetGroup.id, targetGroup.name)
+                }
+              >
+                - 그룹 나가기
+              </a>
+            </>
+          )}
 
           <hr />
           <a href="/" onClick={() => analyticsTrack("클릭_공유_도메인", {})}>

--- a/src/components/prayCard/PrayCardCreateModal.tsx
+++ b/src/components/prayCard/PrayCardCreateModal.tsx
@@ -106,7 +106,7 @@ const PrayCardCreateModal: React.FC<PrayCardCreateModalProps> = ({
             className="min-h-[300px] text-sm flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-gray-700 !opacity-100 !border-none !cursor-default focus:outline-none focus:border-none"
             value={inputPrayCardContent}
             onChange={(e) => setPrayCardContent(e.target.value)}
-            placeholder={`기도제목은  수정할 수 있어요 :)\n\n1. PrayU와 함께 기도할 수 있기를\n2. `}
+            placeholder={`기도제목은 수정할 수 있어요 :)\n\n1. PrayU와 함께 기도할 수 있기를\n2. `}
           />
           {!inputPrayCardContent && (
             <p


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/51ccc3c4-981b-4b28-be6b-8159d99b011e" width="150" />
<img src="https://github.com/user-attachments/assets/b9323b71-fe8f-4aa0-8f08-6844ef0b9467" width="150" />
<img src="https://github.com/user-attachments/assets/168a4ad1-cba4-4d0f-826e-4eed58b7ace2" width="300" />



### 작업 설명

메타 광고를 돌리면서 그룹 생성을 처음에 하는 사람이 많아졌는데
들어와서 그룹 생성 이후 기도제목 작성 페이지에서 이탈을 많이 하고 있습니다.
그룹 생성하면 바로 그룹 페이지로 들어오도록 수정합니다.


### 체크리스트

- [x]  그룹 생성 버튼을 누르면 그룹생성, 멤버 생성, 기도제목 생성이 바로 되도록 합니다.\
- [x]  그룹 버튼과 그룹 생성페이지 뒤로가기 버튼을 추가합니다.

https://www.notion.so/mmyeong/group-member-prayCard-09f88acb8e294c4aa302697c17c5ce49?pvs=4