### PR TITLE
refactor: 카카오 공유 스크립트 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { analytics } from "@/analytics/analytics";
 import ConfirmAlert from "./components/alert/ConfirmAlert";
 import { Toaster } from "./components/ui/toaster";
 import PrayCardCreatePage from "./pages/PrayCardCreatePage";
+import KakaoInit from "./components/share/KakaoInit";
 
 const App = () => {
   useEffect(() => {
@@ -70,6 +71,7 @@ const App = () => {
       </div>
       <Toaster />
       <ConfirmAlert />
+      <KakaoInit />
     </div>
   );
 };

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -71,7 +71,6 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
             <KakaoShareButton
               targetGroup={targetGroup}
               message="카카오톡 링크 공유"
-              id="prayList"
               eventOption={{ where: "PrayList" }}
             />
           </div>

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -61,7 +61,6 @@ const ExpiredPrayCardUI: React.FC = () => {
         <KakaoShareButton
           targetGroup={targetGroup}
           message="카카오톡으로 요청하기"
-          id="prayCardUIToOther"
           eventOption={{ where: "ReactionWithCalendar" }}
         ></KakaoShareButton>
       </div>

--- a/src/components/share/ContentDrawer.tsx
+++ b/src/components/share/ContentDrawer.tsx
@@ -37,7 +37,6 @@ const ContentDrawer = () => {
       </div>
       <KakaoShareButton
         targetGroup={targetGroup}
-        id="ContentDrawer"
         message="카카오톡으로 공유하기"
         eventOption={{ where: "ContentDrawer" }}
         type="bible"

--- a/src/components/share/KakaoInit.tsx
+++ b/src/components/share/KakaoInit.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect } from "react";
+
+declare global {
+  interface Window {
+    Kakao: Kakao;
+  }
+}
+
+interface Kakao {
+  init: (apiKey: string) => void;
+  isInitialized: () => boolean;
+  Share: {
+    createDefaultButton: (options: KakaoLinkObject) => void;
+  };
+}
+
+interface KakaoLinkObject {
+  container: string;
+  objectType: string;
+  content: {
+    title: string;
+    description: string;
+    imageUrl: string;
+    link: {
+      mobileWebUrl: string;
+      webUrl: string;
+    };
+  };
+
+  buttons: Array<{
+    title: string;
+    link: {
+      mobileWebUrl: string;
+      webUrl: string;
+    };
+  }>;
+}
+
+const KakaoInit: React.FC = () => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js";
+    script.integrity =
+      "sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4";
+    script.crossOrigin = "anonymous";
+    script.async = true;
+    script.onload = () => {
+      if (window.Kakao) {
+        window.Kakao.init(`${import.meta.env.VITE_KAKAO_JS_KEY}`);
+        console.log(window.Kakao.isInitialized());
+      }
+    };
+    document.head.appendChild(script);
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  return null;
+};
+
+export default KakaoInit;

--- a/src/components/share/KakaoInit.tsx
+++ b/src/components/share/KakaoInit.tsx
@@ -47,7 +47,6 @@ const KakaoInit: React.FC = () => {
     script.onload = () => {
       if (window.Kakao) {
         window.Kakao.init(`${import.meta.env.VITE_KAKAO_JS_KEY}`);
-        console.log(window.Kakao.isInitialized());
       }
     };
     document.head.appendChild(script);

--- a/src/components/share/KakaoInit.tsx
+++ b/src/components/share/KakaoInit.tsx
@@ -10,12 +10,27 @@ interface Kakao {
   init: (apiKey: string) => void;
   isInitialized: () => boolean;
   Share: {
-    createDefaultButton: (options: KakaoLinkObject) => void;
+    sendDefault: (options: KakaoLinkObject) => void;
+    sendScrap: (options: { requestUrl: string }) => void;
   };
+  API: KakaoAPI;
+}
+interface KakaoAPI {
+  request: (params: KakaoAPIRequestParams) => Promise<KakaoAPIResponse>;
+}
+
+interface KakaoAPIRequestParams {
+  url: string;
+  data?: Record<string, unknown>;
+}
+
+interface KakaoAPIResponse {
+  nickname?: string;
+  profile_image_url?: string;
+  thumbnail_image_url?: string;
 }
 
 interface KakaoLinkObject {
-  container: string;
   objectType: string;
   content: {
     title: string;

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -44,47 +44,29 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
 }) => {
   const groupUrl = `${getDomainUrl()}/group/${targetGroup!.id}`;
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js";
-    script.integrity =
-      "sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4";
-    script.crossOrigin = "anonymous";
-    script.async = true;
-
-    script.onload = () => {
-      if (!window.Kakao.isInitialized()) {
-        window.Kakao.init(`${import.meta.env.VITE_KAKAO_JS_KEY}`);
-      }
-      const content = getContent(targetGroup!.name!, type);
-      window.Kakao.Share.createDefaultButton({
-        container: `#${id}`,
-        objectType: "feed",
-        content: {
-          title: content.title,
-          description: content.description,
-          imageUrl: content.imageUrl,
+    const content = getContent(targetGroup!.name!, type);
+    window.Kakao.Share.createDefaultButton({
+      container: `#${id}`,
+      objectType: "feed",
+      content: {
+        title: content.title,
+        description: content.description,
+        imageUrl: content.imageUrl,
+        link: {
+          mobileWebUrl: groupUrl,
+          webUrl: groupUrl,
+        },
+      },
+      buttons: [
+        {
+          title: "오늘의 기도",
           link: {
             mobileWebUrl: groupUrl,
             webUrl: groupUrl,
           },
         },
-        buttons: [
-          {
-            title: "오늘의 기도",
-            link: {
-              mobileWebUrl: groupUrl,
-              webUrl: groupUrl,
-            },
-          },
-        ],
-      });
-    };
-
-    document.body.appendChild(script);
-
-    return () => {
-      document.body.removeChild(script);
-    };
+      ],
+    });
   }, [targetGroup, groupUrl, id, type]);
 
   const buttonRef = useRef<HTMLButtonElement | null>(null);

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -1,6 +1,5 @@
 import { analyticsTrack } from "@/analytics/analytics";
 import { getDomainUrl, getISOTodayDateYMD } from "@/lib/utils";
-import { useEffect, useRef } from "react";
 import { Group } from "supabase/types/tables";
 
 interface EventOption {
@@ -10,7 +9,6 @@ interface EventOption {
 interface KakaoShareButtonProps {
   targetGroup: Group | null;
   message: string;
-  id: string;
   eventOption: EventOption;
   type?: string;
 }
@@ -37,16 +35,18 @@ const getContent = (groupName: string, type: string) => {
 
 export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
   targetGroup,
-  id,
   message,
   type = "default",
   eventOption,
 }) => {
-  useEffect(() => {
-    const groupUrl = `${getDomainUrl()}/group/${targetGroup!.id}`;
-    const content = getContent(targetGroup!.name!, type);
-    window.Kakao.Share.createDefaultButton({
-      container: `#${id}`,
+  const domainUrl = getDomainUrl();
+  const groupUrl = `${domainUrl}/group/${targetGroup!.id}`;
+  const content = getContent(targetGroup!.name!, type);
+  const handleClickKakaoBtn = () => {
+    analyticsTrack("클릭_카카오_공유", {
+      where: eventOption.where,
+    });
+    window.Kakao.Share.sendDefault({
       objectType: "feed",
       content: {
         title: content.title,
@@ -67,28 +67,14 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
         },
       ],
     });
-  }, [targetGroup, id, type]);
-
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  };
 
   return (
-    <div className="relative">
-      <div
-        className="absolute w-full h-full "
-        onClick={() => {
-          analyticsTrack("클릭_카카오_공유", {
-            where: eventOption.where,
-          });
-          buttonRef.current?.click();
-        }}
-      ></div>
-      <button
-        ref={buttonRef}
-        id={id}
-        className="bg-yellow-300 px-10 py-2 rounded-md text-sm"
-      >
-        <p className="text-black">{message}</p>
-      </button>
-    </div>
+    <button
+      className="bg-yellow-300 px-10 py-2 rounded-md text-sm"
+      onClick={() => handleClickKakaoBtn()}
+    >
+      {message}
+    </button>
   );
 };

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -42,8 +42,8 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
   type = "default",
   eventOption,
 }) => {
-  const groupUrl = `${getDomainUrl()}/group/${targetGroup!.id}`;
   useEffect(() => {
+    const groupUrl = `${getDomainUrl()}/group/${targetGroup!.id}`;
     const content = getContent(targetGroup!.name!, type);
     window.Kakao.Share.createDefaultButton({
       container: `#${id}`,
@@ -67,7 +67,7 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
         },
       ],
     });
-  }, [targetGroup, groupUrl, id, type]);
+  }, [targetGroup, id, type]);
 
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -2,41 +2,6 @@ import { analyticsTrack } from "@/analytics/analytics";
 import { getDomainUrl, getISOTodayDateYMD } from "@/lib/utils";
 import { useEffect, useRef } from "react";
 import { Group } from "supabase/types/tables";
