### PR TITLE
fix: <img>상위 컴포넌트 css에 object-cover 추가

### DIFF
--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -47,7 +47,7 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
     <div className="overflow-y-auto justify-center items-center">
       {isPrayerListEmpty ? (
         <div className="flex flex-col items-center gap-6 px-4">
-          <div className="h-[150px] flex flex-col items-center">
+          <div className="h-[150px] flex flex-col items-center object-cover">
             <img
               className="h-full rounded-md shadow-prayCard"
               src="/images/prayList.png"

--- a/src/components/share/ContentDrawer.tsx
+++ b/src/components/share/ContentDrawer.tsx
@@ -29,7 +29,7 @@ const ContentDrawer = () => {
         </p>
       </div>
 
-      <div className="h-[300px] flex flex-col items-center">
+      <div className="h-[300px] flex flex-col items-center object-cover">
         <img
           className="h-full rounded-md"
           src={`https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/BibleContent/content${contentNumber}.png`}

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -78,7 +78,7 @@ const ShareDrawer: React.FC = () => {
     <Carousel setApi={setApi}>
       <CarouselContent>
         <CarouselItem className="flex flex-col items-center gap-4">
-          <div className="h-[200px] flex flex-col  items-center">
+          <div className="h-[200px] flex flex-col  items-center object-cover">
             <img
               className="h-full rounded-md shadow-prayCard"
               src="/images/KakaoNotification.png"
@@ -95,7 +95,7 @@ const ShareDrawer: React.FC = () => {
           </div>
         </CarouselItem>
         <CarouselItem className="flex flex-col items-center gap-4">
-          <div className="h-[200px] flex flex-col items-center">
+          <div className="h-[200px] flex flex-col items-center object-cover">
             <img
               className="h-full rounded-md shadow-prayCard"
               src="/images/KakaoShareMessage.png"

--- a/src/components/todayPray/TodayPrayCardListDrawer.tsx
+++ b/src/components/todayPray/TodayPrayCardListDrawer.tsx
@@ -109,7 +109,7 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
   );
 
   const completedItem = (
-    <div className="flex flex-col gap-4 justify-center items-center min-h-80vh max-h-80vh pb-10 object-cover">
+    <div className="flex flex-col gap-4 justify-center items-center min-h-80vh max-h-80vh pb-10">
       <img
         src={PrayTypeDatas["pray"].img}
         alt={PrayTypeDatas["pray"].emoji}

--- a/src/components/todayPray/TodayPrayCardListDrawer.tsx
+++ b/src/components/todayPray/TodayPrayCardListDrawer.tsx
@@ -89,7 +89,7 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
   const emptyPrayCardList = (
     <div className="flex flex-col justify-center items-center px-10 gap-4">
       <p className="text-lg font-bold">아직 올라온 기도제목이 없어요 😭</p>
-      <div className="h-[300px] flex flex-col items-center">
+      <div className="h-[300px] flex flex-col items-center object-cover">
         <img
           className="h-full rounded-md"
           src="/images/KakaoShareMessage.png"
@@ -109,7 +109,7 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
   );
 
   const completedItem = (
-    <div className="flex flex-col gap-4 justify-center items-center min-h-80vh max-h-80vh pb-10">
+    <div className="flex flex-col gap-4 justify-center items-center min-h-80vh max-h-80vh pb-10 object-cover">
       <img
         src={PrayTypeDatas["pray"].img}
         alt={PrayTypeDatas["pray"].emoji}
@@ -127,10 +127,7 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
   );
 
   const todayPrayCardList = (
-    <Carousel
-      setApi={setPrayCardCarouselApi}
-      opts={{ startIndex: 1 }}
-    >
+    <Carousel setApi={setPrayCardCarouselApi} opts={{ startIndex: 1 }}>
       <CarouselContent>
         <CarouselItem className="basis-5/6"></CarouselItem>
         {filterdGroupPrayCardList.map((prayCard) => (
@@ -147,7 +144,6 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
     </Carousel>
   );
 
-
   return (
     <Drawer
       open={isOpenTodayPrayDrawer}
@@ -158,12 +154,13 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
           <DrawerTitle></DrawerTitle>
           <DrawerDescription></DrawerDescription>
         </DrawerHeader>
-        {groupPrayCardList.length !== 1 
-          ? todayPrayCardList 
-          : memberList.length == 1
-          ? <TodayPrayCardDummyList />
-          : emptyPrayCardList
-        }
+        {groupPrayCardList.length !== 1 ? (
+          todayPrayCardList
+        ) : memberList.length == 1 ? (
+          <TodayPrayCardDummyList />
+        ) : (
+          emptyPrayCardList
+        )}
       </DrawerContent>
     </Drawer>
   );

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -68,7 +68,7 @@ const GroupCreatePage: React.FC = () => {
         <span className="text-xl font-bold">그룹 만들기</span>
         <GroupMenuBtn userGroupList={groupList} />
       </div>
-      <div className="flex justify-center h-[300px] w-max">
+      <div className="flex justify-center h-[300px] w-max object-cover">
         <img className="h-full object-cover" src="/images/intro_square.png" />
       </div>
       <div className="flex flex-col items-center gap-4 w-full ">

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -99,8 +99,8 @@ const MainPage: React.FC = () => {
       <div className="text-lg font-bold">우리만의 기도제목 나눔 공간 PrayU</div>
       <Carousel setApi={setApi}>
         <CarouselContent>
-          <CarouselItem className="flex flex-col items-center gap-4">
-            <div className="h-[300px] flex flex-col  items-center">
+          <CarouselItem className="w-full flex flex-col items-center gap-4">
+            <div className="h-[300px] flex flex-col  items-center object-cover">
               <img className="h-full" src="/images/MainImage.png" />
             </div>
             <div className="flex flex-col gap-2">
@@ -114,7 +114,7 @@ const MainPage: React.FC = () => {
             </div>
           </CarouselItem>
           <CarouselItem className="flex flex-col items-center gap-4">
-            <div className="h-[300px] flex flex-col  items-center">
+            <div className="h-[300px] flex flex-col  items-center object-cover">
               <img className="h-full" src="/images/MainPageIntro2.png" />
             </div>
             <div className="flex flex-col gap-2">
@@ -130,7 +130,7 @@ const MainPage: React.FC = () => {
             </div>
           </CarouselItem>
           <CarouselItem className="flex flex-col items-center gap-4">
-            <div className="h-[300px] flex flex-col  items-center ">
+            <div className="h-[300px] flex flex-col  items-center object-cover">
               <img className="h-full" src="/images/MainPageIntro4.png" />
             </div>
             <div className="flex flex-col gap-2">

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -120,7 +120,7 @@ const MyProfilePage = () => {
           {isEditing && <Badge>완료</Badge>}
         </div>
       </div>
-      <div className="flex justify-center h-[80px]">
+      <div className="flex justify-center h-[80px] object-cover">
         {myProfile && profileList ? (
           <img
             className="h-full aspect-square rounded-full"


### PR DESCRIPTION

- [x]  이미지 에러 해결
- [x]  다른 div 내의 이미지도 object-cover 달기

https://www.notion.so/mmyeong/fix-5e11389d1aae4b89910303cceecf749e?pvs=4