### PR TITLE
refactor: 카카오 공유 메세지 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import GroupRedirectPage from "./pages/GroupRedirectPage";
 import GroupLimitPage from "./pages/GropuLimitPage";
 import TermServicePage from "./pages/TermServicePage";
 import EmailLoginPage from "./pages/EmailLoginPage";
+import KakaoShareCallBack from "./components/share/KakaoShareCallBack";
 
 const App = () => {
   useEffect(() => {
@@ -52,6 +53,10 @@ const App = () => {
                     <KakaoCallBack />
                   </PrivateRoute>
                 }
+              />
+              <Route
+                path="/share/kakao/callback"
+                element={<KakaoShareCallBack />}
               />
               <Route
                 path="/term"

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -1,6 +1,6 @@
 import useBaseStore from "@/stores/baseStore";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
-import { KakaoShareButton } from "../share/KakaoShareBtn";
+import { KakaoShareButton, TodayPrayLink } from "../share/KakaoShareBtn";
 import { PrayWithProfiles } from "supabase/types/tables";
 import { Button } from "../ui/button";
 import { analyticsTrack } from "@/analytics/analytics";
@@ -11,7 +11,6 @@ interface PrayListProps {
 }
 
 const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
-  const targetGroup = useBaseStore((state) => state.targetGroup);
   const setIsOpenMyPrayDrawer = useBaseStore(
     (state) => state.setIsOpenMyPrayDrawer
   );
@@ -42,6 +41,8 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
     });
   };
 
+  const kakaoLinkObject = TodayPrayLink();
+
   return (
     <div className="overflow-y-auto justify-center items-center">
       {isPrayerListEmpty ? (
@@ -57,8 +58,8 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
             <p>그룹 채팅방에 오늘의 기도 링크를 공유해 보아요</p>
           </div>
           <KakaoShareButton
-            targetGroup={targetGroup}
-            message="카카오톡 링크 공유"
+            buttonText="카카오톡 링크 공유"
+            kakaoLinkObject={kakaoLinkObject}
             eventOption={{ where: "PrayList" }}
           />
         </div>

--- a/src/components/pray/PrayList.tsx
+++ b/src/components/pray/PrayList.tsx
@@ -41,8 +41,6 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
     });
   };
 
