### PR TITLE
refactor: UnionWorship 페이지 로그인 예외 처리

### DIFF
--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -141,6 +141,14 @@ const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
               </a>
             </div>
           ))}
+          {!user && (
+            <div className="flex items-center gap-1">
+              <span className="w-[5px] h-[18px]  rounded-md bg-mainBtn"></span>
+              <a className="cursor-pointer max-w-40 whitespace-nowrap overflow-hidden text-ellipsis font-bold text-[#222222]">
+                1027 연합예배
+              </a>
+            </div>
+          )}
           <hr className="w-full" />
           <div className="flex items-center gap-2">
             <IoPersonCircleOutline size={20} color="#222222" />

--- a/src/components/member/OtherMember.tsx
+++ b/src/components/member/OtherMember.tsx
@@ -18,6 +18,9 @@ const OtherMember: React.FC<OtherMemberProps> = ({ member }) => {
   const setIsOpenOtherMemberDrawer = useBaseStore(
     (state) => state.setIsOpenOtherMemberDrawer
   );
+  const setIsOpenLoginDrawer = useBaseStore(
+    (state) => state.setIsOpenLoginDrawer
+  );
   const dateDistance = getDateDistance(
     new Date(getISOOnlyDate(member.updated_at)),
     new Date(getISOTodayDate())
@@ -25,14 +28,17 @@ const OtherMember: React.FC<OtherMemberProps> = ({ member }) => {
 
   const onClickOtherMember = async () => {
     analyticsTrack("클릭_멤버_구성원", { member: member.user_id });
-    setIsOpenOtherMemberDrawer(true);
-    setOtherMember(null);
-    await fetchOtherPrayCardListByGroupId(
-      user!.id,
-      member.user_id!,
-      member.group_id!
-    );
-    setOtherMember(member);
+    if (!user) setIsOpenLoginDrawer(true);
+    else {
+      setIsOpenOtherMemberDrawer(true);
+      setOtherMember(null);
+      await fetchOtherPrayCardListByGroupId(
+        user.id,
+        member.user_id!,
+        member.group_id!
+      );
+      setOtherMember(member);
+    }
   };
 
   return (

--- a/src/components/member/OtherMemberDrawer.tsx
+++ b/src/components/member/OtherMemberDrawer.tsx
@@ -9,7 +9,6 @@ import useBaseStore from "@/stores/baseStore";
 import OtherPrayCardUI from "../prayCard/OtherPrayCardUI";
 
 const OtherMemberDrawer: React.FC = () => {
-  const user = useBaseStore((state) => state.user);
   const memberList = useBaseStore((state) => state.memberList);
   const isOpenOtherMemberDrawer = useBaseStore(
     (state) => state.isOpenOtherMemberDrawer
@@ -18,7 +17,8 @@ const OtherMemberDrawer: React.FC = () => {
     (state) => state.setIsOpenOtherMemberDrawer
   );
 
-  if (!user || !memberList) return null;
+  if (!memberList) return null;
+
   return (
     <Drawer
       open={isOpenOtherMemberDrawer}
@@ -30,7 +30,6 @@ const OtherMemberDrawer: React.FC = () => {
           <DrawerDescription></DrawerDescription>
         </DrawerHeader>
         <OtherPrayCardUI
-          currentUserId={user.id}
           eventOption={{
             where: "OtherMember",
             total_member: memberList.length,

--- a/src/components/member/OtherMemberList.tsx
+++ b/src/components/member/OtherMemberList.tsx
@@ -14,13 +14,13 @@ const OtherMemberList: React.FC<OtherMembersProps> = ({ otherMemberList }) => {
   const groupList = useBaseStore((state) => state.groupList);
   const memberList = useBaseStore((state) => state.memberList);
 
-  if (!groupList || !memberList) return;
+  if (!memberList) return;
 
   return (
     <div className="flex flex-col gap-2 pb-10">
       <div className="text-sm text-gray-500 p-2">기도 구성원</div>
       <div className="flex flex-col gap-4">
-        {groupList.length == 1 &&
+        {groupList?.length == 1 &&
           (otherMemberList.length == 0 ? <InviteBanner /> : <RewardBanner />)}
         {otherMemberList.length == 0 && <DummyOtherMember />}
         {otherMemberList.map((member) => (

--- a/src/components/notification/NotificationBtn.tsx
+++ b/src/components/notification/NotificationBtn.tsx
@@ -26,10 +26,15 @@ const NotificationBtn = () => {
   const setIsOpenNotificationPopover = useBaseStore(
     (state) => state.setIsOpenNotificationPopover
   );
-
-  if (!user || !targetGroup) return null;
+  const setIsOpenLoginDrawer = useBaseStore(
+    (state) => state.setIsOpenLoginDrawer
+  );
 
   const onClickNotificationBtn = async () => {
+    if (!user || !targetGroup) {
+      setIsOpenLoginDrawer(true);
+      return;
+    }
     analyticsTrack("클릭_알림_버튼", {});
     setUserNotificationView([]);
     if (!isOpenNotificationPopover) {

--- a/src/components/prayCard/OtherPrayCardUI.tsx
+++ b/src/components/prayCard/OtherPrayCardUI.tsx
@@ -7,7 +7,6 @@ import OtherPrayCardMenuBtn from "./OtherPrayCardMenuBtn";
 import ClipLoader from "react-spinners/ClipLoader";
 
 interface OtherPrayCardProps {
-  currentUserId: string;
   eventOption: { where: string; total_member: number };
 }
 

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -49,6 +49,10 @@ const GroupPage: React.FC = () => {
   const isPrayToday = useBaseStore((state) => state.isPrayToday);
   const maxGroupCount = Number(import.meta.env.VITE_MAX_GROUP_COUNT);
 
+  const unionWorshipGroupId = String(
+    import.meta.env.VITE_UNION_WORSHIP_GROUP_ID
+  );
+
   useEffect(() => {
     fetchGroupListByUserId(currentUserId);
     if (groupId) {
@@ -87,10 +91,7 @@ const GroupPage: React.FC = () => {
     } else if (targetGroupLoading == false && targetGroup == null) {
       navigate("/group/not-found");
       return;
-    } else if (
-      !memberLoading &&
-      groupId === "9085a291-7eb2-4b00-9f85-0ccd98f433a7"
-    ) {
+    } else if (!memberLoading && groupId === unionWorshipGroupId) {
       navigate("/group/open/1027-union", { replace: true });
       return;
     }
@@ -104,6 +105,7 @@ const GroupPage: React.FC = () => {
     targetGroupLoading,
     maxGroupCount,
     userPlan,
+    unionWorshipGroupId,
   ]);
 
   useEffect(() => {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -42,7 +42,7 @@ const MainPage: React.FC = () => {
     <div className="flex flex-col items-center justify-center text-center h-full">
       <MainHeader />
       <section className="w-full flex flex-col items-center ">
-        <div className="flex flex-col gap-8 p-10 items-center justify-center ">
+        <div className="flex flex-col gap-8  items-center justify-center ">
           <div className="h-[80px] w-full flex flex-col items-center object-cover">
             <img className="h-full" src="/images/PrayULogo.png" />
           </div>
@@ -63,7 +63,15 @@ const MainPage: React.FC = () => {
             </p>
             <p>PrayU 를 통해 전달되었어요</p>
           </div>
-          <PrayUStartBtn />
+          <div className="flex flex-col gap-4">
+            <PrayUStartBtn />
+            <a
+              className="text-liteBlack underline font-bold"
+              href="/group/open/1027-union"
+            >
+              1027 연합예배 그룹
+            </a>
+          </div>
         </div>
       </section>
 

--- a/src/pages/Open/UnionWorshipPage.tsx
+++ b/src/pages/Open/UnionWorshipPage.tsx
@@ -1,10 +1,12 @@
 import LogInDrawer from "@/components/auth/LogInDrawer";
 import GroupHeader from "@/components/group/GroupHeader";
 import MyMember from "@/components/member/MyMember";
+import OtherMemberDrawer from "@/components/member/OtherMemberDrawer";
+import OtherMemberList from "@/components/member/OtherMemberList";
+import PrayListDrawer from "@/components/pray/PrayListDrawer";
 import ReactionResultBox from "@/components/pray/ReactionResultBox";
 import ShareDrawer from "@/components/share/ShareDrawer";
 import TodayPrayCardListDrawer from "@/components/todayPray/TodayPrayCardListDrawer";
-import TodayPrayStartCard from "@/components/todayPray/TodayPrayStartCard";
 import { Skeleton } from "@/components/ui/skeleton";
 import useBaseStore from "@/stores/baseStore";
 import { useEffect } from "react";
@@ -23,23 +25,23 @@ const UnionWorshipPage = () => {
   const fetchGroupListByUserId = useBaseStore(
     (state) => state.fetchGroupListByUserId
   );
+  const setIsOpenLoginDrawer = useBaseStore(
+    (state) => state.setIsOpenLoginDrawer
+  );
+
   const groupId = String(import.meta.env.VITE_UNION_WORSHIP_GROUP_ID);
 
   useEffect(() => {
     getGroup(groupId);
+    fetchMemberListByGroupId(groupId);
+  }, [fetchMemberListByGroupId, getGroup, groupId]);
+
+  useEffect(() => {
     if (user) {
       getMember(user.id, groupId);
       fetchGroupListByUserId(user.id);
     }
-    fetchMemberListByGroupId(groupId);
-  }, [
-    fetchMemberListByGroupId,
-    getGroup,
-    getMember,
-    user,
-    fetchGroupListByUserId,
-    groupId,
-  ]);
+  }, [getMember, user, fetchGroupListByUserId, groupId]);
 
   if (!targetGroup || !memberList) {
     return (
@@ -51,7 +53,10 @@ const UnionWorshipPage = () => {
   }
 
   const MyMemberUI = (
-    <div className="w-full flex flex-col gap-3 cursor-pointer bg-white p-6 rounded-[15px]">
+    <div
+      onClick={() => setIsOpenLoginDrawer(true)}
+      className="w-full flex flex-col gap-3 cursor-pointer bg-white p-6 rounded-[15px]"
+    >
       <div className="flex flex-col gap-1">
         <h3 className="flex font-bold text-lg">내 기도제목</h3>
         <div className="text-left text-sm text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis">
@@ -64,20 +69,27 @@ const UnionWorshipPage = () => {
     </div>
   );
 
+  const otherMemberList = memberList.filter(
+    (member) => member.user_id != user?.id
+  );
+
   return (
     <div className="flex flex-col h-full gap-5">
       <GroupHeader
         groupList={groupList || []}
         targetGroup={targetGroup}
-        otherMemberList={memberList}
+        otherMemberList={otherMemberList}
       />
       <div className="flex flex-col flex-grow gap-4">
         {myMember ? <MyMember myMember={myMember} /> : MyMemberUI}
-        <TodayPrayStartCard />
+        <OtherMemberList otherMemberList={otherMemberList} />
       </div>
-      <ShareDrawer />
-      <TodayPrayCardListDrawer />
+
       <LogInDrawer />
+      <ShareDrawer />
+      <PrayListDrawer />
+      <OtherMemberDrawer />
+      <TodayPrayCardListDrawer />
     </div>
   );
 };


### PR DESCRIPTION
# 작업 내용

로그인 드로워 예외처리 필요한 부분 적용합니다.
오늘의 기도 시작 카드 대신 멤버리스트가 뜨도록 해두었는데 괜찮으면 적용하겠습니다.

# 체크리스트

- [x]  내 기도제목 로그인 시키기
- [x]  멤버 눌렀을 때 로그인 시키기
- [x]  로그인 전에 그룹 리스트에 1027 연합예배 추가