### PR TITLE
feat: 그룹장 양도 기능 추가

### DIFF
--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -97,6 +97,7 @@ export const createGroup = async (
 export interface updateGroupParams {
   name?: string;
   intro?: string;
+  user_id?: string;
 }
 
 export const updateGroup = async (

--- a/src/components/group/GroupMemberOptionTag.tsx
+++ b/src/components/group/GroupMemberOptionTag.tsx
@@ -1,0 +1,81 @@
+import { MemberWithProfiles } from "supabase/types/tables";
+import { Badge } from "../ui/badge";
+import useBaseStore from "@/stores/baseStore";
+import { analyticsTrack } from "@/analytics/analytics";
+
+interface GroupMemberOptionTagProps {
+  member: MemberWithProfiles;
+}
+
+const GroupMemberOptionTag: React.FC<GroupMemberOptionTagProps> = ({
+  member,
+}) => {
+  const targetGroup = useBaseStore((state) => state.targetGroup);
+  const setAlertData = useBaseStore((state) => state.setAlertData);
+  const setIsConfirmAlertOpen = useBaseStore(
+    (state) => state.setIsConfirmAlertOpen
+  );
+  const updateGroup = useBaseStore((state) => state.updateGroup);
+  const deleteMemberbyGroupId = useBaseStore(
+    (state) => state.deleteMemberbyGroupId
+  );
+  const deletePrayCardByGroupId = useBaseStore(
+    (state) => state.deletePrayCardByGroupId
+  );
+  const activeGroupMemberOption = useBaseStore(
+    (state) => state.activeGroupMemberOption
+  );
+
+  const onClickDeleteMemberInGroup = () => {
+    if (!targetGroup) return;
+    setAlertData({
+      color: "bg-red-400",
+      title: "그룹 내보내기",
+      description: `해당 그룹에서  ${member.profiles.full_name} 님을 내보내시겠어요?\n*${member.profiles.full_name} 님의 기도카드는 모두 삭제되어요`,
+      actionText: "내보내기",
+      cancelText: "취소",
+      onAction: async () => {
+        await deleteMemberbyGroupId(member.profiles.id, targetGroup.id);
+        await deletePrayCardByGroupId(member.profiles.id, targetGroup.id);
+        window.location.replace(`/group/${targetGroup.id}`);
+        analyticsTrack("클릭_그룹_내보내기", { group_id: targetGroup.id });
+      },
+    });
+    setIsConfirmAlertOpen(true);
+  };
+
+  const onClickAssignGroupLeader = () => {
+    if (!targetGroup) return;
+    setAlertData({
+      color: "bg-blue-400",
+      title: "그룹장 양도",
+      description: `${member.profiles.full_name} 님에게 그룹장을 양도하시겠습니까?`,
+      actionText: "그룹장 양도",
+      cancelText: "취소",
+      onAction: async () => {
+        await updateGroup(targetGroup.id, { user_id: member.profiles.id });
+        analyticsTrack("클릭_그룹_그룹장양도", { group_id: targetGroup.id });
+        // window.location.replace(`/group/${targetGroup.id}`);
+      },
+    });
+    setIsConfirmAlertOpen(true);
+  };
+
+  if (activeGroupMemberOption == "assign") {
+    return (
+      <Badge variant="secondary" onClick={() => onClickAssignGroupLeader()}>
+        그룹장 양도
+      </Badge>
+    );
+  } else if (activeGroupMemberOption == "delete") {
+    return (
+      <Badge variant="secondary" onClick={() => onClickDeleteMemberInGroup()}>
+        내보내기
+      </Badge>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default GroupMemberOptionTag;

--- a/src/components/group/GroupMemberOptionTag.tsx
+++ b/src/components/group/GroupMemberOptionTag.tsx
@@ -55,7 +55,7 @@ const GroupMemberOptionTag: React.FC<GroupMemberOptionTagProps> = ({
       onAction: async () => {
         await updateGroup(targetGroup.id, { user_id: member.profiles.id });
         analyticsTrack("클릭_그룹_그룹장양도", { group_id: targetGroup.id });
-        // window.location.replace(`/group/${targetGroup.id}`);
+        window.location.replace(`/group/${targetGroup.id}`);
       },
     });
     setIsConfirmAlertOpen(true);

--- a/src/components/group/GroupMemberSettingsBtn.tsx
+++ b/src/components/group/GroupMemberSettingsBtn.tsx
@@ -1,0 +1,59 @@
+import { analyticsTrack } from "@/analytics/analytics";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { RiMoreFill } from "react-icons/ri";
+import { AiOutlineCrown } from "react-icons/ai";
+import { IoMdExit } from "react-icons/io";
+import useBaseStore from "@/stores/baseStore";
+
+const GroupMemberSettingsBtn = () => {
+  const setActiveGroupMemberOption = useBaseStore(
+    (state) => state.setActiveGroupMemberOption
+  );
+
+  const onClickDeleteMemberInGroup = () => {
+    analyticsTrack("클릭_그룹_내보내기옵션", {});
+    setActiveGroupMemberOption("delete");
+  };
+
+  const onClickAssignGroupLeader = () => {
+    analyticsTrack("클릭_그룹_그룹장양도옵션", {});
+    setActiveGroupMemberOption("assign");
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        onClick={() => {
+          analyticsTrack("클릭_그룹_멤버설정", {});
+        }}
+      >
+        <RiMoreFill className="text-2xl" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          className="flex justify-between"
+          onClick={() => onClickAssignGroupLeader()}
+        >
+          <AiOutlineCrown />
+          그룹양도
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="flex justify-between"
+          onClick={() => onClickDeleteMemberInGroup()}
+        >
+          <IoMdExit />
+          내보내기
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default GroupMemberSettingsBtn;

--- a/src/components/group/GroupMenuBtn.tsx
+++ b/src/components/group/GroupMenuBtn.tsx
@@ -49,7 +49,11 @@ const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
   const setIsOpenGroupSettingsDialog = useBaseStore(
     (state) => state.setIsOpenGroupSettingsDialog
   );
+  const setActiveGroupMemberOption = useBaseStore(
+    (state) => state.setActiveGroupMemberOption
+  );
   const isGroupLeader = useBaseStore((state) => state.isGroupLeader);
+  const memberList = useBaseStore((state) => state.memberList);
 
   const handleClickCreateGroup = () => {
     if (userGroupList.length < maxGroupCount || userPlan === "Premium") {
@@ -62,18 +66,36 @@ const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
     }
   };
 
-  const handleClickExitGroup = (groupId: string, groupName: string | null) => {
+  const handleClickExitGroup = () => {
+    if (!targetGroup || !user || !memberList) return;
+    if (isGroupLeader && memberList.length !== 1) {
+      setAlertData({
+        color: "bg-blue-400",
+        title: "그룹장 양도 필요",
+        description:
+          "그룹장은 그룹을 나갈 수 없어요\n 그룹장 양도를 먼저 진행해주세요!",
+        actionText: "그룹 설정하기",
+        cancelText: "취소",
+        onAction: async () => {
+          setIsConfirmAlertOpen(false);
+          setActiveGroupMemberOption("assign");
+          setIsOpenGroupSettingsDialog(true);
+        },
+      });
+      setIsConfirmAlertOpen(true);
+      return null;
+    }
     setAlertData({
       color: "bg-red-400",
       title: "그룹 나가기",
-      description: `더 이상 ${groupName}의 기도를 받을 수 없어요 😭`,
+      description: `더 이상 ${targetGroup.name}의 기도를 받을 수 없어요 😭`,
       actionText: "나가기",
       cancelText: "취소",
       onAction: async () => {
-        await deleteMemberbyGroupId(user!.id, groupId);
-        await deletePrayCardByGroupId(user!.id, groupId);
+        await deleteMemberbyGroupId(user!.id, targetGroup.id);
+        await deletePrayCardByGroupId(user!.id, targetGroup.id);
         window.location.replace("/");
-        analyticsTrack("클릭_그룹_나가기", { group_id: groupId });
+        analyticsTrack("클릭_그룹_나가기", { group_id: targetGroup.id });
       },
     });
     setIsConfirmAlertOpen(true);
@@ -141,14 +163,6 @@ const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
               </a>
             </div>
           ))}
-          {!user && (
-            <div className="flex items-center gap-1">
-              <span className="w-[5px] h-[18px]  rounded-md bg-mainBtn"></span>
-              <a className="cursor-pointer max-w-40 whitespace-nowrap overflow-hidden text-ellipsis font-bold text-[#222222]">
-                1027 연합예배
-              </a>
-            </div>
-          )}
           <hr className="w-full" />
           <div className="flex items-center gap-2">
             <IoPersonCircleOutline size={20} color="#222222" />
@@ -175,9 +189,7 @@ const GroupMenuBtn: React.FC<GroupMenuBtnProps> = ({
                 <IoRemoveCircleOutline size={20} color="#222222" />
                 <a
                   className="cursor-pointer text-[#222222] font-medium"
-                  onClick={() =>
-                    handleClickExitGroup(targetGroup.id, targetGroup.name)
-                  }
+                  onClick={() => handleClickExitGroup()}
                 >
                   그룹 나가기
                 </a>

--- a/src/components/group/GroupSettingsDialog.tsx
+++ b/src/components/group/GroupSettingsDialog.tsx
@@ -7,12 +7,14 @@ import {
 } from "@/components/ui/dialog";
 import useBaseStore from "@/stores/baseStore";
 import { Input } from "../ui/input";
-import { Group, MemberWithProfiles } from "supabase/types/tables";
+import { Group } from "supabase/types/tables";
 import { useEffect } from "react";
 import { Button } from "../ui/button";
 import { analyticsTrack } from "@/analytics/analytics";
 import { UserProfile } from "../profile/UserProfile";
 import { Badge } from "../ui/badge";
+import GroupMemberSettingsBtn from "./GroupMemberSettingsBtn";
+import GroupMemberOptionTag from "./GroupMemberOptionTag";
 
 interface GroupSettingsDialogProps {
   targetGroup: Group;
@@ -33,17 +35,6 @@ const GroupSettingsDialog: React.FC<GroupSettingsDialogProps> = ({
   const memberList = useBaseStore((state) => state.memberList);
   const getGroup = useBaseStore((state) => state.getGroup);
 
-  const setAlertData = useBaseStore((state) => state.setAlertData);
-  const setIsConfirmAlertOpen = useBaseStore(
-    (state) => state.setIsConfirmAlertOpen
-  );
-  const deleteMemberbyGroupId = useBaseStore(
-    (state) => state.deleteMemberbyGroupId
-  );
-  const deletePrayCardByGroupId = useBaseStore(
-    (state) => state.deletePrayCardByGroupId
-  );
-
   const onClickSaveGroup = async () => {
     if (inputGroupName.trim() === "") return;
     analyticsTrack("클릭_그룹_이름변경", { group_name: GroupSettingsDialog });
@@ -52,23 +43,6 @@ const GroupSettingsDialog: React.FC<GroupSettingsDialogProps> = ({
       getGroup(targetGroup.id);
       setIsOpenGroupSettingsDialog(false);
     }
-  };
-
-  const onClickDeleteMemberInGroup = (member: MemberWithProfiles) => {
-    setAlertData({
-      color: "bg-red-400",
-      title: "그룹 내보내기",
-      description: `해당 그룹에서  ${member.profiles.full_name} 님을 내보내시겠어요?\n*${member.profiles.full_name} 님의 기도카드는 모두 삭제되어요`,
-      actionText: "내보내기",
-      cancelText: "취소",
-      onAction: async () => {
-        await deleteMemberbyGroupId(member.profiles.id, targetGroup.id);
-        await deletePrayCardByGroupId(member.profiles.id, targetGroup.id);
-        window.location.replace(`/group/${targetGroup.id}`);
-        analyticsTrack("클릭_그룹_내보내기", { group_id: targetGroup.id });
-      },
-    });
-    setIsConfirmAlertOpen(true);
   };
 
   useEffect(() => {
@@ -98,9 +72,12 @@ const GroupSettingsDialog: React.FC<GroupSettingsDialogProps> = ({
             />
           </section>
           <section className="flex flex-col gap-4">
-            <label className="text-sm font-medium text-gray-700">
-              그룹원 ({memberList.length})
-            </label>
+            <div className="flex justify-between">
+              <label className="text-sm font-medium text-gray-700">
+                그룹원 ({memberList.length})
+              </label>
+              <GroupMemberSettingsBtn />
+            </div>
             <div className="flex flex-col gap-3 max-h-40 p-1 overflow-auto">
               {[...memberList]
                 .sort((member) =>
@@ -116,12 +93,7 @@ const GroupSettingsDialog: React.FC<GroupSettingsDialogProps> = ({
                     {member.user_id === targetGroup.user_id ? (
                       <Badge>그룹장</Badge>
                     ) : (
-                      <Badge
-                        variant="secondary"
-                        onClick={() => onClickDeleteMemberInGroup(member)}
-                      >
-                        내보내기
-                      </Badge>
+                      <GroupMemberOptionTag member={member} />
                     )}
                   </div>
                 ))}

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -130,6 +130,10 @@ export interface BaseStore {
   setIsOpenTodayPrayDrawer: (isOpenTodayPrayDrawer: boolean) => void;
   isOpenGroupMenuSheet: boolean;
   setIsOpenGroupMenuSheet: (isOpenGroupMenuSheet: boolean) => void;
+  activeGroupMemberOption: string;
+  setActiveGroupMemberOption: (
+    activeGroupMemberOption: string,
+  ) => void;
 
   // member
   memberList: MemberWithProfiles[] | null;
@@ -561,6 +565,14 @@ const useBaseStore = create<BaseStore>()(
     setIsOpenGroupMenuSheet: (isOpenGroupMenuSheet: boolean) => {
       set((state) => {
         state.isOpenGroupMenuSheet = isOpenGroupMenuSheet;
+      });
+    },
+    activeGroupMemberOption: "",
+    setActiveGroupMemberOption: (
+      activeGroupMemberOption: string,
+    ) => {
+      set((state) => {
+        state.activeGroupMemberOption = activeGroupMemberOption;
       });
     },
 


### PR DESCRIPTION
<img width="879" alt="image" src="https://github.com/user-attachments/assets/2b010a87-ff3c-4a01-8e27-1c92568d46c6">




# 작업내용
<img width="400" alt="image" src="https://github.com/user-attachments/assets/23861d84-249e-45f4-8092-a2f2e44c125c">

그룹장 관련 이슈를 겪는 고객이 있어 내용 반영합니다.
기존에 그룹장이 그룹을 나가게 되면 그룹장이 부재하는 상황이 있었는데 이를 해결합니다.
그룹장이 그룹을 나가는 경우를 예외처리하고 그룹장 양도 기능을 추가합니다.


# 체크리스트
- [x]  그룹 나가기 할 때 그룹장 여부 확인
    - [x]  그룹장이면 양도 이후 나가기
- [x]  양도 버튼 추가
- [x]  group rls 추가