### PR TITLE
refactor: 말씀카드 렌더링 단일화 및 AI agent 가이드 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+PrayU 웹 프로젝트에서 AI agent가 작업할 때 따라야 하는 가이드.
+이 프로젝트는 AI agent 도입 이전에 시작되었으며, 기존 사용자 흐름을 보존하면서 점진적으로 개선하는 것을 최우선으로 한다.
+
+## 제품 이해
+
+- 기도제목을 나누고 함께 기도하는 **모바일 중심** 서비스
+- 웹앱 + 앱 WebView(`window.flutter_inappwebview`) 하이브리드 구조
+- 핵심 도메인: 인증, 그룹, 멤버, 기도카드, 감사카드, 알림, QT/말씀카드
+
+## 명령어
+
+```bash
+npm run dev            # 개발 서버
+npm run lint           # ESLint (--max-warnings 0)
+npm run build          # tsc -b && vite build
+npm run supabase-sync  # Supabase 타입 재생성 → supabase/types/database.ts
+```
+
+## 기술 스택과 구조
+
+React 18 + TypeScript + Vite 5 / Tailwind + Radix(shadcn/ui) + Vaul / Zustand + Immer / Supabase (Auth, DB, Edge Functions) / Sentry / Vercel 배포
+
+- `src/App.tsx`: 전체 라우트 중심 (40+ 라우트)
+- `src/AppInit/AppInit.tsx`: WebView 감지, `--vh` 보정, 푸시 이동 처리
+- `src/stores/baseStore.ts`: 핵심 전역 상태 + 비즈니스 액션 집약 (대형 단일 스토어)
+- `src/apis/*`: Supabase/외부 API 호출 계층 — 원격 호출은 여기에 둔다
+- `src/components/auth/*`: 인증, PrivateRoute
+- `src/components/ui/*`: 공용 UI primitives — 새 UI는 먼저 여기 재사용 검토
+- `src/lib/utils.ts`: KST 날짜 유틸 등 공통 유틸
+- `supabase/types/*`: 생성 산출물 — 수동 수정 시 반드시 이유를 남긴다
+
+## 의사결정 우선순위
+
+1. 기존 사용자 흐름을 깨지 않는가
+2. 모바일 사용성과 앱 내 동작을 유지하는가
+3. 타입 안정성과 데이터 정합성을 유지하는가
+4. 변경 범위가 작고 되돌리기 쉬운가
+5. 새 추상화가 기존 구조보다 실제로 단순한가
+
+## 가드레일
+
+- **기존 흐름 보존**: 로그인/로그아웃, 그룹 조회·생성·가입, 기도카드 CRUD, 감사카드 생성·공유, 알림 진입, Kakao callback, WebView 진입·푸시 이동은 회귀 없이 유지
+- **모바일 우선**: `max-w-[480px]` 기반 레이아웃, `--vh` 높이 계산을 함부로 바꾸지 않는다
+- **KST 기준 날짜**: 날짜 로직은 `src/lib/utils.ts`의 KST 유틸 재사용. UTC 계산을 섞어 저장/조회 조건을 바꾸지 않는다
+- **데이터 접근 패턴**: 컴포넌트에서 직접 Supabase 쿼리를 늘리지 않는다. 전역 상태는 기존 Zustand 패턴, 일회성 UI 상태는 지역 상태 우선
+- **환경변수 보호**: `.env` 값 추측 금지. `VITE_ENV` 분기는 staging/prod 동작에 직접 영향 — 임의 변경 금지
+- **소프트 삭제**: `deleted_at` 기준이 일관되게 적용되는지 확인. 쿼리에 `.is("deleted_at", null)` 누락 주의
+- **에러 처리**: 원격 호출 실패는 삼키지 않고 Sentry 캡처 또는 사용자 피드백. null 반환 패턴이 많으므로 호출부 처리까지 함께 본다
+- **문구는 한국어 UX** 맥락 유지, import alias는 `@/` 사용
+
+## 피해야 할 작업
+
+- 전체 라우팅 구조 한 번에 재작성
+- `baseStore`를 근거 없이 대분해
+- 인증/권한 로직 무단 변경
+- Supabase 테이블/컬럼명 추정 수정 (스키마 변경은 migration + 타입 재생성 + 프론트 영향 확인)
+- analytics 이벤트명 대량 변경
+- WebView 브리지 동작 무검증 수정
+- `index.html`, `vercel.json`, `vite.config.ts`를 목적 외로 수정
+
+## 사람 확인이 필요한 변경
+
+DB schema, 인증 흐름, analytics 이벤트 정의, Sentry 설정, 배포 설정, 공유/callback URL, 핵심 UX 문구
+
+## 검증 기준
+
+- `npm run lint` + `npm run build` 통과 (기존 경고 4개는 알려진 상태)
+- 라우트 변경 시 관련 페이지 수동 확인
+- Supabase 연동 변경 시 실패/빈값/null 케이스 확인
+- 라우트 파라미터 비정상 값(uuid 아님, 미존재 id)에서도 안전하게 실패하는지 확인
+
+## 배포 전 체크 (요약)
+
+- 비로그인 보호 라우트 접근 차단, 로그인 redirect 흐름 확인
+- iOS/Android WebView에서 로그인·라우팅·공유 동작 확인 (`flutter_inappwebview` 없는 환경에서도 깨지지 않아야 함)
+- 새로고침 시 모든 라우트 진입 확인 (Vercel rewrite)
+- Sentry 이벤트 수집 확인, 에러 메시지에 민감정보 미포함
+- 초기 번들 크기, 첫 진입 경로의 대형 asset 확인
+- 클라이언트 번들에 시크릿 미노출 확인
+
+핵심 QA 시나리오: 비로그인 첫 진입 → 로그인 → 그룹 진입/생성/초대 → 기도카드 생성·수정·조회 → 감사카드 생성·공유 → 알림 이동 → Kakao callback → 잘못된 URL 접근 → 네트워크 실패 처리

