### PR TITLE
refactor: 로그인 리다이렉트 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import GroupLimitPage from "./pages/GropuLimitPage";
 import TermServicePage from "./pages/TermServicePage";
 import EmailLoginPage from "./pages/EmailLoginPage";
 import KakaoShareCallBack from "./components/share/KakaoShareCallBack";
+import LoginRedirect from "./components/auth/LoginRedirect";
 
 const App = () => {
   useEffect(() => {
@@ -46,6 +47,14 @@ const App = () => {
               import.meta.env.VITE_ENV === "prod") && <AnalyticsTracker />}
             <Routes>
               <Route path="/" element={<MainPage />} />
+              <Route
+                path="/auth/redirect"
+                element={
+                  <PrivateRoute>
+                    <LoginRedirect />
+                  </PrivateRoute>
+                }
+              />
               <Route
                 path="/auth/kakao/callback"
                 element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ const App = () => {
             <Routes>
               <Route path="/" element={<MainPage />} />
               <Route
-                path="/auth/redirect"
+                path="/login-redirect"
                 element={
                   <PrivateRoute>
                     <LoginRedirect />

--- a/src/components/auth/LogInDrawer.tsx
+++ b/src/components/auth/LogInDrawer.tsx
@@ -24,7 +24,7 @@ const LogInDrawer = () => {
   const pathParts = pathname.split("/");
   const groupId =
     pathParts.length === 3 && pathParts[1] === "group" ? pathParts[2] : "";
-  const redirectUrl = `${baseUrl}/auth/redirect?groupId=${groupId}&from=LogInDrawer`;
+  const redirectUrl = `${baseUrl}/login-redirect?groupId=${groupId}&from=LogInDrawer`;
 
   const [isIOSApp, setIsIOSApp] = useState(false);
 

--- a/src/components/auth/LogInDrawer.tsx
+++ b/src/components/auth/LogInDrawer.tsx
@@ -24,7 +24,7 @@ const LogInDrawer = () => {
   const pathParts = pathname.split("/");
   const groupId =
     pathParts.length === 3 && pathParts[1] === "group" ? pathParts[2] : "";
-  const redirectUrl = `${baseUrl}/term?groupId=${groupId}`;
+  const redirectUrl = `${baseUrl}/auth/redirect?groupId=${groupId}&from=LogInDrawer`;
 
   const [isIOSApp, setIsIOSApp] = useState(false);
 

--- a/src/components/auth/LoginRedirect.tsx
+++ b/src/components/auth/LoginRedirect.tsx
@@ -23,19 +23,16 @@ const LoginRedirect = () => {
   const from = params.get("from");
   const groupPageUrl = groupId ? `/group/${groupId}` : "/group";
 
-  console.log(user);
-
   useEffect(() => {
     getProfile(currentUserId);
-  }, [currentUserId, getProfile]);
+    if (from == "MyPrayCard") setIsOpenMyMemberDrawer(true);
+  }, [currentUserId, getProfile, from, setIsOpenMyMemberDrawer]);
 
   useEffect(() => {
     if (!myProfile) return;
     if (!myProfile.kakao_id && provider == "kakao") {
       updateProfile(currentUserId, { kakao_id: kakaoId });
     }
-
-    if (from == "MyPrayCard") setIsOpenMyMemberDrawer(true);
 
     if (!myProfile.terms_agreed_at)
       navigate(`/term?groupId=${groupId}`, { replace: true });
@@ -47,9 +44,7 @@ const LoginRedirect = () => {
     provider,
     updateProfile,
     navigate,
-    from,
     groupId,
-    setIsOpenMyMemberDrawer,
     groupPageUrl,
   ]);
 

--- a/src/components/auth/LoginRedirect.tsx
+++ b/src/components/auth/LoginRedirect.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import useBaseStore from "@/stores/baseStore";
+import useAuth from "@/hooks/useAuth";
+
+const LoginRedirect = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const myProfile = useBaseStore((state) => state.myProfile);
+  const getProfile = useBaseStore((state) => state.getProfile);
+  const updateProfile = useBaseStore((state) => state.updateProfile);
+  const setIsOpenMyMemberDrawer = useBaseStore(
+    (state) => state.setIsOpenMyMemberDrawer
+  );
+
+  const location = useLocation();
+  const currentUserId = user!.id;
+  const provider = user!.app_metadata.provider;
+  const kakaoId = user!.user_metadata.provider_id;
+  const params = new URLSearchParams(location.search);
+  const groupId = params.get("groupId");
+  const from = params.get("from");
+  const groupPageUrl = groupId ? `/group/${groupId}` : "/group";
+
+  console.log(user);
+
+  useEffect(() => {
+    getProfile(currentUserId);
+  }, [currentUserId, getProfile]);
+
+  useEffect(() => {
+    if (!myProfile) return;
+    if (!myProfile.kakao_id && provider == "kakao") {
+      updateProfile(currentUserId, { kakao_id: kakaoId });
+    }
+
+    if (from == "MyPrayCard") setIsOpenMyMemberDrawer(true);
+
+    if (!myProfile.terms_agreed_at)
+      navigate(`/term?groupId=${groupId}`, { replace: true });
+    else navigate(groupPageUrl, { replace: true });
+  }, [
+    myProfile,
+    currentUserId,
+    kakaoId,
+    provider,
+    updateProfile,
+    navigate,
+    from,
+    groupId,
+    setIsOpenMyMemberDrawer,
+    groupPageUrl,
+  ]);
+
+  return null;
+};
+
+export default LoginRedirect;

--- a/src/pages/EmailLoginPage.tsx
+++ b/src/pages/EmailLoginPage.tsx
@@ -12,7 +12,7 @@ const EmailLoginPage = () => {
 
   useEffect(() => {
     if (user) {
-      navigate("/auth/redirect");
+      navigate("/login-redirect");
     }
   }, [user, navigate]);
 

--- a/src/pages/EmailLoginPage.tsx
+++ b/src/pages/EmailLoginPage.tsx
@@ -12,7 +12,7 @@ const EmailLoginPage = () => {
 
   useEffect(() => {
     if (user) {
-      navigate("/term");
+      navigate("/auth/redirect");
     }
   }, [user, navigate]);
 

--- a/src/pages/TermServicePage.tsx
+++ b/src/pages/TermServicePage.tsx
@@ -8,7 +8,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { Checkbox } from "@/components/ui/checkbox";
 import { IoIosArrowForward } from "react-icons/io";
 import { analyticsTrack } from "@/analytics/analytics";
-import { getISOTodayDate } from "@/lib/utils";
+import { getISOToday, getISOTodayDate } from "@/lib/utils";
 
 const TermServicePage: React.FC = () => {
   const getProfile = useBaseStore((state) => state.getProfile);
@@ -57,7 +57,7 @@ const TermServicePage: React.FC = () => {
     setIsDisabledAgreeBtn(true);
     analyticsTrack("클릭_동의_완료", {});
     const updatedProfile = await updateProfile(profile.id, {
-      terms_agreed_at: getISOTodayDate(),
+      terms_agreed_at: getISOToday(),
     });
     if (!updatedProfile) {
       setIsDisabledAgreeBtn(false);

--- a/src/pages/TermServicePage.tsx
+++ b/src/pages/TermServicePage.tsx
@@ -28,7 +28,6 @@ const TermServicePage: React.FC = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const groupId = queryParams.get("groupId");
-  const redirectUrl = groupId ? `/group/${groupId}` : "/group";
 
   const [isChecked, setIsChecked] = useState(false);
   const [isDisabledAgreeBtn, setIsDisabledAgreeBtn] = useState(false);
@@ -37,17 +36,7 @@ const TermServicePage: React.FC = () => {
   useEffect(() => {
     if (user) fetchGroupListByUserId(user.id);
     if (user && !profile) getProfile(user.id);
-    if (profile && profile.terms_agreed_at !== null) {
-      navigate(redirectUrl, { replace: true });
-    }
-  }, [
-    user,
-    profile,
-    getProfile,
-    navigate,
-    redirectUrl,
-    fetchGroupListByUserId,
-  ]);
+  }, [user, profile, getProfile, fetchGroupListByUserId]);
 
   if (!profile || !groupList) return null;
 
@@ -75,16 +64,18 @@ const TermServicePage: React.FC = () => {
       return;
     }
 
-    if (groupId) navigate(redirectUrl, { replace: true });
+    if (groupId) navigate(`/group/${groupId}`, { replace: true });
     else {
       if (groupList.length > 0)
         navigate(`/group/${groupList[0].id}`, { replace: true });
-      const targetGroupId = await handleCreateGroup();
-      if (!targetGroupId) {
-        setIsDisabledAgreeBtn(false);
-        return;
+      else {
+        const targetGroupId = await handleCreateGroup();
+        if (!targetGroupId) {
+          setIsDisabledAgreeBtn(false);
+          return;
+        }
+        navigate(`/group/${targetGroupId}`, { replace: true });
       }
-      navigate(`/group/${targetGroupId}`, { replace: true });
     }
   };
 

--- a/src/pages/TermServicePage.tsx
+++ b/src/pages/TermServicePage.tsx
@@ -8,7 +8,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { Checkbox } from "@/components/ui/checkbox";
 import { IoIosArrowForward } from "react-icons/io";
 import { analyticsTrack } from "@/analytics/analytics";
-import { getISOToday, getISOTodayDate } from "@/lib/utils";
+import { getISOToday } from "@/lib/utils";
 
 const TermServicePage: React.FC = () => {
   const getProfile = useBaseStore((state) => state.getProfile);


### PR DESCRIPTION
# 작업 설명

로그인 종류가 많아지면서 로그인 이후 redirect 하는 지점이 명시되지 않아 혼동이 있습니다.
/login-redirect 라는 경로를 만들고 동의를 안한 유저만 /term 으로 넘기도록 합니다.

# 체크리스트
- [x]  약관 페이지로 리다이렉트 되는 부분 수정
- [x]  로그인 리다이렉트 페이지 만들기

# 테스트

- [x] 첫 유저 로그인 이후 약관 페이지로 잘 가는지 테스트
- [x] 기본 유저 로그인 이후 그룹페이지로 잘 가는지 테스트
