### PR TITLE
fix: 로그아웃에 카카오 쿠키 정보 초기화

### DIFF
--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -14,6 +14,7 @@ import { analyticsTrack } from "@/analytics/analytics";
 import { SlMenu } from "react-icons/sl";
 
 import OpenShareDrawerBtn from "../share/OpenShareDrawerBtn";
+import { KakaoTokenRepo } from "../kakao/KakaoTokenRepo";
 
 interface GroupManuBtnProps {
   userGroupList: Group[];
@@ -94,6 +95,7 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
 
   const onClickSignOut = () => {
     analyticsTrack("클릭_로그아웃", {});
+    KakaoTokenRepo.cleanKakaoTokensInCookies();
     signOut();
   };
 

--- a/src/components/kakao/KakaoTokenRepo.ts
+++ b/src/components/kakao/KakaoTokenRepo.ts
@@ -150,4 +150,10 @@ export class KakaoTokenRepo {
       }; expires=${refreshTokenExpires.toUTCString()}; path=/`;
     }
   }
+
+  static cleanKakaoTokensInCookies() {
+    const pastDate = new Date(0).toUTCString();
+    document.cookie = `${this.ACCESS_TOKEN_COOKIE_NAME}=; expires=${pastDate}; path=/`;
+    document.cookie = `${this.REFRESH_TOKEN_COOKIE_NAME}=; expires=${pastDate}; path=/`;
+  }
 }


### PR DESCRIPTION
카카오 토큰 관련 이슈가 생기면 쿠키를 날려야 하기 때문에
로그아웃에 쿠키 제거 로직을 추가하여 이슈가 있을 경우 로그아웃을 유도합니다.

### 체크리스트
- [x]  kakaoToken 에 cleanKakaoTokenInCookies 추가
- [x]  로그아웃 과정에 쿠키 제거 추가