### PR TITLE
feat: 말씀카드 색상·배리에이션 정비 및 생성 대기 효과 개선

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,23 @@
   font-family: "JNE-Yuna-TTF-Regular", cursive;
 }
 
+/* 말씀카드 생성 대기 스켈레톤: border-radius 를 부드럽게 연속 모핑 */
+@keyframes blobMorph {
+  0%,
+  100% {
+    border-radius: 42% 58% 48% 52% / 46% 44% 56% 54%;
+  }
+  33% {
+    border-radius: 62% 38% 56% 44% / 52% 60% 40% 48%;
+  }
+  66% {
+    border-radius: 46% 54% 38% 62% / 60% 42% 58% 40%;
+  }
+}
+.animate-blob {
+  animation: blobMorph 5s ease-in-out infinite;
+}
+
 .no-scrollbar {
   -ms-overflow-style: none; /* IE, Edge */
   scrollbar-width: none; /* Firefox */

--- a/src/components/prayCard/BibleCardBase.tsx
+++ b/src/components/prayCard/BibleCardBase.tsx
@@ -2,10 +2,13 @@ import { useLayoutEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import {
   BIBLE_CARD_HEIGHT,
+  BIBLE_CARD_TEXT_DARK,
+  BIBLE_CARD_TEXT_MUTED,
   BIBLE_CARD_WIDTH,
   BibleCardContent,
   MAX_BIBLE_CARD_KEYWORDS,
   getBibleVerseStyle,
+  getCardTextColorOnGradient,
 } from "@/constants/bibleCard";
 
 // 말씀카드의 단일 디자인 원본. 화면 표시/썸네일은 ScaledBibleCard 로 축소 렌더링하고,
@@ -21,6 +24,8 @@ export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
   ] = content.radius;
   const bibleSentence = content.bibleSentence.replace(/<[^>]*>/g, "").trim();
   const verseStyle = getBibleVerseStyle(bibleSentence.length);
+  // 글씨는 중립 모노크롬: 구절은 배경 밝기 기반(다크/흰색), 이름은 다크, 키워드는 옅은 그레이
+  const verseColor = getCardTextColorOnGradient(content.colors);
 
   return (
     <div
@@ -38,10 +43,11 @@ export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
         }}
       >
         <div
-          className="handwrittenV2 flex h-full w-full flex-col items-center justify-center gap-[20px] whitespace-pre-wrap py-[20px] text-center text-white"
+          className="handwrittenV2 flex h-full w-full flex-col items-center justify-center gap-[20px] whitespace-pre-wrap py-[20px] text-center"
           style={{
             paddingLeft: verseStyle.paddingX,
             paddingRight: verseStyle.paddingX,
+            color: verseColor,
           }}
         >
           <div
@@ -59,9 +65,17 @@ export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
         </div>
       </div>
 
-      <div style={{ color: primary }} className="flex min-w-0 flex-col">
-        <div className="truncate text-[40px] font-bold">{content.name}</div>
-        <div className="flex flex-wrap gap-x-[8px] text-[20px] text-black-500">
+      <div className="flex min-w-0 flex-col">
+        <div
+          className="truncate text-[40px] font-bold"
+          style={{ color: BIBLE_CARD_TEXT_DARK }}
+        >
+          {content.name}
+        </div>
+        <div
+          className="flex flex-wrap gap-x-[8px] text-[20px]"
+          style={{ color: BIBLE_CARD_TEXT_MUTED }}
+        >
           {content.keywords.slice(0, MAX_BIBLE_CARD_KEYWORDS).map((keyword) => (
             <span key={keyword}>#{keyword}</span>
           ))}

--- a/src/constants/bibleCard.ts
+++ b/src/constants/bibleCard.ts
@@ -47,35 +47,70 @@ export const getBibleVerseStyle = (verseLength: number): BibleVerseStyle => {
   return { fontSize: 14, lineHeight: 19, paddingX: 28 };
 };
 
