### PR TITLE
fix: 기도카드 생성 플로우 뒤로가기 버그 수정

### DIFF
--- a/src/components/prayCard/NewPrayCardGroupSelectStep.tsx
+++ b/src/components/prayCard/NewPrayCardGroupSelectStep.tsx
@@ -15,6 +15,10 @@ interface NewPrayCardGroupSelectStepProps {
   onGroupSelect: (groups: Group[]) => void;
   onNext: () => void;
   onPrev: () => void;
+  // 이미 생성된 플로우인지 (뒤로가기 재진입 시 재생성 방지)
+  hasCreated: boolean;
+  // 생성 성공 시 부모에 알림
+  onCreated: () => void;
 }
 
 // Animation variants for staggered child elements
@@ -32,6 +36,8 @@ const NewPrayCardGroupSelectStep: React.FC<NewPrayCardGroupSelectStepProps> = ({
   onGroupSelect,
   onNext,
   onPrev,
+  hasCreated,
+  onCreated,
 }) => {
   const user = useBaseStore((state) => state.user);
   const bulkUpdateMembers = useBaseStore((state) => state.bulkUpdateMembers);
@@ -100,6 +106,12 @@ const NewPrayCardGroupSelectStep: React.FC<NewPrayCardGroupSelectStepProps> = ({
   
   
   const handleCreatePrayCard = async () => {
+    // 이미 생성된 플로우(완료 후 뒤로가기 재진입)면 재생성하지 않고 완료 화면으로만 이동
+    if (hasCreated) {
+      onNext();
+      return;
+    }
+
     analyticsTrack("클릭_기도카드생성_만들기", { where: "그룹선택" });
     setIsCreating(true);
     if (!user) {
@@ -136,6 +148,7 @@ const NewPrayCardGroupSelectStep: React.FC<NewPrayCardGroupSelectStepProps> = ({
     localStorage.setItem("lastCreatedPrayCardId", prayCardList[0].id);
     localStorage.removeItem("prayCardContent");
     localStorage.removeItem("prayCardLife");
+    onCreated();
     onNext();
   };
 

--- a/src/components/prayCard/PrayCardHeader.tsx
+++ b/src/components/prayCard/PrayCardHeader.tsx
@@ -1,10 +1,19 @@
 import { useNavigate } from "react-router-dom";
 import { IoChevronBack } from "react-icons/io5";
 
-const PrayCardHeader = () => {
+interface PrayCardHeaderProps {
+  // 상단 뒤로가기 동작 커스터마이즈. 미지정 시 history 한 칸 뒤로 이동.
+  onBack?: () => void;
+}
+
+const PrayCardHeader = ({ onBack }: PrayCardHeaderProps) => {
   const navigate = useNavigate();
 
   const handleBack = () => {
+    if (onBack) {
+      onBack();
+      return;
+    }
     navigate(-1);
   };
 

--- a/src/pages/PrayCard/PrayCardCreatePage.tsx
+++ b/src/pages/PrayCard/PrayCardCreatePage.tsx
@@ -52,6 +52,9 @@ const PrayCardCreatePage = () => {
   const [selectedGroups, setSelectedGroups] = useState<Group[]>(
     targetGroup ? [targetGroup] : []
   );
+  // 생성 완료 후 뒤로가기로 그룹선택 단계에 돌아왔을 때 재생성을 막기 위한 플래그.
+  // 단계 전환 시 스텝 컴포넌트는 언마운트되므로, 항상 떠 있는 이 페이지에 둔다.
+  const [hasCreated, setHasCreated] = useState(false);
 
   useEffect(() => {
     if (user) fetchUserPrayCardList(user.id, 1, 0);
@@ -70,6 +73,11 @@ const PrayCardCreatePage = () => {
     if (step > 0) {
       navigate(-1);
     }
+  };
+
+  // 상단 뒤로가기: 단계만큼 쌓인 history 를 한 번에 빠져나가 진입 전 페이지로 이동
+  const handleExit = () => {
+    navigate(-(step + 1));
   };
 
   const handleGroupSelect = (groups: Group[]) => {
@@ -105,6 +113,8 @@ const PrayCardCreatePage = () => {
             onGroupSelect={handleGroupSelect}
             onNext={handleNext}
             onPrev={handlePrev}
+            hasCreated={hasCreated}
+            onCreated={() => setHasCreated(true)}
           />
         );
       case 4:
@@ -117,7 +127,7 @@ const PrayCardCreatePage = () => {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <PrayCardHeader />
+      <PrayCardHeader onBack={handleExit} />
 
       {/* Progress bar */}
       <ProgressBar currentStep={step} totalSteps={totalSteps} />


### PR DESCRIPTION
## 문제

1. `/praycard/new` 상단 뒤로가기 버튼이 '이전' 버튼과 동일하게 단계 한 칸만 뒤로 이동
2. **생성 완료 후 뒤로가기로 그룹선택 단계에 돌아가 '만들기'를 다시 누르면 기도카드가 중복 생성됨** (게다가 localStorage가 비워진 상태라 빈 내용의 중복 카드 생성)

## 동작 정의

| 동작 | 결과 |
|---|---|
| 이전 버튼 | 이전 단계 (기존 유지) |
| 상단 뒤로가기 | 플로우 종료 → 진입 전 페이지 |
| OS/스와이프 백 (폼 단계) | 이전 단계 (안드로이드 관례 보존) |
| 완료 후 OS 백 → 그룹선택 → '만들기' | 재생성 안 함, 완료 화면으로만 이동 |

## 변경

- `PrayCardHeader`: 선택적 `onBack` prop 추가 → 상단 백을 플로우 종료(`navigate(-(step+1))`)로 연결
- `PrayCardCreatePage`: `hasCreated` 플래그를 (단계 전환에도 유지되는) 페이지 레벨 state로 관리
- `NewPrayCardGroupSelectStep`: 이미 생성된 플로우면 재생성 대신 완료 화면으로만 이동, 생성 성공 시 부모에 알림

스키마/마이그레이션 변경 없음. OS 하드웨어 백의 단계 백 동작은 보존됩니다.

## 검증
- `npm run build` 통과, `npm run lint` 신규 경고 없음

## 수동 확인 권장
- 생성 완료 → OS 백으로 그룹선택 복귀 → '만들기' 재탭 → 중복 카드 미생성 확인
- 폼 작성 중 OS 백 → 이전 단계 이동
- 상단 뒤로가기 → 진입 전 페이지로 종료
- `/group/:groupId/praycard/new` 경로에서도 동일 확인

## 알려진 엣지 (스코프 외)
`handleCreatePrayCard`에서 카드는 생성됐으나 멤버 목록이 비어 early-return 되는 경로에서는 `onCreated`가 호출되지 않음(기존 이슈). 필요 시 후속 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)