-declare global {
-  interface Window {
-    Kakao: Kakao;
-  }
-}
-
-interface Kakao {
-  init: (apiKey: string) => void;
-  isInitialized: () => boolean;
-  Share: {
-    createDefaultButton: (options: KakaoLinkObject) => void;
-  };
-}
-
-interface KakaoLinkObject {
-  container: string;
-  objectType: string;
-  content: {
-    title: string;
-    description: string;
-    imageUrl: string;
-    link: {
-      mobileWebUrl: string;
-      webUrl: string;
-    };
-  };
-
-  buttons: Array<{
-    title: string;
-    link: {
-      mobileWebUrl: string;
-      webUrl: string;
-    };
-  }>;
-}
 
 interface EventOption {
   where: string;

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -125,7 +125,6 @@ const ShareDrawer: React.FC = () => {
       <div className="flex flex-col gap-2">
         <KakaoShareButton
           targetGroup={targetGroup}
-          id="groupPage"
           message="카카오톡으로 초대하기"
           eventOption={{ where: "GroupPage" }}
         />

--- a/src/components/todayPray/TodayPrayCardList.tsx
+++ b/src/components/todayPray/TodayPrayCardList.tsx
@@ -103,7 +103,6 @@ const TodayPrayCardList: React.FC<PrayCardListProps> = ({
       </div>
       <KakaoShareButton
         targetGroup={targetGroup}
-        id="paryTodayIntro"
         message="카카오톡으로 초대하기"
         eventOption={{ where: "PrayCardList" }}
       ></KakaoShareButton>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -184,22 +184,6 @@ const MainPage: React.FC = () => {
       </Carousel>
 
       {user ? <PrayUStartBtn /> : <KakaoLoginBtn />}
-
-      <Button
-        onClick={() => {
-          window.Kakao.API.request({
-            url: "/v1/api/talk/profile",
-          })
-            .then(function (response) {
-              console.log(response);
-            })
-            .catch(function (error) {
-              console.log(error);
-            });
-        }}
-      >
-        카카오 프로필
-      </Button>
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -184,6 +184,22 @@ const MainPage: React.FC = () => {
       </Carousel>
 
       {user ? <PrayUStartBtn /> : <KakaoLoginBtn />}
+
+      <Button
+        onClick={() => {
+          window.Kakao.API.request({
+            url: "/v1/api/talk/profile",
+          })
+            .then(function (response) {
+              console.log(response);
+            })
+            .catch(function (error) {
+              console.log(error);
+            });
+        }}
+      >
+        카카오 프로필
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
### 작업 내용
카카오 버튼이 눌릴 때마다 카카오 스크립트를 load 하고있어서 버튼 응답속도가 느렸던 문제를 해결합니다.
추후 카카오 메세지 관련해서도 스크립트를 사용하기 때문에 App 컴포넌트에서 한번만 로드하도록 합니다.

### 체크리스트
- [x]  카카오 init 스크립트 분리
- [x]  카카오 공유 버튼 재구성(Kakao.Share.sendScrap)