+// 파스텔 그라데이션 프리셋. 글씨색은 배경 밝기에 따라 자동 보정하므로(getCardTextColorOnGradient)
+// 밝은 파스텔만 모아도 가독성이 유지된다.
 export const BIBLE_CARD_COLOR_PRESETS: string[][] = [
-  ["#FFD194", "#D1913C"],
-  ["#a8c0ff", "#3f2b96"],
-  ["#89f7fe", "#66a6ff"],
-  ["#ff9966", "#ff5e62"],
   ["#84fab0", "#8fd3f4"],
   ["#ff9a9e", "#fecfef"],
   ["#a1c4fd", "#c2e9fb"],
-  ["#2ebf91", "#FFDAD7"],
-  ["#005AA7", "#FFFDE4"],
-  ["#1f4037", "#99f2c8"],
-  ["#FDEB71", "#F8D800"],
-  ["#F6D365", "#FDA085"],
-  ["#FBC2EB", "#A6C1EE"],
-  ["#D4FC79", "#96E6A1"],
-  ["#E0C3FC", "#8EC5FC"],
-  ["#F093FB", "#F5576C"],
-  ["#4FACFE", "#00F2FE"],
-  ["#43E97B", "#38F9D7"],
-  ["#FA709A", "#FEE140"],
-  ["#30CFD0", "#330867"],
-  ["#667EEA", "#764BA2"],
-  ["#13547A", "#80D0C7"],
-  ["#FFDEE9", "#B5FFFC"],
-  ["#FAD0C4", "#FFD1FF"],
-  ["#C1DFE6", "#FEEBC8"],
-  ["#FFECD2", "#FCB69F"],
-  ["#B7F8DB", "#50A7C2"],
-  ["#FBD3E9", "#BB377D"],
-  ["#F0C27B", "#4B1248"],
-  ["#C9FFBF", "#FFAFBD"],
+  ["#fbc2eb", "#a6c1ee"],
+  ["#d4fc79", "#96e6a1"],
+  ["#e0c3fc", "#8ec5fc"],
+  ["#ffdee9", "#b5fffc"],
+  ["#fad0c4", "#ffd1ff"],
+  ["#c1dfe6", "#feebc8"],
+  ["#ffecd2", "#fcb69f"],
+  ["#c9ffbf", "#ffafbd"],
+  ["#89f7fe", "#66a6ff"],
+  ["#f6d365", "#fda085"],
+  ["#a8edea", "#fed6e3"],
+  ["#fff1eb", "#ace0f9"],
+  ["#fddb92", "#d1fdff"],
+  ["#f5f7fa", "#c3cfe2"],
+  ["#fdcbf1", "#e6dee9"],
+  ["#d9afd9", "#97d9e1"],
+  ["#cfd9df", "#e2ebf0"],
+  ["#accbee", "#e7f0fd"],
+  ["#e9defa", "#fbfcdb"],
+  ["#f3e7e9", "#e3eeff"],
+  ["#fbc2eb", "#bdb2ff"],
+  ["#b5ead7", "#c7ceea"],
+  ["#ffdac1", "#e2f0cb"],
 ];
