### PR TITLE
hotfix: 드로어 내 기도카드 내용 Textarea -> p 태그로 변경

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -21,7 +21,7 @@ jobs:
     if: |
       github.event.action == 'published' || 
       github.event_name == 'push' && startsWith(github.ref, 'refs/heads/v')||
-      github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'hotfix')
+      github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'hotfix')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/components/prayCard/DeletedPrayCardUI.tsx
+++ b/src/components/prayCard/DeletedPrayCardUI.tsx
@@ -1,4 +1,3 @@
-import { Textarea } from "../ui/textarea";
 import { KakaoShareButton } from "../share/KakaoShareBtn";
 import useBaseStore from "@/stores/baseStore";
 import OtherPrayCardMenuBtn from "./OtherPrayCardMenuBtn";
@@ -36,11 +35,9 @@ const ExpiredPrayCardUI: React.FC = () => {
           </div>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
-          <Textarea
-            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={""}
-            disabled={true}
-          />
+          <p className="flex-grow w-full p-2 rounded-md text-sm overflow-y-auto no-scrollbar whitespace-pre-wrap ">
+            {""}
+          </p>
         </div>
       </div>
       <div className="flex flex-col items-center justify-center p-4 gap-4">

--- a/src/components/prayCard/DummyPrayCardUI.tsx
+++ b/src/components/prayCard/DummyPrayCardUI.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Textarea } from "../ui/textarea";
 import DumyReactionBtnWithCalendar from "./DummyReactionWithCalendar";
 
 interface DumyPrayCardProps {
@@ -34,11 +33,9 @@ const DumyPrayCardUI: React.FC<DumyPrayCardProps> = ({
           </p>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
-          <Textarea
-            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={content}
-            disabled={true}
-          />
+          <p className="flex-grow w-full p-2 rounded-md text-sm overflow-y-auto no-scrollbar whitespace-pre-wrap ">
+            {content}
+          </p>
         </div>
       </div>
       <DumyReactionBtnWithCalendar dayOffset={dayOffset} />

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -1,4 +1,3 @@
-import { Textarea } from "../ui/textarea";
 import { getDateDistance } from "@toss/date";
 import { getISODateYMD, getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
 import { KakaoShareButton } from "../share/KakaoShareBtn";
@@ -50,11 +49,9 @@ const ExpiredPrayCardUI: React.FC = () => {
           </p>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
-          <Textarea
-            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={otherMember.pray_summary || ""}
-            disabled={true}
-          />
+          <p className="flex-grow w-full p-2 rounded-md text-sm overflow-y-auto no-scrollbar whitespace-pre-wrap ">
+            {otherMember.pray_summary || ""}
+          </p>
         </div>
       </div>
       <div className="flex flex-col items-center justify-center p-4 gap-4">

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import useBaseStore from "@/stores/baseStore";
 import ReactionWithCalendar from "./ReactionWithCalendar";
-import { Textarea } from "../ui/textarea";
 import { getISODateYMD, getISOTodayDate } from "@/lib/utils";
 import ExpiredPrayCardUI from "./ExpiredPrayCardUI";
 import DeletedPrayCardUI from "./DeletedPrayCardUI";
@@ -78,11 +77,9 @@ const OtherPrayCardUI: React.FC<OtherPrayCardProps> = ({
           </p>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
-          <Textarea
-            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={prayCard.content || ""}
-            disabled={true}
-          />
+          <p className="flex-grow w-full p-2 rounded-md text-sm overflow-y-auto no-scrollbar whitespace-pre-wrap ">
+            {prayCard.content || ""}
+          </p>
         </div>
       </div>
       <ReactionWithCalendar prayCard={prayCard} eventOption={eventOption} />

--- a/src/components/todayPray/TodayPrayCardUI.tsx
+++ b/src/components/todayPray/TodayPrayCardUI.tsx
@@ -1,6 +1,5 @@
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import ReactionWithCalendar from "../prayCard/ReactionWithCalendar";
-import { Textarea } from "../ui/textarea";
 import { getISODateYMD } from "@/lib/utils";
 import OtherPrayCardMenuBtn from "../prayCard/OtherPrayCardMenuBtn";
 import useBaseStore from "@/stores/baseStore";
@@ -60,11 +59,9 @@ const PrayCardUI: React.FC<PrayCardProps> = ({
           </p>
         </div>
         <div className="flex flex-col flex-grow min-h-full max-h-full items-start px-[10px] py-[10px] overflow-y-auto no-scrollbar">
-          <Textarea
-            className="flex-grow w-full p-2 rounded-md overflow-y-auto no-scrollbar text-black !opacity-100 !border-none !cursor-default"
-            value={prayCard.content || ""}
-            disabled={true}
-          />
+          <p className="flex-grow w-full p-2 rounded-md text-sm overflow-y-auto no-scrollbar whitespace-pre-wrap ">
+            {prayCard.content || ""}
+          </p>
         </div>
       </div>
       <ReactionWithCalendar prayCard={prayCard} eventOption={eventOption} />


### PR DESCRIPTION
드로어에 있는 기도카드 내용부분을 스와이프 가능하게 했습니다.
Drawer 내부에서 스와이프 필요한 기도카드UI 들을 다 p 태그로 바꿨습니다.
다만 MyPrayCardUI는 일단 놔뒀습니다.

- [x]  textarea 가로 스와이프 가능 여부 조사
- [x]  드로어 내 사용되는 기도카드 내용 p 태그로 대체

https://www.notion.so/mmyeong/fix-5652cf053abb40c6a9716b1a0bbf6822?pvs=4