### PR TITLE
fix: kakaoLogin Redirect

### DIFF
--- a/src/components/kakao/KakaoCallback.tsx
+++ b/src/components/kakao/KakaoCallback.tsx
@@ -1,92 +1,61 @@
 import { getDomainUrl } from "@/lib/utils";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { KakaoTokenRepo } from "./KakaoTokenRepo";
-import { KakaoTokenResponse } from "./Kakao";
 import { useNavigate } from "react-router-dom";
-import useBaseStore from "@/stores/baseStore";
 import { supabase } from "../../../supabase/client";
+import * as Sentry from "@sentry/react";
 
 const KakaoCallBack = () => {
-  const user = useBaseStore((state) => state.user);
-  const navigate = useNavigate();
-  const location = useLocation();
-  const baseUrl = getDomainUrl();
-  const updateProfile = useBaseStore((state) => state.updateProfile);
-  const setIsOpenTodayPrayDrawer = useBaseStore(
-    (state) => state.setIsOpenTodayPrayDrawer
-  );
-  const setIsOpenMyMemberDrawer = useBaseStore(
-    (state) => state.setIsOpenMyMemberDrawer
-  );
   const parseState = (state: string | null) => {
+    if (!state) return {};
     const stateObj: { [key: string]: string } = {};
-    if (!state) return stateObj;
-
     const parts = state.split(";");
     parts.forEach((part) => {
       const [key, value] = part.split(":");
-      if (key && value) {
-        stateObj[key.trim()] = value.trim();
-      }
+      if (key && value) stateObj[key.trim()] = value.trim();
     });
     return stateObj;
   };
 
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const code = params.get("code");
-    const state = params.get("state");
-    const stateObj = parseState(state);
-    const groupId = stateObj["groupId"] || "";
-    const groupPageUrl = groupId ? `/group/${groupId}` : "/group";
+  const navigate = useNavigate();
+  const location = useLocation();
+  const baseUrl = getDomainUrl();
+  const params = new URLSearchParams(location.search);
+  const code = params.get("code");
+  const state = params.get("state");
+  const stateObj = parseState(state);
+  const groupId = stateObj.groupId || "";
+  const from = stateObj.from || "";
+  const loginRedirectUrl = `/login-redirect?groupId=${groupId}&from=${from}`;
+  const redirectUrl = `${baseUrl}/auth/kakao/callback`;
 
-    if (code) {
-      KakaoTokenRepo.fetchKakaoToken(
-        code,
-        `${baseUrl}/auth/kakao/callback`
-      ).then((response: KakaoTokenResponse | null) => {
-        if (user) {
-          const kakaoId = user.user_metadata.sub;
-          updateProfile(user.id, { kakao_id: kakaoId });
-        }
-        if (response) {
-          KakaoTokenRepo.setKakaoTokensInCookie(response);
-          window.Kakao.Auth.setAccessToken(response.access_token);
-          if (response.id_token && !user) {
-            supabase.auth
-              .signInWithIdToken({
-                provider: "kakao",
-                token: response.id_token,
-              })
-              .then(({ error }) => {
-                if (!error) {
-                  window.location.href = `${baseUrl}/login-redirect?groupId=${groupId}`;
-                } else {
-                  console.error("로그인 실패:", error);
-                  navigate("/", { replace: true });
-                }
-              })
-              .catch((err) => {
-                console.error("로그인 처리 중 오류 발생:", err);
-                navigate("/", { replace: true });
-              });
-          }
-        }
+  useEffect(() => {
+    const KakaoLogin = async () => {
+      if (!code) {
+        navigate("/", { replace: true });
+        return;
+      }
+      const response = await KakaoTokenRepo.fetchKakaoToken(code, redirectUrl);
+      if (!response || !response.id_token) {
+        navigate("/", { replace: true });
+        return;
+      }
+
+      const { data, error } = await supabase.auth.signInWithIdToken({
+        provider: "kakao",
+        token: response.id_token,
       });
-    }
-    if (stateObj["from"] == "TodayPrayDrawer") setIsOpenTodayPrayDrawer(true);
-    if (stateObj["from"] == "MyPrayCard") setIsOpenMyMemberDrawer(true);
-    navigate(groupPageUrl, { replace: true });
-  }, [
-    navigate,
-    location.search,
-    baseUrl,
-    updateProfile,
-    user,
-    setIsOpenTodayPrayDrawer,
-    setIsOpenMyMemberDrawer,
-  ]);
+      if (data) {
+        navigate(loginRedirectUrl, { replace: true });
+      } else if (error) {
+        Sentry.captureException(error.message);
+        navigate("/", { replace: true });
+      }
+    };
+    KakaoLogin();
+  }, [navigate, code, redirectUrl, loginRedirectUrl]);
+
   return null;
 };
 

