### PR TITLE
docs: 보안 백로그 분리 + 후속 이슈 처리 결과 기록

### DIFF
--- a/docs/security-backlog.md
+++ b/docs/security-backlog.md
@@ -1,0 +1,48 @@
+# PrayU 보안 백로그
+
+마이그레이션 체계 도입 과정(2026-06~07, `supabase-migration-plan.md`)에서 발견·정리된 보안 과제 목록.
+여기 항목들은 **운영 중 서비스에 대한 변경**이므로 각각 별도 이슈/PR로, 사람 확인 하에 진행한다.
+
+## 1. RLS 전면 정비 — 🔴 최우선
+
+현행 정책 대부분이 `USING (true)` 계열의 무제한 허용이다. 원본 목록은 baseline
+(`PrayU-Api/supabase/migrations/20260718075321_initial_baseline.sql`)의 `CREATE POLICY` 구문 참조.
+
+핵심 문제 패턴:
+- **그룹 격리 부재**: `group`/`member`/`pray`/`pray_card` 의 SELECT 가 `TO authenticated USING (true)` — 로그인만 하면 **소속 무관 전체 그룹의 기도 데이터를 조회 가능**. 기도제목은 민감 정보다
+- `bible_card`·`group_union` 등의 UPDATE 도 `USING (true)` (역할만 authenticated)
+- 설계 방향: `member` 조인 기반 멤버십 정책으로 재작성 (예: "내가 속한 그룹의 pray_card 만 SELECT")
+- 성능 유의: RLS 서브쿼리 도입 시 기존 인덱스(멤버십 조회 경로)와 함께 검토
+
+진행 방식: 테이블별 마이그레이션으로 쪼개서 로컬 → staging에서 앱 전 플로우 회귀 확인 후 prod.
+`rls_auto_enable` event trigger(신규 테이블 RLS 자동 활성화)는 prod에 이미 존재 — 유지.
+
+## 2. Kakao client secret 프론트 노출 — 🔴
+
+`VITE_KAKAO_CLIENT_SECRET_KEY` 가 web 번들에 포함된다 (`KakaoTokenRepo.fetchKakaoToken` 이
+브라우저에서 직접 kauth.kakao.com 토큰 교환). 조치:
+1. 토큰 교환을 Edge Function 으로 이전 (secret 은 함수 시크릿으로)
+2. Kakao 콘솔에서 client secret 로테이션 (기존 값은 노출된 것으로 간주)
+3. web 에서 `VITE_KAKAO_CLIENT_SECRET_KEY` 제거
+
+## 3. service_role 키(legacy JWT) 로테이션 — ⚠️ 결합 주의
+
+- prod `cron.job` 명령(오늘의기도 리마인더 `net.http_post`)에 **prod service_role JWT 가 하드코딩**돼 있다
+- fcm webhook 쪽 하드코딩은 제거 완료 (`drop_legacy_fcm_webhook`)
+- **로테이션 시 cron.job 명령 갱신을 동시에** 하지 않으면 리마인더 알림이 죽는다
+- 장기적으로는 cron 이 Vault 에서 키를 읽도록 개선 검토
+
+## 4. 어드민 권한 체계 — 이메일 하드코딩 제거
+
+- `AdminPage.tsx` 의 하드코딩 이메일 체크
+- `profiles` 의 `admin can update profiles` 정책도 이메일 배열 하드코딩
+- 방향: DB 롤 또는 custom claim 기반 권한으로 통일 (1번 RLS 정비와 함께 설계)
+
+## 완료된 항목
+
+- ✅ fcm_notification_webhook 제거 — service_role 키 하드코딩 지점 1곳 소멸 (2026-07-20, Api#28 파이프라인)
+- ✅ bible 무제한 쓰기 정책(update/insert `USING(true)`) 제거 (2026-07-24, Api#32)
+
+## 권장 진행 순서
+
+2(Kakao secret — 노출 면적이 가장 공개적) → 1(RLS — 파급 크므로 테이블별 분할) → 4(어드민, 1과 함께) → 3(키 로테이션 — 1·2 마무리 후 일괄)

--- a/docs/supabase-migration-plan.md
+++ b/docs/supabase-migration-plan.md
@@ -10,7 +10,10 @@
 - [x] Phase D(앱 QA) — 리셋 산출물(로컬 스택, staging과 동일 마이그레이션) 대상 E2E 통과 (2026-07-19): 가입→profiles 트리거, 보호 라우트, 그룹 생성, 기도카드 4단계 생성, 말씀카드 생성(bible 시드 조회+openai 함수+storage 업로드+FK 연결), 콘솔 에러 0. 비차단 관찰: onesignal/users 400(테스트 유저 푸시 미등록 — 예상), 헤드리스 브라우저 한정 framer-motion 스텝 전환 지연(앱 이슈 아님)
 - [x] Phase E — **완료 (2026-07-20)**: prod 전체 백업(스키마 25KB + 데이터 380MB, 핵심 테이블 행수 검증) → 히스토리 repair(20240727 reverted, baseline applied — SQL 무실행) → `db diff` 예상 차이 1건(레거시 webhook)만 확인 → `db push`로 drop_legacy 적용 → **최종 diff 空** = 세 환경(로컬/staging/prod) 마이그레이션 히스토리·스키마 완전 일치. 링크는 staging으로 복구. 리허설(로컬→staging→prod 파이프라인 1회 완주)도 이것으로 겸함
 - [x] **레거시 `/bible-card` 플립 페이지 정리 완료 (2026-07-20)**: web — 플립 페이지 클러스터 5개 파일 + dead export(createBibleVerse/fetchBgImage) 제거, 그룹 메뉴는 현행 `/bible-card/new`로 리다이렉트(옛 URL도 Navigate 처리, analytics 이벤트 유지). Api — openai 함수의 vector 레거시 라우트 4종(bible-verse/bible-image/text-embedding/search-bible) + BibleCardService/BibleRepository/pixelsClient/type.ts 제거, `/qt`만 유지. 스모크: 제거 라우트 404, `/bible`·`/qt` 정상
-- [ ] 후속 이슈 레이징 — 드리프트 fix (bible_card.user_id default, `''''''` 디폴트 4건, qt_data.long_label), bible FOR UPDATE 정책(RLS 작업), bible_id_seq=1 quirk
+- [x] 후속 이슈 처리 완료 (2026-07-24, 사용자 결정):
+  - **드리프트 fix 보류(의도적)**: `bible_card.user_id` default — 비즈니스 로직은 DB 가 아닌 앱에서 명시하는 현행 방식이 의도된 설계라 미적용. `profiles.fcm_token` — OneSignal 전환으로 레거시 컬럼(추후 컬럼 정리 후보). `''''''` 디폴트·`qt_data.long_label`·`bible_id_seq=1` — 실피해 없는 화석, 미조치. **재발굴 방지용 기록**
+  - **bible 무제한 쓰기 정책 제거**: Api#32 (`drop_bible_write_policies` — update + 조사 중 발견된 insert 까지)
+  - **보안 백로그 분리**: [security-backlog.md](security-backlog.md) — RLS 전면 정비/Kakao secret/키 로테이션·cron 결합/어드민 권한
 
 ### 로컬 DB MCP (2026-07-24 등록)
 - 두 레포 `.mcp.json`에 `prayu-local-db` 등록: `uvx postgres-mcp --access-mode=unrestricted` → 로컬 스택 DB(127.0.0.1:54322) 직결. **uv 설치 필요** (`brew install uv`)


### PR DESCRIPTION
## 내용
마이그레이션 작업에서 파생된 후속 항목들의 종결 기록입니다.

- **`docs/security-backlog.md` 신설**: 보안 과제 4건(RLS 전면 정비 — 그룹 격리 부재가 핵심 / Kakao client secret 번들 노출 / service_role 키 로테이션↔prod cron 결합 / 어드민 이메일 하드코딩)을 우선순위·진행 방식과 함께 별도 관리
- **드리프트 fix 의도적 보류 기록**: DB 디폴트 대신 앱 명시 원칙(bible_card.user_id), fcm_token 레거시 컬럼 등 — 나중에 재발굴되지 않도록 결정 사유를 남김
- bible 쓰기 정책 제거는 짝 PR: TeamVisioneer/PrayU-Api#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)