### PR TITLE
hotfix: 카카오 소식 url http -> https 로 수정

### DIFF
--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -101,7 +101,7 @@ const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
 
   const onClickOpenNotice = () => {
     analyticsTrack("클릭_카카오_소식", {});
-    window.location.href = "http://pf.kakao.com/_XaHDG/posts";
+    window.location.href = "https://pf.kakao.com/_XaHDG/posts";
   };
   const onClickOpenTutorial = () => {
     analyticsTrack("클릭_튜토리얼", {});


### PR DESCRIPTION
앱에서 가끔 PrayU 소식을 눌렀을 때 잘 들어가지는 이슈가 있었습니다.
(PrayU 문의를 먼저 눌러본 상태라면 PrayU 소식이 들어가졌습니다.)

이유를 찾다가 주소의 url이 http로 되어 있음을 발견하여 https 로 수정하였습니다.
(App에서 http 통신이 안됨)