--- a/src/components/kakao/KakaoCallback.tsx
+++ b/src/components/kakao/KakaoCallback.tsx
@@ -1,5 +1,5 @@
 import { getDomainUrl } from "@/lib/utils";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { KakaoTokenRepo } from "./KakaoTokenRepo";
 import { useNavigate } from "react-router-dom";

--- a/src/components/kakao/KakaoTokenRepo.ts
+++ b/src/components/kakao/KakaoTokenRepo.ts
@@ -87,6 +87,8 @@ export class KakaoTokenRepo {
         return null;
       }
       const responseData: KakaoTokenResponse = await response.json();
+      this.setKakaoTokensInCookie(responseData);
+      window.Kakao.Auth.setAccessToken(responseData.access_token);
       return responseData;
     } catch (error) {
       Sentry.captureException(error);

--- a/src/components/todayPray/TodayPrayBtn.tsx
+++ b/src/components/todayPray/TodayPrayBtn.tsx
@@ -34,7 +34,7 @@ const TodayPrayBtn: React.FC<TodayPrayBtnProps> = ({ eventOption }) => {
     setIsOpenTodayPrayDrawer(true);
     setIsOpenMyPrayDrawer(false);
     setIsOpenMyMemberDrawer(false);
-    setPrayCardCarouselList([]);
+    setPrayCardCarouselList(null);
 
     sleep(100);
     const startDt = getISOTodayDate(-6);

--- a/src/components/todayPray/TodayPrayCardList.tsx
+++ b/src/components/todayPray/TodayPrayCardList.tsx
@@ -41,7 +41,8 @@ const TodayPrayCardList = () => {
     });
   }, [prayCardCarouselApi, setPrayCardCarouselIndex]);
 
-  if (!myMember || !memberList || !groupPrayCardList) return null;
+  if (!myMember || !memberList || !groupPrayCardList || !prayCardCarouselList)
+    return null;
 
   return (
     <Carousel setApi={setPrayCardCarouselApi} opts={{ startIndex: 1 }}>

--- a/src/components/todayPray/TodayPrayCardUI.tsx
+++ b/src/components/todayPray/TodayPrayCardUI.tsx
@@ -31,7 +31,7 @@ const TodayPrayCardUI: React.FC<PrayCardProps> = ({
       <div className="flex justify-between px-2">
         <div className="w-6"></div>
         <div className="text-sm text-gray-400">
-          {prayCardCarouselList.length}명 중 {prayCardCarouselIndex}
+          {prayCardCarouselList?.length || 0}명 중 {prayCardCarouselIndex}
           번째 기도
         </div>
         <OtherPrayCardMenuBtn

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -136,7 +136,7 @@ export interface BaseStore {
   isDisabledPrayCardCreateBtn: boolean;
   isDisabledSkipPrayCardBtn: boolean;
   prayCardCarouselApi: CarouselApi | null;
-  prayCardCarouselList: PrayCardWithProfiles[];
+  prayCardCarouselList: PrayCardWithProfiles[] | null;
   prayCardCarouselIndex: number;
   setPrayCardCarouselIndex: (index: number) => void;
   fetchGroupPrayCardList: (
@@ -151,7 +151,7 @@ export interface BaseStore {
     groupId: string
   ) => Promise<PrayCardWithProfiles[] | null>;
   setPrayCardCarouselList: (
-    prayCardCarouselList: PrayCardWithProfiles[]
+    prayCardCarouselList: PrayCardWithProfiles[] | null
   ) => void;
   fetchUserPrayCardListByGroupId: (
     currentUserId: string,
@@ -505,7 +505,7 @@ const useBaseStore = create<BaseStore>()(
     isDisabledPrayCardCreateBtn: false,
     isDisabledSkipPrayCardBtn: false,
     prayCardCarouselApi: null,
-    prayCardCarouselList: [],
+    prayCardCarouselList: null,
     prayCardCarouselIndex: 0,
     setPrayCardCarouselIndex: (index: number) => {
       set((state) => {
@@ -551,7 +551,9 @@ const useBaseStore = create<BaseStore>()(
       });
       return groupPrayCardList;
     },
-    setPrayCardCarouselList: (prayCardCarouselList: PrayCardWithProfiles[]) => {
+    setPrayCardCarouselList: (
+      prayCardCarouselList: PrayCardWithProfiles[] | null
+    ) => {
       set((state) => {
         state.prayCardCarouselList = prayCardCarouselList;
       });


### PR DESCRIPTION
# 작업 설명

카카오톡 리다이렉트 부분은 라우팅만 하는 곳으로, 

로그인 리다이렉트 부분은 profile 을 업데이트 하는 부분으로 확실히 역할을 분할합니다.

# 체크리스트

- [x]  카카오톡 리다이렉트 깜빡임 이슈 수정
- [x]  await 리팩터링
- [x]  유저 프로필 업데이트 처리 변경