### PR TITLE
refactor: PrayCard 생성 페이지 경로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,11 @@ const App = () => {
 const AnalyticsTracker = () => {
   const location = useLocation();
   const from = location.state?.from?.pathname;
-  const match = matchPath("/group/:groupId/praycard/new", location.pathname);
+  const matchPraycardNew = matchPath(
+    "/group/:groupId/praycard/new",
+    location.pathname
+  );
+  const matchGroup = matchPath("/group/:groupId", location.pathname);
   useEffect(() => {
     switch (location.pathname) {
       case "/":
@@ -127,23 +131,21 @@ const AnalyticsTracker = () => {
         });
         break;
       default:
-        if (location.pathname.startsWith("/group/")) {
+        if (matchGroup) {
           analytics.track("페이지_그룹_홈", {
-            title: "Group Page",
+            title: "Group Home Page",
+            groupId: matchGroup.params.groupId,
             where: from,
           });
-        }
-
-        if (match) {
+        } else if (matchPraycardNew) {
           analytics.track("페이지_기도카드_생성", {
             title: "PrayCard Create Page with Group ID",
-            groupId: match.params.groupId,
+            groupId: matchPraycardNew.params.groupId,
             where: from,
           });
         }
-        break;
     }
-  }, [match, location.pathname, from]);
+  }, [matchPraycardNew, matchGroup, location.pathname, from]);
 
   return null;
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ const App = () => {
                   </PrivateRoute>
                 }
               />
-              <Route path="group/not-found" element={<GroupNotFoundPage />} />
+              <Route path="/group/not-found" element={<GroupNotFoundPage />} />
               <Route
                 path="/profile/me"
                 element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,10 @@
-import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useLocation,
+  matchPath,
+} from "react-router-dom";
 import { useEffect } from "react";
 import { AuthProvider } from "./components/auth/AuthProvider";
 import PrivateRoute from "./components/auth/PrivateRoute";
@@ -12,6 +18,7 @@ import PrayCardCreatePage from "./pages/PrayCardCreatePage";
 import KakaoInit from "./components/kakao/KakaoInit";
 import KakaoCallBack from "./components/kakao/KakaoCallback";
 import MyProfilePage from "./pages/MyProfilePage";
