### PR TITLE
fix: 쿼리 not 연산자 삭제 && 회원 탈퇴 api deleted_at 추가

### DIFF
--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -11,7 +11,6 @@ export const fetchMemberListByGroupId = async (
       .from("member")
       .select(`*, profiles (id, full_name, avatar_url, kakao_id)`)
       .eq("group_id", groupId)
-      .not("user_id", "is", null)
       .is("deleted_at", null)
       .order("updated_at", { ascending: false });
     if (error) {
@@ -59,8 +58,7 @@ export const getMember = async (
         `*, profiles (id, full_name, avatar_url, kakao_id, blocking_users, kakao_notification)`
       )
       .eq("user_id", userId)
-      .eq("group_id", groupId)
-      .not("user_id", "is", null);
+      .eq("group_id", groupId);
     if (error) {
       Sentry.captureException(error.message);
       return null;

--- a/src/apis/prayCard.ts
+++ b/src/apis/prayCard.ts
@@ -21,12 +21,10 @@ export const fetchGroupPrayCardList = async (
       )
       .eq("group_id", groupId)
       .eq("pray.user_id", currentUserId)
-      .not("user_id", "is", null)
-      .not("profiles.id", "is", null)
-      .not("pray.user_id", "is", null)
       .gte("created_at", startDt)
       .lt("created_at", endDt)
       .is("deleted_at", null)
+      .is("pray.deleted_at", null)
       .order("updated_at", { ascending: false });
 
     if (error) {
@@ -59,11 +57,9 @@ export const fetchOtherPrayCardListByGroupId = async (
       )
       .eq("user_id", userId)
       .eq("group_id", groupId)
-      .not("user_id", "is", null)
-      .not("profiles.id", "is", null)
-      .not("pray.user_id", "is", null)
       .eq("pray.user_id", currentUserId)
       .is("deleted_at", null)
+      .is("pray.deleted_at", null)
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
@@ -96,10 +92,8 @@ export const fetchUserPrayCardListByGroupId = async (
       )
       .eq("user_id", currentUserId)
       .eq("group_id", groupId)
-      .not("user_id", "is", null)
-      .not("profiles.id", "is", null)
-      .not("pray.user_id", "is", null)
       .is("deleted_at", null)
+      .is("pray.deleted_at", null)
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,7 +1,58 @@
 import * as Sentry from "@sentry/react";
+import { supabase } from "../../supabase/client";
+import { getISOToday } from "@/lib/utils";
 
 export const deleteUser = async (userId: string): Promise<boolean> => {
   try {
+    // member soft delete
+    const { error } = await supabase
+      .from("member")
+      .update({ deleted_at: getISOToday() })
+      .eq("user_id", userId);
+
+    if (error) {
+      Sentry.captureException(error.message);
+      return false;
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+    return false;
+  }
+
+  try {
+    // pray soft delete
+    const { error } = await supabase
+      .from("pray")
+      .update({ deleted_at: getISOToday() })
+      .eq("user_id", userId);
+
+    if (error) {
+      Sentry.captureException(error.message);
+      return false;
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+    return false;
+  }
+
+  try {
+    // prayCard soft delete
+    const { error } = await supabase
+      .from("pray_card")
+      .update({ deleted_at: getISOToday() })
+      .eq("user_id", userId);
+
+    if (error) {
+      Sentry.captureException(error.message);
+      return false;
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+    return false;
+  }
+
+  try {
+    // user hard delete
     const response = await fetch(
       `${import.meta.env.VITE_SUPA_PROJECT_URL}/functions/v1/delete-user`,
       {


### PR DESCRIPTION
회원 탈퇴와 관련해 이전에 api 로직에서 not 연산을 쿼리문에서 사용하였는데 인덱싱 저하를 일으켜 not 연산자 뺐습니다.
회원 탈퇴 시 해당 유저와 관련된 member, pray, prayCard 들을 soft delete처리하는 과정을 deleteUser 함수에 추가했습니다.

기존에는 탈퇴된 유저를 거르는 것을 not이 했는데 이제는 해당 유저의 행적들을 deleted_at == NULL 을 통해 확인합니다.

- [x]  profiles cascade 설정 유지!
- [x]  not is nulll 쿼리 제거
- [x]  회원 탈퇴 시 해당 회원 관련 데이터 deleted_at null 처리 쿼리문에 추가

https://www.notion.so/mmyeong/refactor-api-3eb6706808564083b374c3929c957416?pvs=4