--- a/src/components/prayCard/BibleCard.tsx
+++ b/src/components/prayCard/BibleCard.tsx
@@ -1,5 +1,6 @@
 import { BibleCard as BibleCardType } from "supabase/types/tables";
-import { getISODateYMD } from "@/lib/utils";
+import { toBibleCardContent } from "@/constants/bibleCard";
+import { ScaledBibleCard } from "./BibleCardBase";
 
 interface BibleCardProps {
   bibleCard: BibleCardType | null | undefined;
@@ -14,49 +15,11 @@ const BibleCard: React.FC<BibleCardProps> = ({ bibleCard }) => {
     );
   }
 
-  const { year, month, day } = getISODateYMD(bibleCard.created_at);
-  const [primary = "#608CFF", secondary = "#AAC7FF"] = bibleCard.colors;
-  const [
-    topLeftRadius = "80px",
-    topRightRadius = "120px",
-    bottomRightRadius = "80px",
-    bottomLeftRadius = "120px",
-  ] = bibleCard.radius;
-
   return (
-    <div className="relative flex aspect-[3/4] w-full flex-col rounded-xl border border-gray-100 bg-[#FEFDFC] px-5 py-4 text-left shadow-prayCard">
-      <div
-        className="flex aspect-square w-full flex-col items-center justify-center px-7 py-5 text-center text-white"
-        style={{
-          background: `linear-gradient(159deg, ${primary}, ${secondary})`,
-          borderTopLeftRadius: topLeftRadius,
-          borderTopRightRadius: topRightRadius,
-          borderBottomRightRadius: bottomRightRadius,
-          borderBottomLeftRadius: bottomLeftRadius,
-        }}
-      >
-        <p className="handwrittenV2 whitespace-pre-wrap text-[26px] leading-[34px]">
-          {bibleCard.bible_sentence.replace(/<[^>]*>/g, "").trim()}
-        </p>
-        <p className="handwrittenV2 mt-5 text-[20px] leading-tight">
-          {bibleCard.bible_reference}
-        </p>
-      </div>
-
-      <div className="mt-3 text-left" style={{ color: primary }}>
-        <p className="truncate text-[34px] font-bold">{bibleCard.name}</p>
-        <div className="flex flex-wrap gap-x-2 text-base text-gray-700">
-          {bibleCard.keywords.map((keyword) => (
-            <span key={keyword}>#{keyword}</span>
-          ))}
-        </div>
-      </div>
-
-      <div className="absolute bottom-4 left-5 right-5 flex justify-between text-xs text-[#666666]">
-        <span>{`${year}.${month}.${day}.`}</span>
-        <span>@prayu.official</span>
-      </div>
-    </div>
+    <ScaledBibleCard
+      content={toBibleCardContent(bibleCard)}
+      className="rounded-xl shadow-prayCard"
+    />
   );
 };
 

