### PR TITLE
fix: 다음에 작성하기 버튼 강조

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,7 @@ const buttonVariants = cva(
         // custom
         primary:
           "shadow-md bg-gradient-to-br from-[#608CFF] to-[#4574F1] text-white cursor-pointer",
+        primaryLight: "shadow-md bg-white text-black cursor-pointer",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/pages/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCardCreatePage.tsx
@@ -218,13 +218,14 @@ const PrayCardCreatePage: React.FC = () => {
           그룹 참여하기
         </Button>
         {!inputPrayCardContent && (
-          <button
-            className="text-sm text-gray-500 underline"
+          <Button
+            className="w-full"
             onClick={() => onClickSkipPrayCard(user!.id, targetGroup.id)}
             disabled={IsDisabledSkipPrayCardBtn}
+            variant="primaryLight"
           >
             다음에 작성하기
-          </button>
+          </Button>
         )}
       </div>
     </div>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/5f412f90-a396-41ea-846d-28ee2817515a" alt="image1" width="200px">

<img src="https://github.com/user-attachments/assets/a64d0e8a-187e-47e4-96eb-5f5cc0bcd919" alt="image2" width="200px">

기존의 다음에 작성하기가 밑줄로 되어 있어서 버튼으로 바꿨습니다.

https://www.notion.so/mmyeong/feat-258c8195886a433e8c1ca0fad87e1930?pvs=4