+import GroupNotFoundPage from "./pages/GroupNotFoundPage";
 
 const App = () => {
   useEffect(() => {
@@ -67,13 +74,14 @@ const App = () => {
                 }
               />
               <Route
-                path="/praycard/new"
+                path="/group/:groupId/praycard/new"
                 element={
                   <PrivateRoute>
                     <PrayCardCreatePage />
                   </PrivateRoute>
                 }
               />
+              <Route path="group/not-found" element={<GroupNotFoundPage />} />
               <Route
                 path="/profile/me"
                 element={
@@ -82,7 +90,6 @@ const App = () => {
                   </PrivateRoute>
                 }
               />
-              {/* <Route path="*" element={<NotFound />} /> */}
             </Routes>
           </AuthProvider>
         </BrowserRouter>
@@ -97,7 +104,7 @@ const App = () => {
 const AnalyticsTracker = () => {
   const location = useLocation();
   const from = location.state?.from?.pathname;
-
+  const match = matchPath("/group/:groupId/praycard/new", location.pathname);
   useEffect(() => {
     switch (location.pathname) {
       case "/":
@@ -109,12 +116,6 @@ const AnalyticsTracker = () => {
       case "/group/new":
         analytics.track("페이지_그룹_생성", {
           title: "Group Create Page",
-          where: from,
-        });
-        break;
-      case "/praycard/new":
-        analytics.track("페이지_기도카드_생성", {
-          title: "PrayCard Create Page",
           where: from,
         });
         break;
@@ -131,9 +132,17 @@ const AnalyticsTracker = () => {
             where: from,
           });
         }
+
+        if (match) {
+          analytics.track("페이지_기도카드_생성", {
+            title: "PrayCard Create Page with Group ID",
+            groupId: match.params.groupId,
+            where: from,
+          });
+        }
         break;
     }
-  }, [location.pathname, from]);
+  }, [match, location.pathname, from]);
 
   return null;
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import KakaoInit from "./components/kakao/KakaoInit";
 import KakaoCallBack from "./components/kakao/KakaoCallback";
 import MyProfilePage from "./pages/MyProfilePage";
 import GroupNotFoundPage from "./pages/GroupNotFoundPage";
+import GroupRedirectPage from "./pages/GroupRedirectPage";
 
 const App = () => {
   useEffect(() => {
@@ -48,12 +49,12 @@ const App = () => {
                     <KakaoCallBack />
                   </PrivateRoute>
                 }
-              ></Route>
+              />
               <Route
                 path="/group"
                 element={
                   <PrivateRoute>
-                    <GroupPage />
+                    <GroupRedirectPage />
                   </PrivateRoute>
                 }
               />

--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -33,6 +33,8 @@ export const getGroup = async (groupId: string): Promise<Group | null> => {
       .eq("id", groupId)
       .single();
     if (error) {
+      if (error.code == "22P02") return null; // groupId가 uuid 가 아닌경우
+      if (error.code == "PGRST116") return null; // 해당 row 가 없는 경우
       Sentry.captureException(error.message);
       return null;
     }

--- a/src/components/group/GroupBody.tsx
+++ b/src/components/group/GroupBody.tsx
@@ -43,10 +43,10 @@ const GroupBody: React.FC<GroupBodyProps> = ({
       !memberLoading &&
       (myMember == null || myMember.updated_at < getISOTodayDate(-6))
     ) {
-      navigate("/praycard/new", { replace: true });
+      navigate(`/group/${targetGroup.id}/praycard/new`, { replace: true });
       return;
     }
-  }, [myMember, memberLoading, memberList, navigate]);
+  }, [myMember, memberLoading, memberList, navigate, targetGroup]);
 
   if (!myMember) {
     return (

--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -16,12 +16,12 @@ import { SlMenu } from "react-icons/sl";
 import OpenShareDrawerBtn from "../share/OpenShareDrawerBtn";
 import { KakaoTokenRepo } from "../kakao/KakaoTokenRepo";
 
-interface GroupManuBtnProps {
+interface GroupMenuBtnProps {
   userGroupList: Group[];
   targetGroup?: Group;
 }
 
-const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
+const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
   userGroupList,
   targetGroup,
 }) => {
@@ -206,4 +206,4 @@ const GroupManuBtn: React.FC<GroupManuBtnProps> = ({
   );
 };
 
-export default GroupManuBtn;
+export default GroupMenuBtn;

--- a/src/components/member/MyMember.tsx
+++ b/src/components/member/MyMember.tsx
@@ -65,7 +65,7 @@ const MyMember: React.FC<MemberProps> = ({ myMember }) => {
       (userPrayCardList.length == 0 ||
         userPrayCardList[0].created_at < getISOTodayDate(-6))
     ) {
-      navigate("/praycard/new", { replace: true });
+      navigate(`/group/${groupId}/praycard/new`, { replace: true });
       return;
     }
   });

--- a/src/pages/GroupNotFoundPage.tsx
+++ b/src/pages/GroupNotFoundPage.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom"; // react-router-dom을 사용하여 링크를 처리
+
+const GroupNotFoundPage: React.FC = () => {
+  return (
+    <div className="h-screen flex flex-col justify-center items-center gap-2">
+      <div>그룹을 찾을 수 없어요😂</div>
+      <Link to="/" className="text-sm underline text-gray-400">
+        PrayU 홈으로
+      </Link>
+    </div>
+  );
+};
+
+export default GroupNotFoundPage;

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -40,7 +40,7 @@ const GroupPage: React.FC = () => {
   ]);
 
   if (targetGroupLoading == false && targetGroup == null)
-    window.location.replace("/group/not-found");
+    window.location.href = "/group/not-found";
 
   if (!targetGroup || !memberList || !groupList) {
     return (

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
 import useBaseStore from "@/stores/baseStore";
 import GroupMenuBtn from "../components/group/GroupMenuBtn";
@@ -13,16 +13,17 @@ import EventDialog from "@/components/notice/EventDialog";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
+  const navigate = useNavigate();
 
   const { groupId: paramsGroupId } = useParams();
   const groupList = useBaseStore((state) => state.groupList);
   const targetGroup = useBaseStore((state) => state.targetGroup);
+  const targetGroupLoading = useBaseStore((state) => state.targetGroupLoading);
   const getGroup = useBaseStore((state) => state.getGroup);
   const memberList = useBaseStore((state) => state.memberList) || [];
   const fetchMemberListByGroupId = useBaseStore(
     (state) => state.fetchMemberListByGroupId
   );
-
   const fetchGroupListByUserId = useBaseStore(
     (state) => state.fetchGroupListByUserId
   );
@@ -39,7 +40,10 @@ const GroupPage: React.FC = () => {
     getGroup,
   ]);
 
-  if (!groupList || !memberList || !targetGroup) {
+  if (targetGroupLoading == false && targetGroup == null)
+    window.location.replace("/group/not-found");
+
+  if (!targetGroup || !memberList || !groupList) {
     return (
       <div className="flex justify-center items-center h-screen">
         <ClipLoader size={20} color={"#70AAFF"} loading={true} />

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
 import useBaseStore from "@/stores/baseStore";
 import GroupMenuBtn from "../components/group/GroupMenuBtn";
@@ -13,7 +13,6 @@ import EventDialog from "@/components/notice/EventDialog";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
-  const navigate = useNavigate();
 
   const { groupId: paramsGroupId } = useParams();
   const groupList = useBaseStore((state) => state.groupList);
@@ -39,18 +38,6 @@ const GroupPage: React.FC = () => {
     paramsGroupId,
     getGroup,
   ]);
-
-  useEffect(() => {
-    if (!paramsGroupId && groupList) {
-      if (groupList.length === 0) {
-        navigate("/group/new", { replace: true });
-        return;
-      } else {
-        navigate(`/group/${groupList[0].id}`, { replace: true });
-        return;
-      }
-    }
-  }, [groupList, navigate, paramsGroupId]);
 
   if (!groupList || !memberList || !targetGroup) {
     return (

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
 import useBaseStore from "@/stores/baseStore";
 import GroupMenuBtn from "../components/group/GroupMenuBtn";
@@ -13,7 +13,6 @@ import EventDialog from "@/components/notice/EventDialog";
 
 const GroupPage: React.FC = () => {
   const { user } = useAuth();
-  const navigate = useNavigate();
 
   const { groupId: paramsGroupId } = useParams();
   const groupList = useBaseStore((state) => state.groupList);

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -74,7 +74,7 @@ const GroupPage: React.FC = () => {
           </div>
           <span className="text-sm text-gray-500">{memberList.length}</span>
         </div>
-        <div className="w-[48px] flex gap-2">
+        <div className="w-[48px] flex justify-between">
           <OpenEventDialogBtn />
           <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
         </div>

--- a/src/pages/GroupRedirectPage.tsx
+++ b/src/pages/GroupRedirectPage.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import useAuth from "../hooks/useAuth";
+import useBaseStore from "@/stores/baseStore";
+
+const GroupRedirectPage: React.FC = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const groupList = useBaseStore((state) => state.groupList);
+  const fetchGroupListByUserId = useBaseStore(
+    (state) => state.fetchGroupListByUserId
+  );
+
+  useEffect(() => {
+    fetchGroupListByUserId(user!.id);
+    if (groupList) {
+      if (groupList.length === 0) {
+        navigate("/group/new", { replace: true });
+      } else {
+        navigate(`/group/${groupList[0].id}`, { replace: true });
+      }
+    }
+  }, [fetchGroupListByUserId, groupList, navigate, user]);
+
+  return null;
+};
+
+export default GroupRedirectPage;

--- a/src/pages/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCardCreatePage.tsx
@@ -7,14 +7,29 @@ import prayerVerses from "@/data/prayCardTemplate.json";
 import { Button } from "@/components/ui/button";
 import { useEffect } from "react";
 import GroupMenuBtn from "@/components/group/GroupMenuBtn";
+import { useParams } from "react-router-dom";
+import ClipLoader from "react-spinners/ClipLoader";
 
 const PrayCardCreatePage: React.FC = () => {
   const { user } = useAuth();
+  const { groupId } = useParams<{ groupId: string }>();
 
-  const groupList = useBaseStore((state) => state.groupList);
   const targetGroup = useBaseStore((state) => state.targetGroup);
+  const getGroup = useBaseStore((state) => state.getGroup);
+  const fetchGroupListByUserId = useBaseStore(
+    (state) => state.fetchGroupListByUserId
+  );
+  const groupList = useBaseStore((state) => state.groupList);
+
   const myMember = useBaseStore((state) => state.myMember);
   const memberList = useBaseStore((state) => state.memberList);
+  const fetchMemberListByGroupId = useBaseStore(
+    (state) => state.fetchMemberListByGroupId
+  );
+  const getMember = useBaseStore((state) => state.getMember);
+  const createMember = useBaseStore((state) => state.createMember);
+  const updateMember = useBaseStore((state) => state.updateMember);
+  const createPrayCard = useBaseStore((state) => state.createPrayCard);
 
   const inputPrayCardContent = useBaseStore(
     (state) => state.inputPrayCardContent
@@ -26,10 +41,6 @@ const PrayCardCreatePage: React.FC = () => {
   const setIsDisabledPrayCardCreateBtn = useBaseStore(
     (state) => state.setIsDisabledGroupCreateBtn
   );
-  const getMember = useBaseStore((state) => state.getMember);
-  const createMember = useBaseStore((state) => state.createMember);
-  const updateMember = useBaseStore((state) => state.updateMember);
-  const createPrayCard = useBaseStore((state) => state.createPrayCard);
 
   const getRandomVerse = () => {
     const randomIndex = Math.floor(Math.random() * prayerVerses.length);
@@ -79,16 +90,25 @@ const PrayCardCreatePage: React.FC = () => {
   };
 
   useEffect(() => {
+    fetchGroupListByUserId(user!.id);
+    if (groupId) getGroup(groupId);
+    if (groupId) fetchMemberListByGroupId(groupId);
+  }, [
+    fetchGroupListByUserId,
+    fetchMemberListByGroupId,
+    getGroup,
+    user,
+    groupId,
+  ]);
+
+  useEffect(() => {
     setPrayCardContent(myMember?.pray_summary || "");
   }, [myMember, setPrayCardContent]);
 
-  if (targetGroup == null || memberList == null) {
+  if (!groupList || !targetGroup || !memberList) {
     return (
-      <div className="h-screen flex flex-col justify-center items-center gap-2">
-        <div>그룹을 찾을 수 없어요😂</div>
-        <a href="/" className="text-sm underline text-gray-400">
-          PrayU 홈으로
-        </a>
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={20} color={"#70AAFF"} loading={true} />
       </div>
     );
   }
@@ -154,10 +174,7 @@ const PrayCardCreatePage: React.FC = () => {
           <span className="text-sm text-gray-500">{memberList.length}</span>
         </div>
         <div className="w-[48px] flex justify-center">
-          <GroupMenuBtn
-            userGroupList={groupList || []}
-            targetGroup={targetGroup}
-          />
+          <GroupMenuBtn userGroupList={groupList} targetGroup={targetGroup} />
         </div>
       </div>
 

--- a/src/pages/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCardCreatePage.tsx
@@ -43,6 +43,12 @@ const PrayCardCreatePage: React.FC = () => {
   const setIsDisabledPrayCardCreateBtn = useBaseStore(
     (state) => state.setIsDisabledGroupCreateBtn
   );
+  const IsDisabledSkipPrayCardBtn = useBaseStore(
+    (state) => state.isDisabledSkipPrayCardBtn
+  );
+  const setIsDisabledSkipPrayCardBtn = useBaseStore(
+    (state) => state.setIsDisabledSkipPrayCardBtn
+  );
 
   useEffect(() => {
     fetchGroupListByUserId(user!.id);
@@ -103,7 +109,7 @@ const PrayCardCreatePage: React.FC = () => {
     currentUserId: string,
     groupId: string
   ) => {
-    setIsDisabledPrayCardCreateBtn(true);
+    setIsDisabledSkipPrayCardBtn(true);
     analyticsTrack("클릭_기도카드_다음에작성", {});
     const randomContent = getRandomVerse();
     const newPrayCard = await handleCreatePrayCard(
@@ -112,7 +118,7 @@ const PrayCardCreatePage: React.FC = () => {
       randomContent
     );
     if (!newPrayCard) {
-      setIsDisabledPrayCardCreateBtn(false);
+      setIsDisabledSkipPrayCardBtn(false);
       return null;
     }
     window.location.replace(`/group/${groupId}`);
@@ -206,7 +212,7 @@ const PrayCardCreatePage: React.FC = () => {
           <button
             className="text-sm text-gray-500 underline"
             onClick={() => onClickSkipPrayCard(user!.id, targetGroup.id)}
-            disabled={isDisabledPrayCardCreateBtn}
+            disabled={IsDisabledSkipPrayCardBtn}
           >
             다음에 작성하기
           </button>

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -104,6 +104,7 @@ export interface BaseStore {
   inputPrayCardContent: string;
   isEditingPrayCard: boolean;
   isDisabledPrayCardCreateBtn: boolean;
+  isDisabledSkipPrayCardBtn: boolean;
   prayCardCarouselApi: CarouselApi | null;
   fetchGroupPrayCardList: (
     groupId: string,
@@ -129,6 +130,7 @@ export interface BaseStore {
   setIsDisabledPrayCardCreateBtn: (
     isDisabledPrayCardCreateBtn: boolean
   ) => void;
+  setIsDisabledSkipPrayCardBtn: (isDisabledSkipPrayCardBtn: boolean) => void;
   updatePrayCardContent: (prayCardId: string, content: string) => Promise<void>;
   setPrayCardContent: (content: string) => void;
   setPrayCardCarouselApi: (prayCardCarouselApi: CarouselApi) => void;
@@ -405,6 +407,7 @@ const useBaseStore = create<BaseStore>()(
     inputPrayCardContent: "",
     isEditingPrayCard: false,
     isDisabledPrayCardCreateBtn: false,
+    isDisabledSkipPrayCardBtn: true,
     prayCardCarouselApi: null,
     setIsEditingPrayCard: (isEditingPrayCard: boolean) => {
       set((state) => {
@@ -516,6 +519,11 @@ const useBaseStore = create<BaseStore>()(
     setIsDisabledPrayCardCreateBtn: (isDisabled: boolean) => {
       set((state) => {
         state.isDisabledPrayCardCreateBtn = isDisabled;
+      });
+    },
+    setIsDisabledSkipPrayCardBtn: (isDisabled: boolean) => {
+      set((state) => {
+        state.isDisabledSkipPrayCardBtn = isDisabled;
       });
     },
     setPrayCardCarouselApi: (prayCardCarouselApi: CarouselApi) => {

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -54,7 +54,7 @@ export interface BaseStore {
   targetGroup: Group | null;
   inputGroupName: string;
   isDisabledGroupCreateBtn: boolean;
-
+  targetGroupLoading: boolean;
   fetchGroupListByUserId: (userId: string) => Promise<void>;
   getGroup: (groupId: string) => Promise<void>;
   setGroupName: (groupName: string) => void;
@@ -297,10 +297,12 @@ const useBaseStore = create<BaseStore>()(
         state.groupList = data;
       });
     },
+    targetGroupLoading: true,
     getGroup: async (groupId: string) => {
       const data = await getGroup(groupId);
       set((state) => {
         state.targetGroup = data;
+        state.targetGroupLoading = false;
       });
     },
     createGroup: async (


### PR DESCRIPTION

<img src="https://github.com/user-attachments/assets/d3492961-da97-405b-8313-6c51e70871f7" width="150" />


# 작업 내용

1. 기도제목 작성 페이지를 독립적으로 사용할 수 있도록 변경합니다.
    1. 작성페이지에서 새로고침 가능
    2. 다음에 작성하기 추가
2. 그룹페이지 리다이렉트 과정을 수정합니다.
    1. 404 페이지 만들기
    2. /group 분리

# 체크리스트

- [x]  /group/{groupId}/praycard/new 로 경로 변경
- [x]  본 경로에서 group, myMember 가져오기
- [x]  다음에 작성하기 버튼 반영
- [x]  /group/{} 404 페이지 처리