### PR TITLE
chore: login drawer 코멘트 수정

### DIFF
--- a/src/components/auth/LogInDrawer.tsx
+++ b/src/components/auth/LogInDrawer.tsx
@@ -48,10 +48,12 @@ const LogInDrawer = () => {
 
   const LoginContent = (
     <div className="flex flex-col gap-6 px-10">
-      <div className="flex flex-col gap-1">
-        <div className="text-xl font-bold">로그인 / 회원가입</div>
-        <p className="flex flex-col justify-center font-thin">
-          기도제목을 올리고, 서로 함께 반응하며 기도해요
+      <div className="flex flex-col gap-3">
+        <div className="text-xl font-semibold">로그인 / 회원가입</div>
+        <p className="flex flex-col justify-center font-light text-[0.95rem]">
+          여러분의 신앙생활은 소중한 개인의 영역입니다.
+          <br />
+          어떤 정보도 외부에 공유되지 않으니 안심하세요.
         </p>
       </div>
       <div className="flex flex-col w-full justify-center gap-2">

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -65,12 +65,6 @@ const MainPage: React.FC = () => {
           </div>
           <div className="flex flex-col gap-4">
             <PrayUStartBtn />
-            <a
-              className="text-liteBlack underline font-bold"
-              href="/group/open/1027-union"
-            >
-              1027 연합예배 그룹
-            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
지금 메인 페이지에서 카카오톡 로그인을 하는 비율이 평균 60%정도 되는데, 이를 늘려볼 수 있지 않을까 싶어서
도메인 특성상 강남언니처럼 "정보 보호" 에 관한 멘트로 수정해보았습니다.

# Result
![image](https://github.com/user-attachments/assets/0f8c8662-ac4d-44e7-ab13-4e85ad93dcc5)

# Reference
![image](https://github.com/user-attachments/assets/94899026-b984-4c26-a45a-5761fdcbbec7)

https://www.notion.so/mmyeong/feat-409cf437936747cf9126340eab9fa306?pvs=4
