### PR TITLE
fix: pushState 중복 방지

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,8 +12,8 @@ const Dialog = ({
   const { open, onOpenChange } = props;
 
   useEffect(() => {
-    if (open && window.history.state?.open) {
-      window.history.pushState({ open: true }, "", window.location.pathname);
+    if (open && window.history.state?.open !== true) {
+      window.history.pushState({ open: true }, "", "");
     }
   }, [open]);
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,16 +12,17 @@ const Dialog = ({
   const { open, onOpenChange } = props;
 
   useEffect(() => {
-    if (open) window.history.pushState(null, "", window.location.pathname);
+    if (open && window.history.state?.open) {
+      window.history.pushState({ open: true }, "", window.location.pathname);
+    }
   }, [open]);
 
   useEffect(() => {
     const handlePopState = () => {
-      if (onOpenChange) {
-        onOpenChange(false);
-      }
+      if (onOpenChange) onOpenChange(false);
     };
     window.addEventListener("popstate", handlePopState);
+    window.history.replaceState(null, "", window.location.pathname);
     return () => {
       window.removeEventListener("popstate", handlePopState);
     };

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -12,8 +12,8 @@ const Drawer = ({
   const { onOpenChange, open } = props;
 
   useEffect(() => {
-    if (open && window.history.state?.open) {
-      window.history.pushState({ open: true }, "", window.location.pathname);
+    if (open && window.history.state?.open !== true) {
+      window.history.pushState({ open: true }, "", "");
     }
   }, [open]);
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -12,7 +12,9 @@ const Drawer = ({
   const { onOpenChange, open } = props;
 
   useEffect(() => {
-    if (open) window.history.pushState(null, "", window.location.pathname);
+    if (open && window.history.state?.open) {
+      window.history.pushState({ open: true }, "", window.location.pathname);
+    }
   }, [open]);
 
   useEffect(() => {
@@ -20,6 +22,7 @@ const Drawer = ({
       if (onOpenChange) onOpenChange(false);
     };
     window.addEventListener("popstate", handlePopState);
+    window.history.replaceState(null, "", window.location.pathname);
     return () => {
       window.removeEventListener("popstate", handlePopState);
     };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -10,8 +10,8 @@ const Popover = ({
   const { open, onOpenChange } = props;
 
   useEffect(() => {
-    if (open && window.history.state?.open) {
-      window.history.pushState({ open: true }, "", window.location.pathname);
+    if (open && window.history.state?.open !== true) {
+      window.history.pushState({ open: true }, "", "");
     }
   }, [open]);
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -10,16 +10,17 @@ const Popover = ({
   const { open, onOpenChange } = props;
 
   useEffect(() => {
-    if (open) window.history.pushState(null, "", window.location.pathname);
+    if (open && window.history.state?.open) {
+      window.history.pushState({ open: true }, "", window.location.pathname);
+    }
   }, [open]);
 
   useEffect(() => {
     const handlePopState = () => {
-      if (onOpenChange) {
-        onOpenChange(false);
-      }
+      if (onOpenChange) onOpenChange(false);
     };
     window.addEventListener("popstate", handlePopState);
+    window.history.replaceState(null, "", window.location.pathname);
     return () => {
       window.removeEventListener("popstate", handlePopState);
     };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -13,8 +13,8 @@ const Sheet = ({
   const { open, onOpenChange } = props;
 
   useEffect(() => {
-    if (open && window.history.state?.open) {
-      window.history.pushState({ open: true }, "", window.location.pathname);
+    if (open && window.history.state?.open !== true) {
+      window.history.pushState({ open: true }, "", "");
     }
   }, [open]);
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -13,16 +13,17 @@ const Sheet = ({
   const { open, onOpenChange } = props;
 
   useEffect(() => {
-    if (open) window.history.pushState(null, "", window.location.pathname);
+    if (open && window.history.state?.open) {
+      window.history.pushState({ open: true }, "", window.location.pathname);
+    }
   }, [open]);
 
   useEffect(() => {
     const handlePopState = () => {
-      if (onOpenChange) {
-        onOpenChange(false);
-      }
+      if (onOpenChange) onOpenChange(false);
     };
     window.addEventListener("popstate", handlePopState);
+    window.history.replaceState(null, "", window.location.pathname);
     return () => {
       window.removeEventListener("popstate", handlePopState);
     };


### PR DESCRIPTION
pushState 가 중복으로 들어가지 않도록 합니다.
아직 문제가 있지만 우선처리합니다.

문제1. 드로워 열고 뒤로가기로 닫지 않을 경우 최대 1개 경로 push
문제2. 드로워 중첩으로 열고 뒤로가기로 닫을 경우 동시에 두개 다 닫힘
