### PR TITLE
fix: 기도카드 모두 삭제된 멤버리스트 보여주기

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/react";
+
 export const deleteUser = async (userId: string): Promise<boolean> => {
   try {
     const response = await fetch(
@@ -17,10 +19,14 @@ export const deleteUser = async (userId: string): Promise<boolean> => {
       return false;
     }
 
-    const data = await response.json();
-    if (!data) return false;
-    return true;
-  } catch {
+    const { error, data } = await response.json();
+    if (error) {
+      Sentry.captureException(error.message);
+      return false;
+    }
+    return data ? true : false;
+  } catch (error) {
+    Sentry.captureException(error);
     return false;
   }
 };

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -14,6 +14,7 @@ import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
 import { getISOTodayDate } from "@/lib/utils";
 import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
 import { MemberWithProfiles } from "supabase/types/tables";
+import { ClipLoader } from "react-spinners";
 
 interface OtherMembersProps {
   currentUserId: string;
@@ -31,6 +32,10 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
   const isOpenOtherMemberDrawer = useBaseStore(
     (state) => state.isOpenOtherMemberDrawer
   );
+
+  const myMember = useBaseStore((state) => state.myMember);
+  const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
+
   const setIsOpenOtherMemberDrawer = useBaseStore(
     (state) => state.setIsOpenOtherMemberDrawer
   );
@@ -46,9 +51,30 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
     (member) => member.updated_at < getISOTodayDate(-6)
   );
 
+  if (!myMember) return null;
+  if (!groupPrayCardList)
+    return (
+      <div className="flex justify-center items-center min-h-80vh max-h-80vh">
+        <ClipLoader size={20} color={"#70AAFF"} loading={true} />
+      </div>
+    );
+
+  const filterdGroupPrayCardList = groupPrayCardList?.filter(
+    (prayCard) =>
+      prayCard.user_id &&
+      prayCard.user_id !== currentUserId &&
+      prayCard.deleted_at == null &&
+      !myMember.profiles.blocking_users.includes(prayCard.user_id)
+  );
+
   if (isPrayToday == null) return null;
   if (otherMemberList.length === 0) return <MemberInviteCard />;
-  if (!isPrayToday && !isExpiredAllMember) return <TodayPrayStartCard />;
+  if (
+    !isPrayToday &&
+    !isExpiredAllMember &&
+    filterdGroupPrayCardList.length != 0
+  )
+    return <TodayPrayStartCard />;
 
   return (
     <>

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -58,12 +58,13 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({
         <ClipLoader size={20} color={"#70AAFF"} loading={true} />
       </div>
     );
+  const todayDt = getISOTodayDate();
 
   const filterdGroupPrayCardList = groupPrayCardList?.filter(
     (prayCard) =>
       prayCard.user_id &&
       prayCard.user_id !== currentUserId &&
-      prayCard.deleted_at == null &&
+      prayCard.pray?.filter((pray) => pray.created_at >= todayDt).length == 0 &&
       !myMember.profiles.blocking_users.includes(prayCard.user_id)
   );
 

--- a/src/components/prayCard/DeletedPrayCardUI.tsx
+++ b/src/components/prayCard/DeletedPrayCardUI.tsx
@@ -1,0 +1,62 @@
+import { Textarea } from "../ui/textarea";
+import { KakaoShareButton } from "../share/KakaoShareBtn";
+import useBaseStore from "@/stores/baseStore";
+import OtherPrayCardMenuBtn from "./OtherPrayCardMenuBtn";
+
+const ExpiredPrayCardUI: React.FC = () => {
+  const targetGroup = useBaseStore((state) => state.targetGroup);
+  const otherMember = useBaseStore((state) => state.otherMember);
+
+  if (!otherMember) return null;
+
+  return (
+    <div className="flex flex-col gap-2 min-h-80vh max-h-80vh">
+      <div className="flex justify-end px-2">
+        <OtherPrayCardMenuBtn
+          targetUserId={otherMember.user_id || ""}
+          prayContent={otherMember.pray_summary || ""}
+        />
+      </div>
+      <div className="flex flex-col flex-grow min-h-full max-h-full bg-white rounded-2xl shadow-prayCard">
+        <div className="flex flex-col justify-center items-start gap-1 bg-gradient-to-r from-start via-middle via-30% to-end rounded-t-2xl p-5">
+          <div className="flex items-center gap-2">
+            <img
+              src={
+                otherMember.profiles.avatar_url ||
+                "/images/defaultProfileImage.png"
+              }
+              onError={(e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+                e.currentTarget.src = "/images/defaultProfileImage.png";
+              }}
+              className="w-7 h-7 rounded-full object-cover"
+            />
+            <p className="text-white text-lg">
+              {otherMember.profiles.full_name}
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
+          <Textarea
+            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
+            value={""}
+            disabled={true}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col items-center justify-center p-4 gap-4">
+        <div className="flex flex-col items-center gap-1">
+          {<p className="font-bold">기도제목이 삭제되었어요 😂</p>}
+          <p className="text-sm">기도제목을 요청해봐요!</p>
+        </div>
+
+        <KakaoShareButton
+          targetGroup={targetGroup}
+          message="카카오톡으로 요청하기"
+          eventOption={{ where: "ReactionWithCalendar" }}
+        ></KakaoShareButton>
+      </div>
+    </div>
+  );
+};
+
+export default ExpiredPrayCardUI;

--- a/src/components/prayCard/DeletedPrayCardUI.tsx
+++ b/src/components/prayCard/DeletedPrayCardUI.tsx
@@ -45,7 +45,7 @@ const ExpiredPrayCardUI: React.FC = () => {
       </div>
       <div className="flex flex-col items-center justify-center p-4 gap-4">
         <div className="flex flex-col items-center gap-1">
-          {<p className="font-bold">기도제목이 삭제되었어요 😂</p>}
+          <p className="font-bold">기도제목이 아직 없어요 😂</p>
           <p className="text-sm">기도제목을 요청해봐요!</p>
         </div>
 

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -43,17 +43,13 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
     );
   }
 
-  if (
-    otherPrayCardList &&
-    (otherPrayCardList.length == 0 || otherPrayCardList[0].deleted_at != null)
-  ) {
+  if (otherPrayCardList && otherPrayCardList.length == 0) {
     return <DeletedPrayCardUI />;
   }
 
   if (
     otherPrayCardList &&
-    (otherPrayCardList.length == 0 ||
-      otherPrayCardList[0].created_at < getISOTodayDate(-6))
+    otherPrayCardList[0].created_at < getISOTodayDate(-6)
   ) {
     return <ExpiredPrayCardUI />;
   }

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -4,6 +4,7 @@ import ReactionWithCalendar from "./ReactionWithCalendar";
 import { Textarea } from "../ui/textarea";
 import { getISODateYMD, getISOTodayDate } from "@/lib/utils";
 import ExpiredPrayCardUI from "./ExpiredPrayCardUI";
+import DeletedPrayCardUI from "./DeletedPrayCardUI";
 import { ClipLoader } from "react-spinners";
 import OtherPrayCardMenuBtn from "./OtherPrayCardMenuBtn";
 
@@ -40,6 +41,13 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
         <ClipLoader size={20} color={"#70AAFF"} loading={true} />
       </div>
     );
+  }
+
+  if (
+    otherPrayCardList &&
+    (otherPrayCardList.length == 0 || otherPrayCardList[0].deleted_at != null)
+  ) {
+    return <DeletedPrayCardUI />;
   }
 
   if (

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -43,16 +43,9 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
     );
   }
 