+
+// ---- 색상 유틸: 배경 밝기에 따른 가독성 좋은 글씨색 산출 ----
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } => {
+  const normalized = hex.replace("#", "");
+  const full =
+    normalized.length === 3
+      ? normalized
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : normalized;
+  const value = parseInt(full, 16);
+  return { r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255 };
+};
+
+const relativeLuminance = (hex: string): number => {
+  const { r, g, b } = hexToRgb(hex);
+  const channel = (c: number) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+// 카드 색 정체성은 그라데이션 블롭이 담당하고, 글씨는 중립 모노크롬으로 위계를 만든다.
+// (색을 글씨에 분산하지 않아야 블롭이 색 주인공으로 정돈된다)
+export const BIBLE_CARD_TEXT_DARK = "#2B2B2B"; // 구절·이름 (주요 텍스트)
+export const BIBLE_CARD_TEXT_MUTED = "#6B7280"; // 키워드 (메타 텍스트)
+
+// 구절 본문 글씨색: 밝은 파스텔이면 중립 다크, 어두운 배경(기존 진한 프리셋 카드)이면 흰색.
+export const getCardTextColorOnGradient = (colors: string[]): string => {
+  const avgLuminance =
+    colors.reduce((sum, c) => sum + relativeLuminance(c), 0) /
+    (colors.length || 1);
+  return avgLuminance < 0.5 ? "#FFFFFF" : BIBLE_CARD_TEXT_DARK;
+};

--- a/src/pages/BibleCardPage/BibleCardNewPage.tsx
+++ b/src/pages/BibleCardPage/BibleCardNewPage.tsx
@@ -42,18 +42,12 @@ interface BibleCardDraft {
   keywords: string[];
 }
 
-const getRandomRadius = () => `${Math.floor(Math.random() * 160) + 40}px`;
+// 네 모서리를 독립 랜덤으로 크게 흔들어(40~200px) 의도적으로 찌그러진 비대칭 블롭 연출
+const getRandomRadius = (): string[] =>
+  Array.from({ length: 4 }, () => `${Math.floor(Math.random() * 160) + 40}px`);
 const STATIC_SKELETON_RADIUS = "42% 58% 48% 52% / 46% 44% 56% 54%";
 const INITIAL_PRAY_CARD_PAGE_SIZE = 18;
 const MORE_PRAY_CARD_PAGE_SIZE = 18;
-const getRandomSkeletonRadius = () => {
-  const values = Array.from(
-    { length: 8 },
-    () => `${Math.floor(Math.random() * 24) + 38}%`,
-  );
-
-  return `${values.slice(0, 4).join(" ")} / ${values.slice(4).join(" ")}`;
-};
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
@@ -116,34 +110,19 @@ const createBibleReference = (bible: {
     : `${bible.long_label} ${bible.chapter}장 ${bible.paragraph}절`;
 
 const EmptyBibleCardBackSlot = ({ isCreating }: { isCreating: boolean }) => {
-  const [skeletonRadius, setSkeletonRadius] = useState(STATIC_SKELETON_RADIUS);
-
-  useEffect(() => {
-    if (!isCreating) {
-      setSkeletonRadius(STATIC_SKELETON_RADIUS);
-      return;
-    }
-
-    setSkeletonRadius(getRandomSkeletonRadius());
-    const intervalId = window.setInterval(() => {
-      setSkeletonRadius(getRandomSkeletonRadius());
-    }, 280);
-
-    return () => window.clearInterval(intervalId);
-  }, [isCreating]);
-
   return (
     <div className="relative flex aspect-[3/4] w-full flex-col overflow-hidden rounded-xl border border-dashed border-blue-200 bg-[#FEFDFC] px-5 py-4 text-center shadow-prayCard">
       <div className={isCreating ? "animate-pulse" : ""}>
-        <motion.div
-          className="flex aspect-square w-full flex-col items-center justify-center bg-gradient-to-br from-blue-100 via-sky-100 to-emerald-50 px-7 py-8"
-          animate={{ borderRadius: skeletonRadius }}
-          transition={{ duration: isCreating ? 0.08 : 0 }}
+        <div
+          className={`flex aspect-square w-full flex-col items-center justify-center bg-gradient-to-br from-blue-100 via-sky-100 to-emerald-50 px-7 py-8 ${
+            isCreating ? "animate-blob" : ""
+          }`}
+          style={isCreating ? undefined : { borderRadius: STATIC_SKELETON_RADIUS }}
         >
           <div className="h-3 w-10/12 rounded-full bg-white/80" />
           <div className="mt-3 h-3 w-8/12 rounded-full bg-white/70" />
           <div className="mt-7 h-2 w-5/12 rounded-full bg-white/70" />
-        </motion.div>
+        </div>
 
         <div className="mt-4 space-y-2 text-left">
           <div className="h-8 w-28 rounded-lg bg-blue-100" />
@@ -158,17 +137,6 @@ const EmptyBibleCardBackSlot = ({ isCreating }: { isCreating: boolean }) => {
           <div className="h-3 w-20 rounded-full bg-gray-100" />
         </div>
       </div>
-
-      {!isCreating && (
-        <div className="absolute inset-x-6 top-[42%] rounded-2xl bg-white/80 px-4 py-4 shadow-sm backdrop-blur-sm">
-          <p className="text-sm font-bold leading-snug text-gray-950">
-            아직 뒷면이 비어 있어요
-          </p>
-          <p className="mt-1 text-xs leading-relaxed text-gray-500">
-            말씀카드를 만들어 붙일 수 있어요.
-          </p>
-        </div>
-      )}
     </div>
   );
 };
@@ -468,12 +436,7 @@ const BibleCardNewPage = () => {
           Math.floor(Math.random() * BIBLE_CARD_COLOR_PRESETS.length)
         ],
       ];
-      const radius = [
-        getRandomRadius(),
-        getRandomRadius(),
-        getRandomRadius(),
-        getRandomRadius(),
-      ];
+      const radius = getRandomRadius();
       const nextDraft = {
         bibleReference: createBibleReference(targetBible),
         bibleSentence: targetBible.sentence,


### PR DESCRIPTION
## 배경
말씀카드 색상/배리에이션과 생성 대기 단계 연출을 점검해 다듬었습니다.

## 변경 내용

### 색상 — 파스텔 + 중립 모노크롬 글씨
- 프리셋을 **파스텔 26종**으로 교체·확장 (진한/탁한 톤 제거)
- 카드의 색 정체성은 **그라데이션 블롭이 전담**, 글씨는 색을 빼고 명도/크기/굵기로 위계 구성
  - 구절: 배경 밝기(luminance) 기반 — 밝은 파스텔이면 중립 다크(`#2B2B2B`), 어두운 배경이면 흰색
  - 이름: 중립 다크 / 키워드: 옅은 그레이(`#6B7280`)
- → 본문(구절) 무게감 확보 + 이름·키워드 컬러 언밸런스 해소
- **기존에 진한 프리셋으로 저장된 카드**도 흰 글씨로 안전하게 렌더 (하위호환)

### 카드 모서리 — 의도적 비대칭 블롭
- 네 코너 독립 랜덤(40~200px)으로 찌그러진 유기적 모양 연출

### 생성 대기 스켈레톤 — 부드러운 모핑
- JS `setInterval` 랜덤 점프 제거 → CSS `@keyframes blobMorph` 연속 모핑(5s ease-in-out)
- 코드도 상태/타이머가 빠져 간결해짐

### 기타
- '아직 뒷면이 비어 있어요' 안내 섹션 제거

## 검증
- `npm run build` 통과, `npm run lint` 신규 경고 없음
- dev 서버에서 26종 색상/위계/블롭/모핑 육안 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)