### PR TITLE
hotfix: 만료카드 예외처리-re

### DIFF
--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -42,12 +42,14 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
   }
 
   if (!otherMember) return null;
+
+  const isExpiredOtherMember = otherMember.updated_at < getISOTodayDate(-6);
+  if (isExpiredOtherMember) return <ExpiredPrayCardUI />;
+
   if (otherPrayCardList && otherPrayCardList.length == 0) {
     // TODO: 예외처리 필요
     return null;
   }
-  const isExpiredOtherMember = otherMember.updated_at < getISOTodayDate(-6);
-  if (isExpiredOtherMember) return <ExpiredPrayCardUI />;
 
   const prayCard = otherPrayCardList[0];
   const createdDateYMD = getISODateYMD(prayCard.created_at);


### PR DESCRIPTION
만료된 기도카드가 리턴 되기 전에 OtherPrayCard 를 fetch 하고 있어서 예외처리합니다.