### PR TITLE
feat: 그룹 입장 메세지 알림 추가

### DIFF
--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -1,5 +1,9 @@
 import { supabase } from "./../../supabase/client";
-import { MemberWithGroup, Group } from "../../supabase/types/tables";
+import {
+  MemberWithGroup,
+  Group,
+  GroupWithProfiles,
+} from "../../supabase/types/tables";
 import * as Sentry from "@sentry/react";
 import { getISOToday } from "@/lib/utils";
 
@@ -26,11 +30,13 @@ export const fetchGroupListByUserId = async (
   }
 };
 
-export const getGroup = async (groupId: string): Promise<Group | null> => {
+export const getGroup = async (
+  groupId: string
+): Promise<GroupWithProfiles | null> => {
   try {
     const { error, data } = await supabase
       .from("group")
-      .select("*")
+      .select(`*, profiles (id, full_name, avatar_url, kakao_id)`)
       .eq("id", groupId)
       .single();
     if (error) {
@@ -39,7 +45,7 @@ export const getGroup = async (groupId: string): Promise<Group | null> => {
       Sentry.captureException(error.message);
       return null;
     }
-    return data;
+    return data as GroupWithProfiles;
   } catch (error) {
     Sentry.captureException(error);
     return null;
@@ -50,17 +56,17 @@ export const createGroup = async (
   userId: string,
   name: string,
   intro: string
-): Promise<Group | null> => {
+): Promise<GroupWithProfiles | null> => {
   try {
     const { error, data } = await supabase
       .from("group")
       .insert([{ user_id: userId, name, intro }])
-      .select();
+      .select(`*, profiles (id, full_name, avatar_url, kakao_id)`);
     if (error) {
       Sentry.captureException(error.message);
       return null;
     }
-    return data ? data[0] : null;
+    return data ? (data[0] as GroupWithProfiles) : null;
   } catch (error) {
     Sentry.captureException(error);
     return null;

--- a/src/components/auth/LoginRedirect.tsx
+++ b/src/components/auth/LoginRedirect.tsx
@@ -6,7 +6,6 @@ import useAuth from "@/hooks/useAuth";
 
 const LoginRedirect = () => {
   const { user } = useAuth();
-  const session = useBaseStore((state) => state.session);
   const updateUserMetaData = useBaseStore((state) => state.updateUserMetaData);
   const navigate = useNavigate();
   const myProfile = useBaseStore((state) => state.myProfile);
@@ -33,7 +32,6 @@ const LoginRedirect = () => {
   useEffect(() => {
     if (!myProfile) return;
     if (provider == "kakao") {
-      window.Kakao.Auth.setAccessToken(session?.provider_token || "");
       if (!user?.user_metadata.full_name) {
         updateUserMetaData({
           full_name: user!.user_metadata.name,
@@ -64,7 +62,6 @@ const LoginRedirect = () => {
     navigate,
     groupId,
     groupPageUrl,
-    session,
     user,
   ]);
 

--- a/src/components/kakao/KakaoCallback.tsx
+++ b/src/components/kakao/KakaoCallback.tsx
@@ -37,6 +37,9 @@ const KakaoCallBack = () => {
         return;
       }
       const response = await KakaoTokenRepo.fetchKakaoToken(code, redirectUrl);
+      if (response?.access_token)
+        window.Kakao.Auth.setAccessToken(response.access_token);
+
       if (!response || !response.id_token) {
         navigate("/", { replace: true });
         return;

--- a/src/components/kakao/KakaoController.tsx
+++ b/src/components/kakao/KakaoController.tsx
@@ -97,7 +97,7 @@ export class KakaoController {
 
   static async sendDirectMessage(
     message: KakaoMessageObject,
-    kakaoId: string
+    kakaoId: string | null
   ): Promise<KakaoSendMessageResponse | null> {
     try {
       const kakaoFriendsResponse: KakaoFriendsResponse | null =

--- a/src/components/kakao/KakaoMessage.ts
+++ b/src/components/kakao/KakaoMessage.ts
@@ -24,25 +24,20 @@ export const PrayRequestMessage = (userName: string | null) => {
   } as KakaoMessageObject;
 };
 
-export const MemberJoinMessage = (
-  groupName: string | null,
-  userName: string | null
-) => {
+export const MemberJoinMessage = (userName: string | null, groupId: string) => {
+  const groupUrl = `${baseUrl}/group/${groupId}`;
   return {
     object_type: "feed",
     content: {
-      title: "💌 PrayU 입장 알림",
-      description: `${userName}님이 ${groupName} 그룹에 입장했어요!`,
+      title: "📢 PrayU 입장 알림",
+      description: `${userName}님이 기도그룹에 입장했어요!`,
       image_url: "",
       link: { web_url: baseUrl, mobile_web_url: baseUrl },
     },
     buttons: [
       {
         title: "기도제목 확인하기",
-        link: {
-          mobile_web_url: window.location.href,
-          web_url: window.location.href,
-        },
+        link: { mobile_web_url: groupUrl, web_url: groupUrl },
       },
     ],
   } as KakaoMessageObject;

--- a/src/components/kakao/KakaoMessage.ts
+++ b/src/components/kakao/KakaoMessage.ts
@@ -23,3 +23,27 @@ export const PrayRequestMessage = (userName: string | null) => {
     ],
   } as KakaoMessageObject;
 };
+
+export const MemberJoinMessage = (
+  groupName: string | null,
+  userName: string | null
+) => {
+  return {
+    object_type: "feed",
+    content: {
+      title: "💌 PrayU 입장 알림",
+      description: `${userName}님이 ${groupName} 그룹에 입장했어요!`,
+      image_url: "",
+      link: { web_url: baseUrl, mobile_web_url: baseUrl },
+    },
+    buttons: [
+      {
+        title: "기도제목 확인하기",
+        link: {
+          mobile_web_url: window.location.href,
+          web_url: window.location.href,
+        },
+      },
+    ],
+  } as KakaoMessageObject;
+};

--- a/src/pages/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCardCreatePage.tsx
@@ -95,9 +95,8 @@ const PrayCardCreatePage: React.FC = () => {
     if (!myMember) {
       updatedMember = await createMember(groupId, currentUserId, content);
 
-      const kakaoMessage = MemberJoinMessage(user?.user_metadata.name, groupId);
       await KakaoController.sendDirectMessage(
-        kakaoMessage,
+        MemberJoinMessage(user?.user_metadata.name, groupId),
         targetGroup.profiles.kakao_id
       );
     } else {

--- a/src/pages/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCardCreatePage.tsx
@@ -9,6 +9,8 @@ import { useEffect } from "react";
 import GroupMenuBtn from "@/components/group/GroupMenuBtn";
 import { useParams } from "react-router-dom";
 import ClipLoader from "react-spinners/ClipLoader";
+import { KakaoController } from "@/components/kakao/KakaoController";
+import { MemberJoinMessage } from "@/components/kakao/KakaoMessage";
 
 const PrayCardCreatePage: React.FC = () => {
   const { user } = useAuth();
@@ -92,6 +94,12 @@ const PrayCardCreatePage: React.FC = () => {
     let updatedMember: Member | null;
     if (!myMember) {
       updatedMember = await createMember(groupId, currentUserId, content);
+
+      const kakaoMessage = MemberJoinMessage(user?.user_metadata.name, groupId);
+      await KakaoController.sendDirectMessage(
+        kakaoMessage,
+        targetGroup.profiles.kakao_id
+      );
     } else {
       updatedMember = await updateMember(
         myMember.id,

--- a/src/pages/TermServicePage.tsx
+++ b/src/pages/TermServicePage.tsx
@@ -41,11 +41,8 @@ const TermServicePage: React.FC = () => {
   if (!profile || !groupList) return null;
 
   const handleCreateGroup = async () => {
-    const groupName = profile.full_name
-      ? `${profile.full_name}의 기도그룹`
-      : user!.user_metadata.name
-      ? `${user!.user_metadata.name}의 기도그룹`
-      : "새 기도그룹";
+    const userName = profile.full_name || user?.user_metadata.name;
+    const groupName = userName ? `${userName}의 기도그룹` : "새 기도그룹";
     const targetGroup = await createGroup(profile.id, groupName, "intro");
     if (!targetGroup) return;
     const myMember = await createMember(targetGroup.id, profile.id, "");

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -18,6 +18,7 @@ import {
   TodayPrayTypeHash,
   PrayWithProfiles,
   Profiles,
+  GroupWithProfiles,
 } from "../../supabase/types/tables";
 import {
   fetchGroupListByUserId,
@@ -78,7 +79,7 @@ export interface BaseStore {
 
   // group
   groupList: Group[] | null;
-  targetGroup: Group | null;
+  targetGroup: GroupWithProfiles | null;
   inputGroupName: string;
   isDisabledGroupCreateBtn: boolean;
   isGroupLeader: boolean;
@@ -92,7 +93,7 @@ export interface BaseStore {
     userId: string,
     name: string,
     intro: string
-  ) => Promise<Group | null>;
+  ) => Promise<GroupWithProfiles | null>;
   updateGroup: (
     groupId: string,
     params: updateGroupParams
@@ -406,7 +407,7 @@ const useBaseStore = create<BaseStore>()(
       userId: string,
       name: string,
       intro: string
-    ): Promise<Group | null> => {
+    ): Promise<GroupWithProfiles | null> => {
       const group = await createGroup(userId, name, intro);
       set((state) => {
         state.targetGroup = group;

--- a/supabase/types/tables.ts
+++ b/supabase/types/tables.ts
@@ -11,6 +11,10 @@ export type PrayCard = Database["public"]["Tables"]["pray_card"]["Row"];
 
 export type Pray = Database["public"]["Tables"]["pray"]["Row"];
 
+export interface GroupWithProfiles extends Group {
+  profiles: Profiles;
+}
+
 export interface MemberWithGroup extends Member {
   group: Group;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cbebd78f-fb38-4591-91f0-ebe73324f0ce)


# 작업 설명
카카오톡 메세지가 선택 동의 처리 됨에 따라 
그룹원이 입장했을 때 카카오톡 메세지로 그룹장에게 알림을 주는 기능을 구현합니다.

# 체크리스트
- [x]  getGroup 할 때 Profiles 포함
- [x]  알림 로직 추가