-  if (otherPrayCardList && otherPrayCardList.length == 0) {
-    return <DeletedPrayCardUI />;
-  }
-
-  if (
-    otherPrayCardList &&
-    otherPrayCardList[0].created_at < getISOTodayDate(-6)
-  ) {
+  if (otherPrayCardList.length == 0) return <DeletedPrayCardUI />;
+  if (otherPrayCardList[0].created_at < getISOTodayDate(-6))
     return <ExpiredPrayCardUI />;
-  }
 
   const prayCard = otherPrayCardList[0];
   const createdDateYMD = getISODateYMD(prayCard.created_at);


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/534152b9-5b5d-4ba0-988a-6d69af40250e" alt="image" width="200px">
<img src="https://github.com/user-attachments/assets/67456ee1-b35b-40d2-84c4-abf657a68f90" alt="image" width="200px">

api를 통해 기도카드를 fetch할 때 기본적으로 deleted_at 이 null 인 기도카드들만 불러오게끔 돼 있어서 현재 처리한 방식이 '삭제'와 관련해 타 도메인(ex.만료)과 독립적이지 않을 수 있습니다. 추후 api 함수 개선, 데이터베이스 개선 등의 리팩토링 과정에서 이 부분도 다시 고려돼도 좋을듯합니다.


fix: deleteUser api 호출함수 data, error, sentry 추가

feat: 멤버들 기도카드 모두 삭제된 경우 분기 처리

feat: DeletedPrayCardUI