### PR TITLE
feat: 말씀카드 키워드 3개 제한 및 어절 단위 줄바꿈

### DIFF
--- a/src/components/prayCard/BibleCardBase.tsx
+++ b/src/components/prayCard/BibleCardBase.tsx
@@ -4,6 +4,7 @@ import {
   BIBLE_CARD_HEIGHT,
   BIBLE_CARD_WIDTH,
   BibleCardContent,
+  MAX_BIBLE_CARD_KEYWORDS,
   getBibleVerseStyle,
 } from "@/constants/bibleCard";
 
@@ -61,7 +62,7 @@ export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
       <div style={{ color: primary }} className="flex min-w-0 flex-col">
         <div className="truncate text-[40px] font-bold">{content.name}</div>
         <div className="flex flex-wrap gap-x-[8px] text-[20px] text-black-500">
-          {content.keywords.map((keyword) => (
+          {content.keywords.slice(0, MAX_BIBLE_CARD_KEYWORDS).map((keyword) => (
             <span key={keyword}>#{keyword}</span>
           ))}
         </div>

--- a/src/components/prayCard/BibleCardBase.tsx
+++ b/src/components/prayCard/BibleCardBase.tsx
@@ -45,7 +45,7 @@ export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
           }}
         >
           <div
-            className="tracking-[1px]"
+            className="whitespace-normal text-balance break-keep tracking-[1px]"
             style={{
               fontSize: verseStyle.fontSize,
               lineHeight: `${verseStyle.lineHeight}px`,

--- a/src/constants/bibleCard.ts
+++ b/src/constants/bibleCard.ts
@@ -1,6 +1,9 @@
 import { BibleCard as BibleCardType } from "supabase/types/tables";
 import { getISODateYMD } from "@/lib/utils";
 
+// 말씀카드에 표시할 키워드 최대 개수
+export const MAX_BIBLE_CARD_KEYWORDS = 3;
+
 // 말씀카드 디자인 원본(BibleCardBase)의 기준 크기.
 // 화면 표시는 이 크기를 scale 로 축소하고, 캡처는 원본 크기로 찍는다.
 export const BIBLE_CARD_WIDTH = 380;

--- a/src/pages/BibleCardPage/BibleCardNewPage.tsx
+++ b/src/pages/BibleCardPage/BibleCardNewPage.tsx
@@ -25,7 +25,10 @@ import useBaseStore from "@/stores/baseStore";
 import { useSaveImage } from "@/hooks/useSaveImage";
 import { analyticsTrack } from "@/analytics/analytics";
 import { getDomainUrl, getISOTodayDateYMD, getTodayNumber } from "@/lib/utils";
-import { BIBLE_CARD_COLOR_PRESETS } from "@/constants/bibleCard";
+import {
+  BIBLE_CARD_COLOR_PRESETS,
+  MAX_BIBLE_CARD_KEYWORDS,
+} from "@/constants/bibleCard";
 import {
   BibleCard as BibleCardType,
   PrayCardWithProfiles,
@@ -458,6 +461,8 @@ const BibleCardNewPage = () => {
         return;
       }
 
+      const limitedKeywords = keywords.slice(0, MAX_BIBLE_CARD_KEYWORDS);
+
       const colors = [
         ...BIBLE_CARD_COLOR_PRESETS[
           Math.floor(Math.random() * BIBLE_CARD_COLOR_PRESETS.length)
@@ -474,7 +479,7 @@ const BibleCardNewPage = () => {
         bibleSentence: targetBible.sentence,
         colors,
         radius,
-        keywords,
+        keywords: limitedKeywords,
       };
       setDraft(nextDraft);
 
@@ -499,7 +504,7 @@ const BibleCardNewPage = () => {
       const bibleCard = await createBibleCard({
         user_id: user.id,
         name: displayName,
-        keywords,
+        keywords: limitedKeywords,
         bible_reference: nextDraft.bibleReference,
         bible_sentence: nextDraft.bibleSentence,
         colors,


### PR DESCRIPTION
PR #448 머지 이후 추가된 두 가지 개선사항입니다. (448이 squash 머지되며 해당 커밋들이 main에 누락되어 새 PR로 분리)

## 변경 내용

### 키워드 최대 3개 제한
- 생성 시 `searchBible` 결과 키워드를 `MAX_BIBLE_CARD_KEYWORDS`(3)로 slice (draft·캡처·DB 저장 동일 적용)
- `BibleCardBase` 렌더 시에도 캡 적용 → 기존에 4개 이상으로 저장된 카드도 화면에서 3개만 표시

### 구절 어절 단위 줄바꿈
- `word-break: keep-all`(`break-keep`)로 음절 중간 끊김 방지 → 공백(어절) 경계에서만 줄바꿈
- `text-wrap: balance`(`text-balance`)로 줄 길이 균형
- 구형 WebView(balance 미지원)에서도 keep-all은 적용되어 어절 단위 줄바꿈 보장

## 검증
- `npm run build` 통과
- `npm run lint`: 기존 경고 4개 외 신규 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)