-  const kakaoLinkObject = TodayPrayLink();
-
   return (
     <div className="overflow-y-auto justify-center items-center">
       {isPrayerListEmpty ? (
@@ -59,7 +57,7 @@ const PrayList: React.FC<PrayListProps> = ({ prayData }) => {
           </div>
           <KakaoShareButton
             buttonText="카카오톡 링크 공유"
-            kakaoLinkObject={kakaoLinkObject}
+            kakaoLinkObject={TodayPrayLink()}
             eventOption={{ where: "PrayList" }}
           />
         </div>

--- a/src/components/prayCard/DeletedPrayCardUI.tsx
+++ b/src/components/prayCard/DeletedPrayCardUI.tsx
@@ -1,9 +1,8 @@
-import { KakaoShareButton } from "../share/KakaoShareBtn";
+import { ExpiredMemberLink, KakaoShareButton } from "../share/KakaoShareBtn";
 import useBaseStore from "@/stores/baseStore";
 import OtherPrayCardMenuBtn from "./OtherPrayCardMenuBtn";
 
 const ExpiredPrayCardUI: React.FC = () => {
-  const targetGroup = useBaseStore((state) => state.targetGroup);
   const otherMember = useBaseStore((state) => state.otherMember);
 
   if (!otherMember) return null;
@@ -47,8 +46,8 @@ const ExpiredPrayCardUI: React.FC = () => {
         </div>
 
         <KakaoShareButton
-          targetGroup={targetGroup}
-          message="카카오톡으로 요청하기"
+          buttonText="카카오톡으로 요청하기"
+          kakaoLinkObject={ExpiredMemberLink()}
           eventOption={{ where: "ReactionWithCalendar" }}
         ></KakaoShareButton>
       </div>

--- a/src/components/prayCard/ExpiredPrayCardUI.tsx
+++ b/src/components/prayCard/ExpiredPrayCardUI.tsx
@@ -1,11 +1,10 @@
 import { getDateDistance } from "@toss/date";
 import { getISODateYMD, getISOOnlyDate, getISOTodayDate } from "@/lib/utils";
-import { KakaoShareButton } from "../share/KakaoShareBtn";
+import { ExpiredMemberLink, KakaoShareButton } from "../share/KakaoShareBtn";
 import useBaseStore from "@/stores/baseStore";
 import OtherPrayCardMenuBtn from "./OtherPrayCardMenuBtn";
 
 const ExpiredPrayCardUI: React.FC = () => {
-  const targetGroup = useBaseStore((state) => state.targetGroup);
   const otherMember = useBaseStore((state) => state.otherMember);
 
   if (!otherMember) return null;
@@ -67,8 +66,8 @@ const ExpiredPrayCardUI: React.FC = () => {
         </div>
 
         <KakaoShareButton
-          targetGroup={targetGroup}
-          message="카카오톡으로 요청하기"
+          buttonText="카카오톡으로 요청하기"
+          kakaoLinkObject={ExpiredMemberLink()}
           eventOption={{ where: "ReactionWithCalendar" }}
         ></KakaoShareButton>
       </div>

--- a/src/components/share/ContentDrawer.tsx
+++ b/src/components/share/ContentDrawer.tsx
@@ -6,11 +6,10 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "../ui/drawer";
-import { KakaoShareButton } from "./KakaoShareBtn";
+import { BibleCardLink, KakaoShareButton } from "./KakaoShareBtn";
 import { getISOTodayDateYMD } from "@/lib/utils";
 
 const ContentDrawer = () => {
-  const targetGroup = useBaseStore((state) => state.targetGroup);
   const isOpenContentDrawer = useBaseStore(
     (state) => state.isOpenContentDrawer
   );
@@ -36,10 +35,9 @@ const ContentDrawer = () => {
         />
       </div>
       <KakaoShareButton
-        targetGroup={targetGroup}
-        message="카카오톡으로 공유하기"
+        buttonText="카카오톡으로 공유하기"
+        kakaoLinkObject={BibleCardLink()}
         eventOption={{ where: "ContentDrawer" }}
-        type="bible"
       />
     </div>
   );

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -41,7 +41,7 @@ export const BibleCardLink = () => {
     objectType: "feed",
     content: {
       title: `${today.year}.${today.month}.${today.day} 오늘의 말씀`,
-      description: "PrayU 에서 오늘의 말씀과 함께 기도해요!",
+      description: "PrayU 에서 말씀과 함께 기도해요!",
       imageUrl: `https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/BibleContent/content${contentNumber}.png`,
       link: {
         webUrl: window.location.href,
@@ -65,7 +65,7 @@ export const GroupInviteLink = (groupName: string) => {
     objectType: "feed",
     content: {
       title: "PrayU 그룹 초대 알림",
-      description: `${groupName} 그룹에 초대 되었어요!\nPrayU 에서 매일의 기도를 시작해 보아요`,
+      description: `${groupName} 그룹에 초대 되었어요!\nPrayU 에서 매일의 기도를 시작해요`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/intro_800_500.png",
       imageWidth: 800,
@@ -92,7 +92,7 @@ export const TodayPrayLink = () => {
     objectType: "feed",
     content: {
       title: "PrayU 오늘의 기도 알림",
-      description: `오늘의 기도를 기다리는 기도제목이 있어요!`,
+      description: `기도를 기다리는 기도제목들이 있어요`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/notification.png",
       imageWidth: 400,
@@ -119,7 +119,7 @@ export const ExpiredMemberLink = () => {
     objectType: "feed",
     content: {
       title: "PrayU 기도카드 작성 알림",
-      description: `일주일이 지나 새로운 기도카드가 필요해요 😭`,
+      description: `이번 주 기도제목을 작성해 주세요🙏`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/expired.png",
       imageWidth: 400,

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -1,72 +1,25 @@
 import { analyticsTrack } from "@/analytics/analytics";
-import { getDomainUrl, getISOTodayDateYMD } from "@/lib/utils";
-import { Group } from "supabase/types/tables";
+import { getISOTodayDateYMD } from "@/lib/utils";
+import { KakaoLinkObject } from "../kakao/Kakao";
 
 interface EventOption {
   where: string;
 }
 
 interface KakaoShareButtonProps {
-  targetGroup: Group | null;
-  message: string;
+  buttonText: string;
+  kakaoLinkObject: KakaoLinkObject;
   eventOption: EventOption;
-  type?: string;
 }
 
-const getContent = (groupName: string, type: string) => {
-  const today = getISOTodayDateYMD();
-  const contentNumber = parseInt(today.day, 10) % 31;
-  switch (type) {
-    case "bible":
-      return {
-        title: `${today.year}.${today.month}.${today.day} 오늘의 말씀`,
-        description: "PrayU에서 오늘의 말씀과 함께 기도해요!",
-        imageUrl: `https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/BibleContent/content${contentNumber}.png`,
-      };
-    default:
-      return {
-        title: `PrayU - ${groupName}`,
-        description: "우리만의 기도제목 나눔 공간\nPrayU에서 함께 기도해요🙏",
-        imageUrl:
-          "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/introImage.png",
-      };
-  }
-};
-
 export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
-  targetGroup,
-  message,
-  type = "default",
+  buttonText,
+  kakaoLinkObject,
   eventOption,
 }) => {
-  const domainUrl = getDomainUrl();
-  const groupUrl = `${domainUrl}/group/${targetGroup!.id}`;
-  const content = getContent(targetGroup!.name!, type);
   const handleClickKakaoBtn = () => {
-    analyticsTrack("클릭_카카오_공유", {
-      where: eventOption.where,
-    });
-    window.Kakao.Share.sendDefault({
-      objectType: "feed",
-      content: {
-        title: content.title,
-        description: content.description,
-        imageUrl: content.imageUrl,
-        link: {
-          mobileWebUrl: groupUrl,
-          webUrl: groupUrl,
-        },
-      },
-      buttons: [
-        {
-          title: "오늘의 기도",
-          link: {
-            mobileWebUrl: groupUrl,
-            webUrl: groupUrl,
-          },
-        },
-      ],
-    });
+    analyticsTrack("클릭_카카오_공유", { where: eventOption.where });
+    window.Kakao.Share.sendDefault(kakaoLinkObject);
   };
 
   return (
@@ -74,7 +27,110 @@ export const KakaoShareButton: React.FC<KakaoShareButtonProps> = ({
       className="bg-yellow-300 px-10 py-2 rounded-md text-sm"
       onClick={() => handleClickKakaoBtn()}
     >
-      {message}
+      {buttonText}
     </button>
   );
+};
+
+// KakaoLinkObject
+
+export const BibleCardLink = () => {
+  const today = getISOTodayDateYMD();
+  const contentNumber = parseInt(today.day, 10) % 31;
+  return {
+    objectType: "feed",
+    content: {
+      title: `${today.year}.${today.month}.${today.day} PrayU 오늘의 말씀카드`,
+      description: "PrayU 에서 오늘의 말씀과 함께 기도해요!",
+      imageUrl: `https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/BibleContent/content${contentNumber}.png`,
+      link: {
+        webUrl: window.location.href,
+        mobileWebUrl: window.location.href,
+      },
+    },
+    buttons: [
+      {
+        title: "오늘의 기도 시작하기",
+        link: {
+          mobileWebUrl: window.location.href,
+          webUrl: window.location.href,
+        },
+      },
+    ],
+  } as KakaoLinkObject;
+};
+
+export const GroupInviteLink = (groupName: string) => {
+  return {
+    objectType: "feed",
+    content: {
+      title: "PrayU 그룹 초대 알림",
+      description: `${groupName} 그룹에 초대 되었어요!\nPrayU 와 함께 기도생활을 시작해보아요`,
+      imageUrl:
+        "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/intro_800_500.png",
+      link: {
+        webUrl: window.location.href,
+        mobileWebUrl: window.location.href,
+      },
+    },
+    buttons: [
+      {
+        title: "그룹 입장하기",
+        link: {
+          mobileWebUrl: window.location.href,
+          webUrl: window.location.href,
+        },
+      },
+    ],
+  } as KakaoLinkObject;
+};
+
+export const TodayPrayLink = () => {
+  return {
+    objectType: "feed",
+    content: {
+      title: "PrayU 오늘의 기도 알림",
+      description: `아직 오늘의 기도를 진행하지 않으셨나요?\n기도를 완료하고 내게 기도해준 친구를 확인해보아요!`,
+      imageUrl:
+        "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/notification.png",
+      link: {
+        webUrl: window.location.href,
+        mobileWebUrl: window.location.href,
+      },
+    },
+    buttons: [
+      {
+        title: "오늘의 기도 시작하기",
+        link: {
+          mobileWebUrl: window.location.href,
+          webUrl: window.location.href,
+        },
+      },
+    ],
+  } as KakaoLinkObject;
+};
+
+export const ExpiredMemberLink = () => {
+  return {
+    objectType: "feed",
+    content: {
+      title: "PrayU 기도카드 작성 알림",
+      description: `일주일이 지나 새로운 기도카드가 필요해요\n기도카드를 올리고 이번 주 기도를 받아 보아요!`,
+      imageUrl:
+        "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/expired.png",
+      link: {
+        webUrl: window.location.href,
+        mobileWebUrl: window.location.href,
+      },
+    },
+    buttons: [
+      {
+        title: "기도카드 작성하기",
+        link: {
+          mobileWebUrl: window.location.href,
+          webUrl: window.location.href,
+        },
+      },
+    ],
+  } as KakaoLinkObject;
 };

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -68,6 +68,8 @@ export const GroupInviteLink = (groupName: string) => {
       description: `${groupName} 그룹에 초대 되었어요!\nPrayU 와 함께 기도생활을 시작해보아요`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/intro_800_500.png",
+      imageWidth: 800,
+      imageHeight: 500,
       link: {
         webUrl: window.location.href,
         mobileWebUrl: window.location.href,
@@ -93,6 +95,8 @@ export const TodayPrayLink = () => {
       description: `아직 오늘의 기도를 진행하지 않으셨나요?\n기도를 완료하고 내게 기도해준 친구를 확인해보아요!`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/notification.png",
+      imageWidth: 400,
+      imageHeight: 240,
       link: {
         webUrl: window.location.href,
         mobileWebUrl: window.location.href,
@@ -118,6 +122,8 @@ export const ExpiredMemberLink = () => {
       description: `일주일이 지나 새로운 기도카드가 필요해요\n기도카드를 올리고 이번 주 기도를 받아 보아요!`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/expired.png",
+      imageWidth: 400,
+      imageHeight: 240,
       link: {
         webUrl: window.location.href,
         mobileWebUrl: window.location.href,

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -92,7 +92,7 @@ export const TodayPrayLink = () => {
     objectType: "feed",
     content: {
       title: "PrayU 오늘의 기도 알림",
-      description: `기도를 기다리는 기도제목들이 있어요`,
+      description: `기도를 기다리는 기도제목들이 있어요!`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/notification.png",
       imageWidth: 400,

--- a/src/components/share/KakaoShareBtn.tsx
+++ b/src/components/share/KakaoShareBtn.tsx
@@ -40,7 +40,7 @@ export const BibleCardLink = () => {
   return {
     objectType: "feed",
     content: {
-      title: `${today.year}.${today.month}.${today.day} PrayU 오늘의 말씀카드`,
+      title: `${today.year}.${today.month}.${today.day} 오늘의 말씀`,
       description: "PrayU 에서 오늘의 말씀과 함께 기도해요!",
       imageUrl: `https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/BibleContent/content${contentNumber}.png`,
       link: {
@@ -65,7 +65,7 @@ export const GroupInviteLink = (groupName: string) => {
     objectType: "feed",
     content: {
       title: "PrayU 그룹 초대 알림",
-      description: `${groupName} 그룹에 초대 되었어요!\nPrayU 와 함께 기도생활을 시작해보아요`,
+      description: `${groupName} 그룹에 초대 되었어요!\nPrayU 에서 매일의 기도를 시작해 보아요`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/intro_800_500.png",
       imageWidth: 800,
@@ -92,7 +92,7 @@ export const TodayPrayLink = () => {
     objectType: "feed",
     content: {
       title: "PrayU 오늘의 기도 알림",
-      description: `아직 오늘의 기도를 진행하지 않으셨나요?\n기도를 완료하고 내게 기도해준 친구를 확인해보아요!`,
+      description: `오늘의 기도를 기다리는 기도제목이 있어요!`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/notification.png",
       imageWidth: 400,
@@ -119,7 +119,7 @@ export const ExpiredMemberLink = () => {
     objectType: "feed",
     content: {
       title: "PrayU 기도카드 작성 알림",
-      description: `일주일이 지나 새로운 기도카드가 필요해요\n기도카드를 올리고 이번 주 기도를 받아 보아요!`,
+      description: `일주일이 지나 새로운 기도카드가 필요해요 😭`,
       imageUrl:
         "https://qggewtakkrwcclyxtxnz.supabase.co/storage/v1/object/public/prayu/expired.png",
       imageWidth: 400,

--- a/src/components/share/KakaoShareCallBack.tsx
+++ b/src/components/share/KakaoShareCallBack.tsx
@@ -1,0 +1,8 @@
+import { analyticsTrack } from "@/analytics/analytics";
+
+const KakaoShareCallBack: React.FC = () => {
+  analyticsTrack("콜백_카카오_전송완료", { where: "KakaoShareCallBack" });
+  return null;
+};
+
+export default KakaoShareCallBack;

--- a/src/components/share/OpenShareDrawerBtn.tsx
+++ b/src/components/share/OpenShareDrawerBtn.tsx
@@ -43,10 +43,10 @@ const OpenShareDrawerBtn: React.FC<OpenShareDrawerBtnProps> = ({
   if (type == "tag")
     return (
       <div
-        className="w-[48px] flex items-center gap-1 text-[12px] cursor-pointer"
+        className="w-[48px] flex items-center gap-1 text-[14px] cursor-pointer"
         onClick={() => handleClickSharBtn()}
       >
-        <img src={inviteIcon} className="w-[10px] h-[10px]" />
+        <img src={inviteIcon} className="w-[16px] h-[16px]" />
         <span>{text}</span>
       </div>
     );

--- a/src/components/share/ShareDrawer.tsx
+++ b/src/components/share/ShareDrawer.tsx
@@ -12,7 +12,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "../ui/drawer";
-import { KakaoShareButton } from "./KakaoShareBtn";
+import { GroupInviteLink, KakaoShareButton } from "./KakaoShareBtn";
 import { Button } from "../ui/button";
 import { toast } from "../ui/use-toast";
 import { analyticsTrack } from "@/analytics/analytics";
@@ -125,8 +125,8 @@ const ShareDrawer: React.FC = () => {
       {ImageCerousel}
       <div className="flex flex-col gap-2">
         <KakaoShareButton
-          targetGroup={targetGroup}
-          message="카카오톡으로 초대하기"
+          buttonText="카카오톡으로 초대하기"
+          kakaoLinkObject={GroupInviteLink(targetGroup?.name || "")}
           eventOption={{ where: "GroupPage" }}
         />
         <Button

--- a/src/components/todayPray/TodayPrayCardListDrawer.tsx
+++ b/src/components/todayPray/TodayPrayCardListDrawer.tsx
@@ -7,7 +7,7 @@ import useBaseStore from "@/stores/baseStore";
 import PrayCardUI from "./TodayPrayCardUI";
 import { useEffect } from "react";
 import { getISOTodayDate } from "@/lib/utils";
-import { KakaoShareButton } from "../share/KakaoShareBtn";
+import { KakaoShareButton, TodayPrayLink } from "../share/KakaoShareBtn";
 import MyMemberBtn from "../member/MyMemberBtn";
 import { PrayTypeDatas } from "@/Enums/prayType";
 import OpenContentDrawerBtn from "../share/OpenContentDrawerBtn";
@@ -31,7 +31,6 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
 }) => {
   const myMember = useBaseStore((state) => state.myMember);
   const memberList = useBaseStore((state) => state.memberList);
-  const targetGroup = useBaseStore((state) => state.targetGroup);
   const groupPrayCardList = useBaseStore((state) => state.groupPrayCardList);
   const fetchGroupPrayCardList = useBaseStore(
     (state) => state.fetchGroupPrayCardList
@@ -101,8 +100,8 @@ const TodayPrayCardListDrawer: React.FC<PrayCardListProps> = ({
         </p>
       </div>
       <KakaoShareButton
-        targetGroup={targetGroup}
-        message="카카오톡으로 초대하기"
+        buttonText="카카오톡으로 초대하기"
+        kakaoLinkObject={TodayPrayLink()}
         eventOption={{ where: "PrayCardList" }}
       ></KakaoShareButton>
     </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5cc0f97f-daae-451e-9dc5-aff3eee10777)


### 작업설명
초대 카드의 각 역할에 맞춰 이미지와 멘트를 수정합니다.
이후 이미지는 디자이너 기준으로 추가 수정합니다.

### 작업 내용
1. 카카오 공유 버튼 리팩터링
2. 커스텀 메세지 컴포넌트 추가
3. 사용처 업데이트
4. 카카오 전송완료 콜백 추가

### 체크리스트
- [x]  초대 메세지
- [x]  입장 및 리마인드 메세지
- [x]  말씀카드 메세지 `유지`
- [x]  만료 유저 독려 메세지