--- a/src/components/prayCard/BibleCardBase.tsx
+++ b/src/components/prayCard/BibleCardBase.tsx
@@ -1,0 +1,121 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  BIBLE_CARD_HEIGHT,
+  BIBLE_CARD_WIDTH,
+  BibleCardContent,
+  getBibleVerseStyle,
+} from "@/constants/bibleCard";
+
+// 말씀카드의 단일 디자인 원본. 화면 표시/썸네일은 ScaledBibleCard 로 축소 렌더링하고,
+// 이미지 캡처는 BibleCardBase 를 원본 크기 그대로 찍는다. 같은 컴포넌트를 쓰므로
+// 화면에 보이는 카드와 저장되는 이미지가 항상 일치한다.
+export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
+  const [primary = "#608CFF", secondary = "#AAC7FF"] = content.colors;
+  const [
+    borderTopLeftRadius = "80px",
+    borderTopRightRadius = "120px",
+    borderBottomRightRadius = "80px",
+    borderBottomLeftRadius = "120px",
+  ] = content.radius;
+  const bibleSentence = content.bibleSentence.replace(/<[^>]*>/g, "").trim();
+  const verseStyle = getBibleVerseStyle(bibleSentence.length);
+
+  return (
+    <div
+      className="relative flex flex-col border border-gray-200 bg-[#FEFDFC] px-[30px] py-[20px]"
+      style={{ width: BIBLE_CARD_WIDTH, height: BIBLE_CARD_HEIGHT }}
+    >
+      <div
+        className="flex aspect-square w-full flex-col items-center justify-center"
+        style={{
+          background: `linear-gradient(159deg, ${primary}, ${secondary})`,
+          borderTopLeftRadius,
+          borderTopRightRadius,
+          borderBottomRightRadius,
+          borderBottomLeftRadius,
+        }}
+      >
+        <div
+          className="handwrittenV2 flex h-full w-full flex-col items-center justify-center gap-[20px] whitespace-pre-wrap py-[20px] text-center text-white"
+          style={{
+            paddingLeft: verseStyle.paddingX,
+            paddingRight: verseStyle.paddingX,
+          }}
+        >
+          <div
+            className="tracking-[1px]"
+            style={{
+              fontSize: verseStyle.fontSize,
+              lineHeight: `${verseStyle.lineHeight}px`,
+            }}
+          >
+            {bibleSentence}
+          </div>
+          <div className="text-[24px] leading-tight tracking-[1px]">
+            {content.bibleReference}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ color: primary }} className="flex min-w-0 flex-col">
+        <div className="truncate text-[40px] font-bold">{content.name}</div>
+        <div className="flex flex-wrap gap-x-[8px] text-[20px] text-black-500">
+          {content.keywords.map((keyword) => (
+            <span key={keyword}>#{keyword}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="absolute bottom-[25px] left-[30px] right-[30px] flex justify-between text-[#666666]">
+        <span className="tracking-[1px]">{`${content.date.year}.${content.date.month}.${content.date.day}.`}</span>
+        <div>@prayu.official</div>
+      </div>
+    </div>
+  );
+};
+
+interface ScaledBibleCardProps {
+  content: BibleCardContent;
+  className?: string;
+}
+
+export const ScaledBibleCard = ({
+  content,
+  className,
+}: ScaledBibleCardProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    setWidth(element.clientWidth);
+    const observer = new ResizeObserver(([entry]) => {
+      setWidth(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("aspect-[3/4] w-full overflow-hidden", className)}
+    >
+      {width > 0 && (
+        <div
+          style={{
+            width: BIBLE_CARD_WIDTH,
+            height: BIBLE_CARD_HEIGHT,
+            transform: `scale(${width / BIBLE_CARD_WIDTH})`,
+            transformOrigin: "top left",
+          }}
+        >
+          <BibleCardBase content={content} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/prayCard/BibleCardThumbnail.tsx
+++ b/src/components/prayCard/BibleCardThumbnail.tsx
@@ -1,5 +1,7 @@
 import { BibleCard as BibleCardType } from "supabase/types/tables";
-import { cn, getISODateYMD } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { toBibleCardContent } from "@/constants/bibleCard";
+import { ScaledBibleCard } from "./BibleCardBase";
 
 interface BibleCardThumbnailProps {
   bibleCard: BibleCardType | null | undefined;
@@ -27,55 +29,9 @@ const BibleCardThumbnail: React.FC<BibleCardThumbnailProps> = ({
     );
   }
 
-  const { year, month, day } = getISODateYMD(bibleCard.created_at);
-  const [primary = "#608CFF", secondary = "#AAC7FF"] = bibleCard.colors;
-  const [
-    topLeftRadius = "40px",
-    topRightRadius = "60px",
-    bottomRightRadius = "40px",
-    bottomLeftRadius = "60px",
-  ] = bibleCard.radius;
-
   return (
-    <div
-      className={cn(
-        "relative flex h-full w-full flex-col bg-[#FEFDFC] p-1 text-left",
-        className,
-      )}
-    >
-      <div
-        className="flex aspect-square w-full shrink-0 flex-col items-center justify-center gap-1 px-2 py-2 text-center text-white"
-        style={{
-          background: `linear-gradient(159deg, ${primary}, ${secondary})`,
-          borderTopLeftRadius: topLeftRadius,
-          borderTopRightRadius: topRightRadius,
-          borderBottomRightRadius: bottomRightRadius,
-          borderBottomLeftRadius: bottomLeftRadius,
-        }}
-      >
-        <p className="handwrittenV2 line-clamp-4 text-[9px] leading-[13px]">
-          {bibleCard.bible_sentence.replace(/<[^>]*>/g, "").trim()}
-        </p>
-        <p className="handwrittenV2 mt-1 line-clamp-1 text-[7px] leading-tight">
-          {bibleCard.bible_reference}
-        </p>
-      </div>
-
-      <div className="mt-1 min-h-0 flex-1" style={{ color: primary }}>
-        <p className="truncate text-[13px] font-bold leading-tight">
-          {bibleCard.name}
-        </p>
-        <div className="mt-0.5 flex flex-wrap gap-x-1 text-[8px] leading-tight text-gray-700">
-          {bibleCard.keywords.slice(0, 3).map((keyword) => (
-            <span key={keyword}>#{keyword}</span>
-          ))}
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between gap-1 text-[7px] leading-none text-gray-400">
-        <span>{`${year}.${month}.${day}.`}</span>
-        <span className="truncate">@prayu.official</span>
-      </div>
+    <div className={cn("relative h-full w-full", className)}>
+      <ScaledBibleCard content={toBibleCardContent(bibleCard)} />
 
       {dimmed && <div className="absolute inset-0 bg-white/65" />}
       {label && (

--- a/src/constants/bibleCard.ts
+++ b/src/constants/bibleCard.ts
@@ -1,3 +1,33 @@
+import { BibleCard as BibleCardType } from "supabase/types/tables";
+import { getISODateYMD } from "@/lib/utils";
+
+// 말씀카드 디자인 원본(BibleCardBase)의 기준 크기.
+// 화면 표시는 이 크기를 scale 로 축소하고, 캡처는 원본 크기로 찍는다.
+export const BIBLE_CARD_WIDTH = 380;
+export const BIBLE_CARD_HEIGHT = (BIBLE_CARD_WIDTH * 4) / 3;
+
+export interface BibleCardContent {
+  name: string;
+  bibleSentence: string;
+  bibleReference: string;
+  colors: string[];
+  radius: string[];
+  keywords: string[];
+  date: { year: string; month: string; day: string };
+}
+
+export const toBibleCardContent = (
+  bibleCard: BibleCardType,
+): BibleCardContent => ({
+  name: bibleCard.name,
+  bibleSentence: bibleCard.bible_sentence,
+  bibleReference: bibleCard.bible_reference,
+  colors: bibleCard.colors,
+  radius: bibleCard.radius,
+  keywords: bibleCard.keywords,
+  date: getISODateYMD(bibleCard.created_at),
+});
+
 // 380px 기준 카드에서 구절 길이에 따라 폰트 크기를 단계적으로 줄인다.
 // 같은 길이는 항상 같은 스타일을 반환하므로 화면 렌더링과 이미지 캡처 결과가 일치한다.
 export interface BibleVerseStyle {

--- a/src/pages/BibleCardPage/BibleCardNewPage.tsx
+++ b/src/pages/BibleCardPage/BibleCardNewPage.tsx
@@ -17,6 +17,7 @@ import { createBibleCard } from "@/apis/bibleCard";
 import { updatePrayCard } from "@/apis/prayCard";
 import PrayCard from "@/components/prayCard/PrayCard";
 import BibleCardView from "@/components/prayCard/BibleCard";
+import { BibleCardBase } from "@/components/prayCard/BibleCardBase";
 import BibleCardThumbnail from "@/components/prayCard/BibleCardThumbnail";
 import ShowMoreBtn from "@/components/common/ShowMoreBtn";
 import ShareButtonGroup from "@/components/share/ShareButtonGroup";
@@ -24,10 +25,7 @@ import useBaseStore from "@/stores/baseStore";
 import { useSaveImage } from "@/hooks/useSaveImage";
 import { analyticsTrack } from "@/analytics/analytics";
 import { getDomainUrl, getISOTodayDateYMD, getTodayNumber } from "@/lib/utils";
-import {
-  BIBLE_CARD_COLOR_PRESETS,
-  getBibleVerseStyle,
-} from "@/constants/bibleCard";
+import { BIBLE_CARD_COLOR_PRESETS } from "@/constants/bibleCard";
 import {
   BibleCard as BibleCardType,
   PrayCardWithProfiles,
@@ -226,75 +224,6 @@ const PrayCardBibleBackPreview = ({
     </button>
   </div>
 );
-
-const CaptureBibleCard = ({
-  name,
-  draft,
-}: {
-  name: string;
-  draft: BibleCardDraft;
-}) => {
-  const { year, month, day } = getISOTodayDateYMD();
-  const [primary = "#608CFF", secondary = "#AAC7FF"] = draft.colors;
-  const [
-    borderTopLeftRadius = "80px",
-    borderTopRightRadius = "120px",
-    borderBottomRightRadius = "80px",
-    borderBottomLeftRadius = "120px",
-  ] = draft.radius;
-  const bibleSentence = draft.bibleSentence.replace(/<[^>]*>/g, "").trim();
-  const verseStyle = getBibleVerseStyle(bibleSentence.length);
-
-  return (
-    <div className="relative flex aspect-[3/4] w-[380px] flex-col border border-gray-200 bg-[#FEFDFC] px-[30px] py-[20px]">
-      <div
-        className="flex aspect-square w-full flex-col items-center justify-center"
-        style={{
-          background: `linear-gradient(159deg, ${primary}, ${secondary})`,
-          borderTopLeftRadius,
-          borderTopRightRadius,
-          borderBottomRightRadius,
-          borderBottomLeftRadius,
-        }}
-      >
-        <div
-          className="handwrittenV2 flex h-full w-full flex-col items-center justify-center gap-[20px] whitespace-pre-wrap py-[20px] text-center text-white"
-          style={{
-            paddingLeft: verseStyle.paddingX,
-            paddingRight: verseStyle.paddingX,
-          }}
-        >
-          <div
-            className="tracking-[1px]"
-            style={{
-              fontSize: verseStyle.fontSize,
-              lineHeight: `${verseStyle.lineHeight}px`,
-            }}
-          >
-            {bibleSentence}
-          </div>
-          <div className="text-[24px] leading-tight tracking-[1px]">
-            {draft.bibleReference}
-          </div>
-        </div>
-      </div>
-
-      <div style={{ color: primary }} className="mt-0 flex min-w-0 flex-col">
-        <div className="truncate text-[40px] font-bold">{name}</div>
-        <div className="flex flex-wrap gap-x-[8px] text-[20px] text-black-500">
-          {draft.keywords.map((keyword) => (
-            <span key={keyword}>#{keyword}</span>
-          ))}
-        </div>
-      </div>
-
-      <div className="absolute bottom-[25px] left-[30px] right-[30px] flex justify-between text-[#666666]">
-        <span className="tracking-[1px]">{`${year}.${month}.${day}.`}</span>
-        <div>@prayu.official</div>
-      </div>
-    </div>
-  );
-};
 
 const BibleCardNewPage = () => {
   const navigate = useNavigate();
@@ -525,6 +454,7 @@ const BibleCardNewPage = () => {
 
       if (!targetBible || !keywords) {
         toast({ description: "말씀을 가져오지 못했어요. 다시 시도해 주세요" });
+        setIsFlipped(false);
         return;
       }
 
@@ -562,6 +492,7 @@ const BibleCardNewPage = () => {
 
       if (!imageUrl) {
         toast({ description: "말씀카드 이미지를 저장하지 못했어요" });
+        setIsFlipped(false);
         return;
       }
 
@@ -578,6 +509,7 @@ const BibleCardNewPage = () => {
 
       if (!bibleCard) {
         toast({ description: "말씀카드를 저장하지 못했어요" });
+        setIsFlipped(false);
         return;
       }
 
@@ -827,8 +759,18 @@ const BibleCardNewPage = () => {
 
       {draft && (
         <div className="fixed -top-[100vh] -z-40 pointer-events-none">
-          <div ref={bibleCardRef} className="w-[380px] aspect-[3/4]">
-            <CaptureBibleCard name={displayName} draft={draft} />
+          <div ref={bibleCardRef}>
+            <BibleCardBase
+              content={{
+                name: displayName,
+                bibleSentence: draft.bibleSentence,
+                bibleReference: draft.bibleReference,
+                colors: draft.colors,
+                radius: draft.radius,
+                keywords: draft.keywords,
+                date: getISOTodayDateYMD(),
+              }}
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
## 목적

말씀카드가 화면 표시용(`BibleCard`), 캡처용(`CaptureBibleCard`), 썸네일용(`BibleCardThumbnail`) 3곳에서 각각 손으로 그려져 있어, 저장되는 이미지와 화면 UI가 달랐던 문제를 구조적으로 해결합니다.

## 변경 내용

### 말씀카드 렌더링 단일화
- **`BibleCardBase`** (신규): 380px 기준 카드 디자인 원본. 구절 길이에 따른 폰트 단계(`getBibleVerseStyle`) 적용
- **`ScaledBibleCard`** (신규): 컨테이너 너비를 측정해 `transform: scale()`로 축소 렌더링하는 래퍼
- `BibleCard` / `BibleCardThumbnail`: 자체 스타일 제거하고 `ScaledBibleCard` 래퍼로 교체 (외부 API 동일)
- `BibleCardNewPage`의 `CaptureBibleCard` 제거: 캡처 노드가 `BibleCardBase`를 원본 크기로 직접 사용

→ **화면에 보이는 카드 = 썸네일 = 저장되는 이미지**가 같은 컴포넌트에서 나오므로 항상 일치합니다. 카드 디자인 수정도 한 파일로 끝납니다.

### 버그 수정
- 말씀카드 생성 실패 시(말씀 검색/이미지 저장/DB 저장 실패) 빈 뒷면이 보인 채로 남던 문제 → flip 상태 복구

### 문서
- `CLAUDE.md` 추가: Agents.md, ReleaseChecklist.md 내용을 AI agent 가이드로 통합 정리

## 검증
- `npm run build` 통과 (tsc + vite)
- `npm run lint`: 기존 경고 4개 외 신규 경고 없음

## 수동 확인 권장
- 말씀카드 생성 플로우: 카드 생성 → 뒷면 플립 → 저장된 이미지가 화면과 동일한지
- 기도카드 선택 드로어의 썸네일 표시
- 공유 페이지(`/bible-card/share/:id`)의 이미지 없는 카드 fallback 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)