### PR TITLE
feat: 기도제목 공유 메세지 구현

### DIFF
--- a/src/components/kakao/Kakao.d.ts
+++ b/src/components/kakao/Kakao.d.ts
@@ -23,11 +23,7 @@ interface Kakao {
     setAccessToken: (token: string) => void;
   };
   Picker: {
-    selectFriends: (options: {
-      title: string;
-      maxPickableCount: number;
-      minPickableCount: number;
-    }) => Promise<SelectedUsers>;
+    selectFriends: (options: { title: string }) => Promise<SelectedUsers>;
   };
 }
 

--- a/src/components/kakao/KakaoCallback.tsx
+++ b/src/components/kakao/KakaoCallback.tsx
@@ -16,13 +16,33 @@ const KakaoCallBack = () => {
   const setIsOpenTodayPrayDrawer = useBaseStore(
     (state) => state.setIsOpenTodayPrayDrawer
   );
+  const setIsOpenMyMemberDrawer = useBaseStore(
+    (state) => state.setIsOpenMyMemberDrawer
+  );
+  const parseState = (state: string | null) => {
+    const stateObj: { [key: string]: string } = {};
+    if (!state) return stateObj;
+
+    // ';'로 구분하여 split하고, 각 key-value를 처리
+    const parts = state.split(";");
+    parts.forEach((part) => {
+      const [key, value] = part.split(":");
+      if (key && value) {
+        stateObj[key.trim()] = value.trim();
+      }
+    });
+    return stateObj;
+  };
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const code = params.get("code");
     const state = params.get("state");
-    const groupPageUrl =
-      state && state.includes(":") ? `/group/${state.split(":")[1]}` : "/group";
+    const stateObj = parseState(state);
+
+    const groupPageUrl = stateObj["groupId"]
+      ? `/group/${stateObj["groupId"]}`
+      : "/group";
 
     if (code) {
       KakaoTokenRepo.fetchKakaoToken(
@@ -39,7 +59,8 @@ const KakaoCallBack = () => {
         }
       });
     }
-    setIsOpenTodayPrayDrawer(true);
+    if (stateObj["from"] == "TodayPrayDrawer") setIsOpenTodayPrayDrawer(true);
+    if (stateObj["from"] == "MyPrayCard") setIsOpenMyMemberDrawer(true);
     navigate(groupPageUrl, { replace: true });
   }, [
     navigate,
@@ -48,6 +69,7 @@ const KakaoCallBack = () => {
     updateProfile,
     user,
     setIsOpenTodayPrayDrawer,
+    setIsOpenMyMemberDrawer,
   ]);
   return null;
 };

