### PR TITLE
refactor: 멤버 드로워 분리 및 개선

### DIFF
--- a/src/components/member/OtherMemberDrawer.tsx
+++ b/src/components/member/OtherMemberDrawer.tsx
@@ -1,0 +1,39 @@
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import useBaseStore from "@/stores/baseStore";
+import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
+
+const OtherMemberDrawer: React.FC = () => {
+  const user = useBaseStore((state) => state.user);
+  const isOpenOtherMemberDrawer = useBaseStore(
+    (state) => state.isOpenOtherMemberDrawer
+  );
+  const setIsOpenOtherMemberDrawer = useBaseStore(
+    (state) => state.setIsOpenOtherMemberDrawer
+  );
+
+  return (
+    <Drawer
+      open={isOpenOtherMemberDrawer}
+      onOpenChange={setIsOpenOtherMemberDrawer}
+    >
+      <DrawerContent className="bg-mainBg pb-5">
+        <DrawerHeader>
+          <DrawerTitle></DrawerTitle>
+          <DrawerDescription></DrawerDescription>
+        </DrawerHeader>
+        <OtherPrayCardUI
+          currentUserId={user!.id}
+          eventOption={{ where: "OtherMember" }}
+        />
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default OtherMemberDrawer;

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -1,88 +1,24 @@
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
-import { useEffect } from "react";
-import useBaseStore from "@/stores/baseStore";
 import OtherMember from "./OtherMember";
 import TodayPrayBtn from "../todayPray/TodayPrayBtn";
-import TodayPrayStartCard from "../todayPray/TodayPrayStartCard";
-import { getISOTodayDate } from "@/lib/utils";
-import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
 import { MemberWithProfiles } from "supabase/types/tables";
 
 interface OtherMembersProps {
-  currentUserId: string;
-  groupId: string;
-  memberList: MemberWithProfiles[];
+  otherMemberList: MemberWithProfiles[];
 }
 
-const OtherMemberList: React.FC<OtherMembersProps> = ({
-  currentUserId,
-  groupId,
-  memberList,
-}) => {
-  const isPrayToday = useBaseStore((state) => state.isPrayToday);
-  const fetchIsPrayToday = useBaseStore((state) => state.fetchIsPrayToday);
-  const isOpenOtherMemberDrawer = useBaseStore(
-    (state) => state.isOpenOtherMemberDrawer
-  );
-
-  const myMember = useBaseStore((state) => state.myMember);
-
-  const setIsOpenOtherMemberDrawer = useBaseStore(
-    (state) => state.setIsOpenOtherMemberDrawer
-  );
-
-  useEffect(() => {
-    fetchIsPrayToday(currentUserId, groupId);
-  }, [currentUserId, fetchIsPrayToday, groupId]);
-
-  const otherMemberList = memberList.filter(
-    (member) => member.user_id && member.user_id !== currentUserId
-  );
-  const isExpiredAllMember = otherMemberList.every(
-    (member) => member.updated_at < getISOTodayDate(-6)
-  );
-
-  if (!myMember || isPrayToday == null) return null;
-  if ((!isPrayToday && !isExpiredAllMember) || otherMemberList.length == 0)
-    return <TodayPrayStartCard />;
-
+const OtherMemberList: React.FC<OtherMembersProps> = ({ otherMemberList }) => {
   return (
-    <>
-      <div className="flex flex-col gap-2 pb-10">
-        <div className="text-sm text-gray-500 p-2">기도 구성원</div>
-        <div className="flex flex-col gap-4">
-          {otherMemberList.map((member) => (
-            <OtherMember key={member.id} member={member}></OtherMember>
-          ))}
-        </div>
-        <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
-          <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />
-        </div>
+    <div className="flex flex-col gap-2 pb-10">
+      <div className="text-sm text-gray-500 p-2">기도 구성원</div>
+      <div className="flex flex-col gap-4">
+        {otherMemberList.map((member) => (
+          <OtherMember key={member.id} member={member}></OtherMember>
+        ))}
       </div>
-      <Drawer
-        open={isOpenOtherMemberDrawer}
-        onOpenChange={setIsOpenOtherMemberDrawer}
-      >
-        <DrawerContent className="bg-mainBg pb-5">
-          <DrawerHeader>
-            <DrawerTitle></DrawerTitle>
-            <DrawerDescription></DrawerDescription>
-          </DrawerHeader>
-          {/* PrayCard */}
-          <OtherPrayCardUI
-            currentUserId={currentUserId}
-            eventOption={{ where: "OtherMember" }}
-          />
-          {/* PrayCard */}
-        </DrawerContent>
-      </Drawer>
-    </>
+      <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2">
+        <TodayPrayBtn eventOption={{ where: "OtherMemberList" }} />
+      </div>
+    </div>
   );
 };
 

--- a/src/components/prayCard/DeletedPrayCardUI.tsx
+++ b/src/components/prayCard/DeletedPrayCardUI.tsx
@@ -46,7 +46,8 @@ const ExpiredPrayCardUI: React.FC = () => {
         </div>
 
         <KakaoShareButton
-          buttonText="카카오톡으로 요청하기"
+          className="w-48"
+          buttonText="요청 메세지 보내기"
           kakaoLinkObject={ExpiredMemberLink()}
           eventOption={{ where: "ReactionWithCalendar" }}
         ></KakaoShareButton>

--- a/src/components/todayPray/TodayPrayCardList.tsx
+++ b/src/components/todayPray/TodayPrayCardList.tsx
@@ -25,6 +25,7 @@ const TodayPrayCardList = () => {
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
 
   useEffect(() => {
+    setPrayCardCarouselIndex(1);
     prayCardCarouselApi?.on("select", () => {
       const currentIndex = prayCardCarouselApi.selectedScrollSnap();
       setPrayCardCarouselIndex(currentIndex);

--- a/src/components/todayPray/TodayPrayCompletedItem.tsx
+++ b/src/components/todayPray/TodayPrayCompletedItem.tsx
@@ -54,6 +54,7 @@ const TodayPrayCompletedItem = () => {
 
   return (
     <div className="relative flex flex-col gap-4 justify-center items-center min-h-80vh max-h-80vh pb-10">
+      s{" "}
       <div className="h-[280px] w-full flex flex-col items-center">
         <img
           className={`h-full rounded-2xl transition-opacity duration-1000 ease-in ${
@@ -82,7 +83,7 @@ const TodayPrayCompletedItem = () => {
         eventOption={{ where: "TodayPrayCompletedItem" }}
       />
       <button
-        className="absolute bottom-10 flex gap-1 items-center text-gray-400"
+        className="absolute bottom-3 flex gap-1 items-center text-gray-400"
         onClick={() => setIsOpenTodayPrayDrawer(false)}
       >
         <IoClose />

--- a/src/components/todayPray/TodayPrayCompletedItem.tsx
+++ b/src/components/todayPray/TodayPrayCompletedItem.tsx
@@ -54,7 +54,6 @@ const TodayPrayCompletedItem = () => {
 
   return (
     <div className="relative flex flex-col gap-4 justify-center items-center min-h-80vh max-h-80vh pb-10">
-      s{" "}
       <div className="h-[280px] w-full flex flex-col items-center">
         <img
           className={`h-full rounded-2xl transition-opacity duration-1000 ease-in ${

--- a/src/components/todayPray/TodayPrayCompletedItem.tsx
+++ b/src/components/todayPray/TodayPrayCompletedItem.tsx
@@ -25,7 +25,6 @@ const TodayPrayCompletedItem = () => {
 
   useEffect(() => {
     if (
-      !isPrayToday &&
       prayCardCarouselApi &&
       prayCardCarouselIndex !== prayCardCarouselApi!.scrollSnapList().length - 2
     ) {

--- a/src/components/todayPray/TodayPrayDummyCompletedItem.tsx
+++ b/src/components/todayPray/TodayPrayDummyCompletedItem.tsx
@@ -81,7 +81,7 @@ const TodayPrayDummyCompletedItem = () => {
         eventOption={{ where: "TodayPrayDummyCompletedItem" }}
       />
       <button
-        className="absolute bottom-10 flex gap-1 items-center text-gray-400"
+        className="absolute bottom-3 flex gap-1 items-center text-gray-400"
         onClick={() => setIsOpenTodayPrayDrawer(false)}
       >
         <IoClose />

--- a/src/components/todayPray/TodayPrayEmptyItem.tsx
+++ b/src/components/todayPray/TodayPrayEmptyItem.tsx
@@ -1,8 +1,8 @@
-import { KakaoShareButton, TodayPrayLink } from "../share/KakaoShareBtn";
+import { KakaoShareButton, ExpiredMemberLink } from "../share/KakaoShareBtn";
 
 const TodayPrayEmptyItem = () => {
   return (
-    <div className="flex flex-col justify-center items-center px-10 gap-4">
+    <div className="flex flex-col justify-center items-center px-10 pb-5 gap-4">
       <p className="text-lg font-bold">아직 올라온 기도제목이 없어요 😭</p>
       <div className="h-[300px] w-full flex flex-col items-center">
         <img
@@ -16,8 +16,9 @@ const TodayPrayEmptyItem = () => {
         </p>
       </div>
       <KakaoShareButton
-        buttonText="카카오톡으로 초대하기"
-        kakaoLinkObject={TodayPrayLink()}
+        className="w-64"
+        buttonText="요청 메세지 보내기"
+        kakaoLinkObject={ExpiredMemberLink()}
         eventOption={{ where: "PrayCardList" }}
       ></KakaoShareButton>
     </div>


### PR DESCRIPTION
### 체크리스트
- [x]  그룹페이지에서 isTodayPray fetching 하도록 수정
- [x]  멤버드로워 분리 및 그룹페이지로 이동
- [x]  그룹페이지에서 TodayPrayStartCard 와 MemberList 분기 처리
- [x]  완료 아이템 노출 타이밍 버그 수정