### PR TITLE
refactor: 카카오톡 이용중 동의 개선

### DIFF
--- a/src/components/auth/LoginRedirect.tsx
+++ b/src/components/auth/LoginRedirect.tsx
@@ -6,6 +6,7 @@ import useAuth from "@/hooks/useAuth";
 
 const LoginRedirect = () => {
   const { user } = useAuth();
+  const session = useBaseStore((state) => state.session);
   const navigate = useNavigate();
   const myProfile = useBaseStore((state) => state.myProfile);
   const getProfile = useBaseStore((state) => state.getProfile);
@@ -30,8 +31,10 @@ const LoginRedirect = () => {
 
   useEffect(() => {
     if (!myProfile) return;
-    if (!myProfile.kakao_id && provider == "kakao") {
-      updateProfile(currentUserId, { kakao_id: kakaoId });
+    if (provider == "kakao") {
+      window.Kakao.Auth.setAccessToken(session?.provider_token || "");
+      if (!myProfile.kakao_id)
+        updateProfile(currentUserId, { kakao_id: kakaoId });
     }
 
     if (!myProfile.terms_agreed_at)
@@ -46,6 +49,7 @@ const LoginRedirect = () => {
     navigate,
     groupId,
     groupPageUrl,
+    session,
   ]);
 
   return null;

--- a/src/components/kakao/Kakao.d.ts
+++ b/src/components/kakao/Kakao.d.ts
@@ -81,6 +81,20 @@ interface KakaoSendMessageResponse extends KakaoAPIResponse {
   successful_receiver_uuids: string[];
 }
 
+interface KakaoScopeResponse extends KakaoAPIResponse {
+  id: number;
+  scopes: Scope[];
+}
+
+interface Scope {
+  id: string;
+  display_name: string;
+  type: "PRIVACY" | "SERVICE";
+  using: boolean;
+  agreed: boolean;
+  revocable?: boolean;
+}
+
 interface Friend {
   id: number;
   uuid: string;

--- a/src/components/kakao/KakaoController.tsx
+++ b/src/components/kakao/KakaoController.tsx
@@ -2,14 +2,24 @@ import * as Sentry from "@sentry/react";
 import {
   KakaoFriendsResponse,
   KakaoMessageObject,
+  KakaoScopeResponse,
   KakaoSendMessageResponse,
 } from "./Kakao";
-import { KakaoTokenRepo } from "./KakaoTokenRepo";
 
-// 본 컨트롤러 사용처에서 로그인 페이지로 이동 할 수 있다는 것 인지
 export class KakaoController {
-  constructor() {
-    KakaoTokenRepo.init();
+  static async checkKakaoScope(): Promise<boolean> {
+    try {
+      const response: KakaoScopeResponse = await window.Kakao.API.request({
+        url: "/v2/user/scopes",
+        data: { scopes: ["friends", "talk_message"] },
+      });
+      const hasDisagreedScope = response.scopes.some((scope) => !scope.agreed);
+      if (hasDisagreedScope) return false;
+      else return true;
+    } catch (error) {
+      Sentry.captureException(error);
+      return false;
+    }
   }
 
   static async getMyProfiles() {

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -66,7 +66,7 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
     else {
       setAlertData({
         color: "bg-mainBtn",
-        title: "메세지 전송 동의",
+        title: "카카오톡 전송 동의",
         description: `그룹원들과 카카오톡으로 기도요청 메세지를 보내요!`,
         actionText: "계속하기",
         cancelText: "취소",

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -67,7 +67,7 @@ const MyPrayCardMenuBtn: React.FC<MyMoreBtnProps> = ({
       setAlertData({
         color: "bg-mainBtn",
         title: "메세지 전송 동의",
-        description: `그룹원들과 카카오톡 기도요청 메세지를 보내보아요!`,
+        description: `그룹원들과 카카오톡으로 기도요청 메세지를 보내요!`,
         actionText: "계속하기",
         cancelText: "취소",
         onAction: async () => {

--- a/src/components/prayCard/MyPrayCardMenuBtn.tsx
+++ b/src/components/prayCard/MyPrayCardMenuBtn.tsx
@@ -15,7 +15,6 @@ import { toast } from "../ui/use-toast";
 import { deletePrayCard } from "@/apis/prayCard";
 import { KakaoTokenRepo } from "../kakao/KakaoTokenRepo";
 import { KakaoController } from "../kakao/KakaoController";
-import { KakaoSendMessageResponse, SelectedUsers } from "../kakao/Kakao";
 import { MdMailOutline } from "react-icons/md";
 import { PrayCardWithProfiles } from "supabase/types/tables";
 import { PrayRequestMessage } from "../kakao/KakaoMessage";

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -7,7 +7,7 @@ import {
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { supabase } from "../../supabase/client";
-import { User } from "@supabase/supabase-js";
+import { User, Session } from "@supabase/supabase-js";
 import {
   Group,
   Member,
@@ -56,6 +56,7 @@ import { getProfile } from "@/apis/profiles";
 
 export interface BaseStore {
   // user
+  session: Session | null;
   user: User | null;
   userLoading: boolean;
   userPlan: string;
@@ -253,6 +254,7 @@ export interface BaseStore {
 const useBaseStore = create<BaseStore>()(
   immer((set) => ({
     // user
+    session: null,
     user: null,
     userLoading: true,
     userPlan: "",
@@ -261,6 +263,7 @@ const useBaseStore = create<BaseStore>()(
         data: { session },
       } = await supabase.auth.getSession();
       set((state) => {
+        state.session = session;
         state.user = session?.user || null;
         state.userLoading = false;
       });


### PR DESCRIPTION
# 작업 설명

카카오 로그인 처음 할 때 소셜 기능 관련 선택 동의가 가능한 것 같아 그에 맞게 수정합니다.
이후 카카오 메세지 관련 기획이 들어간다면 이를 활용할 수 있는 토대를 마련합니다.

# 체크리스트

- [x]  supabase 카카오 로그인을 통해 나온 session.provider_token 사용
- [x]  사용처에서 scope 동의 목록 확인하도록 수정
- [x]  6시간 이후(카카오톡 토큰 만료) 재접속시에 어떻게 되는지 스테이징에서 확인 필요