### PR TITLE
refactor: Mymember 에서 prayCard 생성 분기처리

### DIFF
--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -94,7 +94,6 @@ export const fetchUserPrayCardListByGroupId = async (
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
-    console.log(data);
     if (error) {
       Sentry.captureException(error.message);
       return null;

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -94,6 +94,7 @@ export const fetchUserPrayCardListByGroupId = async (
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
+    console.log(data);
     if (error) {
       Sentry.captureException(error.message);
       return null;

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -7,6 +7,7 @@ import OtherMemberList from "@/components/member/OtherMemberList";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
 import { useNavigate } from "react-router-dom";
+import { getISOTodayDate } from "@/lib/utils";
 
 interface GroupBodyProps {
   currentUserId: string;
@@ -37,7 +38,11 @@ const GroupBody: React.FC<GroupBodyProps> = ({
   }, [currentUserId, targetGroup, getMember]);
 
   useEffect(() => {
-    if (memberList && !memberLoading && myMember == null) {
+    if (
+      memberList &&
+      !memberLoading &&
+      (myMember == null || myMember.updated_at < getISOTodayDate(-6))
+    ) {
       navigate("/praycard/new", { replace: true });
       return;
     }

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -4,10 +4,8 @@ import TodayPrayCardList from "@/components/todayPray/TodayPrayCardList";
 import MyMember from "@/components/member/MyMember";
 import GroupLimitCard from "@/components/group/GroupLimitCard";
 import OtherMemberList from "@/components/member/OtherMemberList";
-import { getISOTodayDate } from "@/lib/utils";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
-import { useNavigate } from "react-router-dom";
 
 interface GroupBodyProps {
   currentUserId: string;
@@ -20,33 +18,18 @@ const GroupBody: React.FC<GroupBodyProps> = ({
   groupList,
   targetGroup,
 }) => {
-  const navigate = useNavigate();
-
   const isParamsGroupIdinGroupList = groupList.some(
     (group) => group.id === targetGroup.id
   );
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
 
   const myMember = useBaseStore((state) => state.myMember);
-  const memberLoading = useBaseStore((state) => state.memberLoading);
-  const memberList = useBaseStore((state) => state.memberList);
   const getMember = useBaseStore((state) => state.getMember);
   const userPlan = useBaseStore((state) => state.userPlan);
 
   useEffect(() => {
     if (targetGroup) getMember(currentUserId, targetGroup.id);
   }, [currentUserId, targetGroup, getMember]);
-
-  useEffect(() => {
-    if (
-      memberList &&
-      !memberLoading &&
-      (myMember == null || myMember.updated_at < getISOTodayDate(-6))
-    ) {
-      navigate("/praycard/new", { replace: true });
-      return;
-    }
-  }, [myMember, memberLoading, memberList, navigate]);
 
   if (!myMember) {
     return (

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -4,7 +4,6 @@ import TodayPrayCardList from "@/components/todayPray/TodayPrayCardList";
 import MyMember from "@/components/member/MyMember";
 import GroupLimitCard from "@/components/group/GroupLimitCard";
 import OtherMemberList from "@/components/member/OtherMemberList";
-import { getISOTodayDate } from "@/lib/utils";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
 import { useNavigate } from "react-router-dom";

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -8,6 +8,7 @@ import { getISOTodayDate } from "@/lib/utils";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
 import { useNavigate } from "react-router-dom";
+
 interface GroupBodyProps {
   currentUserId: string;
   groupList: Group[];
@@ -26,7 +27,7 @@ const GroupBody: React.FC<GroupBodyProps> = ({
   );
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
 
-  const member = useBaseStore((state) => state.myMember);
+  const myMember = useBaseStore((state) => state.myMember);
   const memberLoading = useBaseStore((state) => state.memberLoading);
   const memberList = useBaseStore((state) => state.memberList);
   const getMember = useBaseStore((state) => state.getMember);
@@ -38,16 +39,16 @@ const GroupBody: React.FC<GroupBodyProps> = ({
 
   useEffect(() => {
     if (
-      !memberLoading &&
       memberList &&
-      (member == null || member.updated_at < getISOTodayDate(-6))
+      !memberLoading &&
+      (myMember == null || myMember.updated_at < getISOTodayDate(-6))
     ) {
       navigate("/praycard/new", { replace: true });
       return;
     }
-  }, [member, memberLoading, memberList, navigate]);
+  }, [myMember, memberLoading, memberList, navigate]);
 
-  if (memberLoading) {
+  if (!myMember) {
     return (
       <div className="flex justify-center items-center h-screen">
         <ClipLoader size={20} color={"#70AAFF"} loading={true} />
@@ -65,7 +66,7 @@ const GroupBody: React.FC<GroupBodyProps> = ({
 
   return (
     <div className="flex flex-col h-full gap-4">
-      <MyMember currentUserId={currentUserId} groupId={targetGroup.id} />
+      <MyMember myMember={myMember} />
       <OtherMemberList currentUserId={currentUserId} groupId={targetGroup.id} />
       <TodayPrayCardList
         currentUserId={currentUserId}

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -4,8 +4,10 @@ import TodayPrayCardList from "@/components/todayPray/TodayPrayCardList";
 import MyMember from "@/components/member/MyMember";
 import GroupLimitCard from "@/components/group/GroupLimitCard";
 import OtherMemberList from "@/components/member/OtherMemberList";
+import { getISOTodayDate } from "@/lib/utils";
 import { useEffect } from "react";
 import { ClipLoader } from "react-spinners";
+import { useNavigate } from "react-router-dom";
 
 interface GroupBodyProps {
   currentUserId: string;
@@ -18,18 +20,29 @@ const GroupBody: React.FC<GroupBodyProps> = ({
   groupList,
   targetGroup,
 }) => {
+  const navigate = useNavigate();
+
   const isParamsGroupIdinGroupList = groupList.some(
     (group) => group.id === targetGroup.id
   );
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
 
   const myMember = useBaseStore((state) => state.myMember);
+  const memberLoading = useBaseStore((state) => state.memberLoading);
+  const memberList = useBaseStore((state) => state.memberList);
   const getMember = useBaseStore((state) => state.getMember);
   const userPlan = useBaseStore((state) => state.userPlan);
 
   useEffect(() => {
     if (targetGroup) getMember(currentUserId, targetGroup.id);
   }, [currentUserId, targetGroup, getMember]);
+
+  useEffect(() => {
+    if (memberList && !memberLoading && myMember == null) {
+      navigate("/praycard/new", { replace: true });
+      return;
+    }
+  }, [myMember, memberLoading, memberList, navigate]);
 
   if (!myMember) {
     return (

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -28,13 +28,13 @@ const MyMember: React.FC<MemberProps> = ({ myMember }) => {
     (state) => state.fetchUserPrayCardListByGroupId
   );
   const userPrayCardList = useBaseStore((state) => state.userPrayCardList);
-  const isOpenMyMemberDrawer = useBaseStore(
-    (state) => state.isOpenMyMemberDrawer
-  );
+  const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
   const inputPrayCardContent = useBaseStore(
     (state) => state.inputPrayCardContent
   );
-  const setPrayCardContent = useBaseStore((state) => state.setPrayCardContent);
+  const isOpenMyMemberDrawer = useBaseStore(
+    (state) => state.isOpenMyMemberDrawer
+  );
   const setIsOpenMyMemberDrawer = useBaseStore(
     (state) => state.setIsOpenMyMemberDrawer
   );

--- a/src/components/prayCard/MyPrayCardUI.tsx
+++ b/src/components/prayCard/MyPrayCardUI.tsx
@@ -8,13 +8,12 @@ import { FaEdit, FaSave } from "react-icons/fa";
 import iconUserMono from "@/assets/icon-user-mono.svg";
 import { analyticsTrack } from "@/analytics/analytics";
 import { ClipLoader } from "react-spinners";
-import { useNavigate } from "react-router-dom";
 import { useRef } from "react";
 
 interface PrayCardProps {
   currentUserId: string;
   groupId: string;
-  member: MemberWithProfiles | null;
+  member: MemberWithProfiles;
 }
 
 const MyPrayCardUI: React.FC<PrayCardProps> = ({
@@ -22,7 +21,6 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({
   groupId,
   member,
 }) => {
-  const navigate = useNavigate();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const userPrayCardList = useBaseStore((state) => state.userPrayCardList);
   const fetchUserPrayCardListByGroupId = useBaseStore(
@@ -73,17 +71,7 @@ const MyPrayCardUI: React.FC<PrayCardProps> = ({
     fetchUserPrayCardListByGroupId(currentUserId, groupId);
   }, [fetchUserPrayCardListByGroupId, currentUserId, groupId]);
 
-  useEffect(() => {
-    if (
-      userPrayCardList &&
-      (userPrayCardList.length === 0 ||
-        userPrayCardList[0].created_at < getISOTodayDate(-6))
-    ) {
-      navigate("/praycard/new", { replace: true });
-    }
-  }, [userPrayCardList, navigate]);
-
-  if (!userPrayCardList || !member) {
+  if (!userPrayCardList) {
     return (
       <div className="flex justify-center items-center h-screen">
         <ClipLoader size={20} color={"#70AAFF"} loading={true} />

--- a/src/pages/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCardCreatePage.tsx
@@ -94,7 +94,6 @@ const PrayCardCreatePage: React.FC = () => {
   }
 
   const todayDateYMD = getISOTodayDateYMD();
-  console.log(user?.user_metadata);
 
   const PrayCardUI = (
     <div className="flex flex-col gap-6 justify-center">


### PR DESCRIPTION
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b0c255dc-2c10-4aee-a493-b537c67b2b0b">


## 작업 내용
member.updated_at 에만 의존해서 기도카드 생성을 분기처리하는 문제를 수정합니다.

### **기존**
groupBody 에서 member.updated_at 으로 분기처리

### **수정**
1. groupBody 에서는 멤버 유무 및 업데이트로 분기처리
2. MyMember 에서 카드 생성일자로 분기처리

### 테스트
- [x] 새로운 그룹에 입장
- [x] 기존 그룹 만료 상태에서 입장 