### PR TITLE
feat: QT 생성 호출에 세션 토큰 적용 및 일일 한도 안내

### DIFF
--- a/src/apis/openai.ts
+++ b/src/apis/openai.ts
@@ -1,3 +1,4 @@
+import { supabase } from "./../../supabase/client";
 import * as Sentry from "@sentry/react";
 
 export interface QTData {
@@ -10,22 +11,43 @@ export interface QTData {
   practical_tasks: { task: string }[];
 }
 
-export const createQT = async (content: string): Promise<QTData | null> => {
+export type CreateQTResult = {
+  data: QTData | null;
+  errorCode?: "DAILY_LIMIT_EXCEEDED" | "LOGIN_REQUIRED";
+};
+
+export const createQT = async (content: string): Promise<CreateQTResult> => {
   try {
+    // 개인별 일일 한도가 걸린 엔드포인트 — 세션 토큰 필수 (anon key는 서버가 401로 거부)
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session) return { data: null, errorCode: "LOGIN_REQUIRED" };
+
     const response = await fetch(
       `${import.meta.env.VITE_SUPA_PROJECT_URL}/functions/v1/openai/qt`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          authorization: `Bearer ${import.meta.env.VITE_SUPA_ANON_KEY}`,
+          authorization: `Bearer ${session.access_token}`,
         },
         body: JSON.stringify({ content }),
       },
     );
-    return response.json();
+    if (response.status === 429) {
+      return { data: null, errorCode: "DAILY_LIMIT_EXCEEDED" };
+    }
+    if (response.status === 401) {
+      return { data: null, errorCode: "LOGIN_REQUIRED" };
+    }
+    if (!response.ok) {
+      Sentry.captureMessage(`createQT failed: ${response.status}`);
+      return { data: null };
+    }
+    return { data: (await response.json()) as QTData };
   } catch (error) {
     Sentry.captureException(error);
-    return null;
+    return { data: null };
   }
 };

--- a/src/stores/baseStore.ts
+++ b/src/stores/baseStore.ts
@@ -8,6 +8,7 @@ import {
 } from "./../apis/pray";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { toast } from "@/components/ui/use-toast";
 import { supabase } from "../../supabase/client";
 import { Session, User } from "@supabase/supabase-js";
 import {
@@ -1244,7 +1245,17 @@ const useBaseStore = create<BaseStore>()(
     ) => {
       const content =
         `${longLabel} ${chapter}:${startParagraph}~${endParagraph}`;
-      const qtGenerated = await createQT(content);
+      const { data: qtGenerated, errorCode } = await createQT(content);
+      if (!qtGenerated) {
+        if (errorCode === "DAILY_LIMIT_EXCEEDED") {
+          toast({
+            description: "오늘 QT 생성 횟수를 모두 사용했어요. 내일 다시 만들 수 있어요",
+          });
+        } else if (errorCode === "LOGIN_REQUIRED") {
+          toast({ description: "로그인 후 이용할 수 있어요" });
+        }
+        return null;
+      }
       const result = JSON.stringify(qtGenerated);
       const qtData = await createQtData(
         userId,


### PR DESCRIPTION
## 배경
짝 PR: TeamVisioneer/PrayU-Api#35 (QT 일일 생성 한도 — anon 거부·429 도입)
Api 반영 후 구버전 웹은 QT 생성이 401로 막히므로, 세션 토큰을 보내도록 전환합니다.

## 작업 내용
- `apis/openai.ts` `createQT`: anon key → **세션 토큰** 전송. 반환을 `{ data, errorCode }`로 확장 (401 `LOGIN_REQUIRED` / 429 `DAILY_LIMIT_EXCEEDED`)
- `baseStore.createQtData`: 생성 실패 시 **저장 가드** + toast 안내 ("오늘 QT 생성 횟수를 모두 사용했어요…")
  - 부수 버그 수정: 기존엔 생성 실패 시 `JSON.stringify(null)` = 문자열 `"null"`이 qt_data에 저장될 수 있었음 → 가드로 차단

## 검증
- `npm run lint` (기존 경고 4개 외 신규 0) / `npm run build` 통과
- 수동 확인 권장 (staging, Api #35 반영 후): QT 생성 정상 / 11회째 429 toast / 비로그인 안내

## merge 시점
Api #35이 staging 반영된 뒤 merge 권장 (그 전에도 무해 — 구 함수는 세션 토큰도 수용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