--- a/src/components/kakao/KakaoController.tsx
+++ b/src/components/kakao/KakaoController.tsx
@@ -27,9 +27,7 @@ export class KakaoController {
   static async selectUsers() {
     try {
       const response = await window.Kakao.Picker.selectFriends({
-        title: "친구 선택",
-        maxPickableCount: 10,
-        minPickableCount: 1,
+        title: "공유할 친구 선택",
       });
       return response;
     } catch (error) {

--- a/src/components/kakao/KakaoTokenRepo.ts
+++ b/src/components/kakao/KakaoTokenRepo.ts
@@ -25,7 +25,7 @@ export class KakaoTokenRepo {
       if (response) {
         this.setKakaoTokensInCookie(response);
         window.Kakao.Auth.setAccessToken(response.access_token);
-        return KAKAOTOKENS.accessToken;
+        return response.access_token;
       }
     } else {
       this.openKakaoLoginPage(state);

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -9,11 +9,20 @@ import {
 import { RiMoreFill } from "react-icons/ri";
 import { FiEdit } from "react-icons/fi";
 import { LuCopy } from "react-icons/lu";
+import { MdIosShare } from "react-icons/md";
 import { RiDeleteBin6Line } from "react-icons/ri";
 import { analyticsTrack } from "@/analytics/analytics";
 import useBaseStore from "@/stores/baseStore";
 import { toast } from "../ui/use-toast";
 import { deletePrayCard } from "@/apis/prayCard";
+import { KakaoTokenRepo } from "../kakao/KakaoTokenRepo";
+import { KakaoController } from "../kakao/KakaoController";
+import {
+  KakaoMessageObject,
+  KakaoSendMessageResponse,
+  SelectedUsers,
+} from "../kakao/Kakao";
+import { getDomainUrl } from "@/lib/utils";
 
 interface MyMoreBtnProps {
   handleEditClick: () => void;
@@ -52,6 +61,58 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
     analyticsTrack("클릭_기도카드_복사", {});
   };
 
+  const onClickSharePrayCard = async () => {
+    if (!KakaoTokenRepo.isInit()) {
+      analyticsTrack("페이지_카카오_로그인", { where: "MyPrayCardMenuBtn" });
+      KakaoTokenRepo.init();
+    } else {
+      const baseUrl = getDomainUrl();
+      const kakaoMessage: KakaoMessageObject = {
+        object_type: "feed",
+        content: {
+          title: "📮 PrayU 공유 알림",
+          description: "오늘의 기도를 통해 공유된 기도제목을 확인해 주세요",
+          image_url:
+            "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/PrayCardPrayU.png",
+          image_width: 400,
+          image_height: 300,
+          link: {
+            web_url: baseUrl,
+            mobile_web_url: baseUrl,
+          },
+        },
+        buttons: [
+          {
+            title: "오늘의 기도 시작",
+            link: {
+              mobile_web_url: window.location.href,
+              web_url: window.location.href,
+            },
+          },
+        ],
+      };
+
+      const selectFriendsResponse: SelectedUsers | null =
+        await KakaoController.selectUsers();
+      if (selectFriendsResponse?.users) {
+        const friendsUUID = selectFriendsResponse.users.map(
+          (friends) => friends.uuid
+        );
+        const sendMessageResponse: KakaoSendMessageResponse | null =
+          await KakaoController.sendMessageForFriends(
+            kakaoMessage,
+            friendsUUID
+          );
+        if (sendMessageResponse) {
+          toast({
+            description: `📮 ${sendMessageResponse.successful_receiver_uuids.length}명의 친구들에게 기도제목 공유 메세지를 보냈어요`,
+          });
+        }
+      }
+    }
+    analyticsTrack("클릭_기도카드_공유", {});
+  };
+
   const onClickDeletePrayCard = () => {
     setAlertData({
       title: "내 기도제목 삭제하기",
@@ -68,46 +129,52 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
     return;
   };
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        onClick={() => {
+          analyticsTrack("클릭_기도카드_더보기", {});
+        }}
+      >
+        <RiMoreFill className="text-2xl" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          className="flex justify-between"
           onClick={() => {
-            analyticsTrack("클릭_기도카드_더보기", {});
+            setTimeout(() => {
+              handleEditClick();
+            }, 180);
           }}
         >
-          <RiMoreFill className="text-2xl" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuItem
-            className="flex justify-between"
-            onClick={() => {
-              setTimeout(() => {
-                handleEditClick();
-              }, 180);
-            }}
-          >
-            <FiEdit />
-            수정하기
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className="flex justify-between"
-            onClick={() => onClickCopyPrayCard()}
-          >
-            <LuCopy />
-            복사하기
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className="flex justify-between text-red-600"
-            onClick={() => onClickDeletePrayCard()}
-          >
-            <RiDeleteBin6Line />
-            삭제하기
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </>
+          <FiEdit />
+          수정하기
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="flex justify-between"
+          onClick={() => onClickCopyPrayCard()}
+        >
+          <LuCopy />
+          복사하기
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="flex justify-between"
+          onClick={() => onClickSharePrayCard()}
+        >
+          <MdIosShare />
+          공유하기
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="flex justify-between text-red-600"
+          onClick={() => onClickDeletePrayCard()}
+        >
+          <RiDeleteBin6Line />
+          삭제하기
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -62,52 +62,45 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
   };
 
   const onClickSharePrayCard = async () => {
-    if (!KakaoTokenRepo.isInit()) {
-      analyticsTrack("페이지_카카오_로그인", { where: "MyPrayCardMenuBtn" });
-      KakaoTokenRepo.init();
-    } else {
-      const baseUrl = getDomainUrl();
-      const kakaoMessage: KakaoMessageObject = {
-        object_type: "feed",
-        content: {
-          title: "📮 PrayU 공유 알림",
-          description: "오늘의 기도를 통해 공유된 기도제목을 확인해 주세요",
-          image_url:
-            "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/PrayCardPrayU.png",
-          image_width: 400,
-          image_height: 300,
+    await KakaoTokenRepo.init();
+    const baseUrl = getDomainUrl();
+    const kakaoMessage: KakaoMessageObject = {
+      object_type: "feed",
+      content: {
+        title: "📮 PrayU 공유 알림",
+        description: "오늘의 기도를 통해 공유된 기도제목을 확인해 주세요",
+        image_url:
+          "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/PrayCardPrayU.png",
+        image_width: 400,
+        image_height: 300,
+        link: {
+          web_url: baseUrl,
+          mobile_web_url: baseUrl,
+        },
+      },
+      buttons: [
+        {
+          title: "오늘의 기도 시작",
           link: {
-            web_url: baseUrl,
-            mobile_web_url: baseUrl,
+            mobile_web_url: window.location.href,
+            web_url: window.location.href,
           },
         },
-        buttons: [
-          {
-            title: "오늘의 기도 시작",
-            link: {
-              mobile_web_url: window.location.href,
-              web_url: window.location.href,
-            },
-          },
-        ],
-      };
+      ],
+    };
 
-      const selectFriendsResponse: SelectedUsers | null =
-        await KakaoController.selectUsers();
-      if (selectFriendsResponse?.users) {
-        const friendsUUID = selectFriendsResponse.users.map(
-          (friends) => friends.uuid
-        );
-        const sendMessageResponse: KakaoSendMessageResponse | null =
-          await KakaoController.sendMessageForFriends(
-            kakaoMessage,
-            friendsUUID
-          );
-        if (sendMessageResponse) {
-          toast({
-            description: `📮 ${sendMessageResponse.successful_receiver_uuids.length}명의 친구들에게 기도제목 공유 메세지를 보냈어요`,
-          });
-        }
+    const selectFriendsResponse: SelectedUsers | null =
+      await KakaoController.selectUsers();
+    if (selectFriendsResponse?.users) {
+      const friendsUUID = selectFriendsResponse.users.map(
+        (friends) => friends.uuid
+      );
+      const sendMessageResponse: KakaoSendMessageResponse | null =
+        await KakaoController.sendMessageForFriends(kakaoMessage, friendsUUID);
+      if (sendMessageResponse) {
+        toast({
+          description: `📮 ${sendMessageResponse.successful_receiver_uuids.length}명의 친구들에게 기도제목 공유 메세지를 보냈어요`,
+        });
       }
     }
     analyticsTrack("클릭_기도카드_공유", {});

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -75,8 +75,8 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
         description: "오늘의 기도를 통해 공유된 기도제목을 확인해 주세요",
         image_url:
           "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/PrayCardPrayU.png",
-        image_width: 400,
-        image_height: 300,
+        image_width: 800,
+        image_height: 400,
         link: {
           web_url: baseUrl,
           mobile_web_url: baseUrl,

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -40,6 +40,7 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
   const setIsConfirmAlertOpen = useBaseStore(
     (state) => state.setIsConfirmAlertOpen
   );
+  const targetGroup = useBaseStore((state) => state.targetGroup);
   const onClickCopyPrayCard = () => {
     if (!inputPrayCardContent) {
       toast({
@@ -61,8 +62,8 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
     analyticsTrack("클릭_기도카드_복사", {});
   };
 
-  const onClickSharePrayCard = async () => {
-    await KakaoTokenRepo.init();
+  const onClickSharePrayCard = async (targetGroupId: string) => {
+    await KakaoTokenRepo.init(`groupId:${targetGroupId};from:MyPrayCard`);
     const baseUrl = getDomainUrl();
     const kakaoMessage: KakaoMessageObject = {
       object_type: "feed",
@@ -153,7 +154,7 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="flex justify-between"
-          onClick={() => onClickSharePrayCard()}
+          onClick={() => onClickSharePrayCard(targetGroup!.id)}
         >
           <MdIosShare />
           공유하기

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -63,7 +63,10 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
   };
 
   const onClickSharePrayCard = async (targetGroupId: string) => {
-    await KakaoTokenRepo.init(`groupId:${targetGroupId};from:MyPrayCard`);
+    const kakaoToken = await KakaoTokenRepo.init(
+      `groupId:${targetGroupId};from:MyPrayCard`
+    );
+    if (!kakaoToken) return null;
     const baseUrl = getDomainUrl();
     const kakaoMessage: KakaoMessageObject = {
       object_type: "feed",

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -76,7 +76,7 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
         image_url:
           "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/PrayCardPrayU.png",
         image_width: 800,
-        image_height: 400,
+        image_height: 600,
         link: {
           web_url: baseUrl,
           mobile_web_url: baseUrl,

--- a/src/components/todayPray/TodayPrayBtn.tsx
+++ b/src/components/todayPray/TodayPrayBtn.tsx
@@ -17,7 +17,9 @@ const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ eventOption }) => {
   const targetGroup = useBaseStore((state) => state.targetGroup);
 
   const onClickTodayPrayBtn = async (targetGroupId: string) => {
-    const kakaoToken = await KakaoTokenRepo.init(`groupId:${targetGroupId}`);
+    const kakaoToken = await KakaoTokenRepo.init(
+      `groupId:${targetGroupId};from:TodayPrayDrawer`
+    );
     if (!kakaoToken) return null;
     window.history.pushState(null, "", window.location.pathname);
     setIsOpenTodayPrayDrawer(true);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0eaa3ccb-3f71-413e-a482-e6c3964e48fb)

## 작업 내용
카카오톡 메세지 기능을 활용하여 기도제목 공유 기능을 구현합니다.
현재는 임의의 이미지로 메세지가 가지만 이후에는 동적으로 본인 메세지를 이미지로 생성해서 보내도 좋을 것 같습니다.

## 체크리스트
- [x] 카카오 로그인 콜백 과정에 state 추가 (groupId 정보, from 정보)
- [x] parseState 를 통해 파싱 후 라우팅에 반영
- [x] 내 기도제목 공유하기 버튼 추가
- [x] 공유시 피커를 통한 전송 및 토스트 메세지 추가