### PR TITLE
hotfix: 앱일 때, 이메일 로그인 추가

### DIFF
--- a/src/components/auth/LogInDrawer.tsx
+++ b/src/components/auth/LogInDrawer.tsx
@@ -26,12 +26,15 @@ const LogInDrawer = () => {
     pathParts.length === 3 && pathParts[1] === "group" ? pathParts[2] : "";
   const redirectUrl = `${baseUrl}/login-redirect?groupId=${groupId}&from=LogInDrawer`;
 
-  const [isIOSApp, setIsIOSApp] = useState(false);
+  const [isApp, setIsApp] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
 
   useEffect(() => {
     const userAgent = window.navigator.userAgent.toLowerCase();
-    const isIOSApp = userAgent.includes("prayu-ios");
-    setIsIOSApp(isIOSApp);
+    const isApp = userAgent.includes("prayu");
+    const isIOS = userAgent.includes("prayu-ios");
+    setIsApp(isApp);
+    setIsIOS(isIOS);
   }, []);
 
   const LoginContent = (
@@ -47,9 +50,9 @@ const LogInDrawer = () => {
           redirectUri={`${baseUrl}/auth/kakao/callback`}
           state={`groupId:${groupId}`}
         />
-        {isIOSApp && (
+        {isApp && (
           <>
-            <AppleLoginBtn redirectUrl={redirectUrl} />
+            {isIOS && <AppleLoginBtn redirectUrl={redirectUrl} />}
             <EmailLoginBtn />
           </>
         )}


### PR DESCRIPTION
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f2673922-9b9a-4032-a6d2-186c29bd52cf">

기존에 ios 앱일 때만 이메일 로그인이 보였는데,
안드로이드 테스터 계정 제공을 위해
앱일 때에는 이메일 로그인이 보이도록 userAgent 를 수정하였습니다!

https://www.notion.so/mmyeong/feat-1f67d57f17844de4934a34043b6ab308?pvs=4