### PR TITLE
feat: toast UX 개편 — 위로 스와이프 닫기 및 스타일 개선

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,8 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      // 모바일 우선: 상단 중앙 고정 (위로 스와이프해 닫는 동작과 방향 일치)
+      "fixed left-1/2 top-0 z-[100] flex w-full max-w-[420px] -translate-x-1/2 flex-col items-center gap-2 p-4",
       className
     )}
     {...props}
@@ -23,11 +24,12 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  // 스와이프 축을 세로(y)로 전환 — 위로 밀어 닫기, 닫힐 때도 위로 슬라이드 아웃
+  "group pointer-events-auto relative flex w-fit min-w-[200px] max-w-full items-center justify-between space-x-3 overflow-hidden rounded-xl px-4 py-3 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-y-0 data-[swipe=end]:translate-y-[var(--radix-toast-swipe-end-y)] data-[swipe=move]:translate-y-[var(--radix-toast-swipe-move-y)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-top-full data-[state=open]:slide-in-from-top-full",
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
+        default: "border-none bg-gray-900/90 text-white backdrop-blur-sm",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
       },
@@ -75,7 +77,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-white/60 opacity-0 transition-opacity hover:text-white focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -12,7 +12,7 @@ export function Toaster() {
   const { toasts } = useToast()
 
   return (
-    <ToastProvider>
+    <ToastProvider swipeDirection="up" swipeThreshold={30}>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
           <Toast key={id} {...props}>

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -4,7 +4,8 @@ import * as React from "react";
 import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1500;
+const TOAST_DURATION = 2500; // 자동 소멸까지 표시 시간
+const TOAST_REMOVE_DELAY = 1500; // 닫힘 애니메이션 후 DOM 제거 대기
 
 type ToasterToast = ToastProps & {
   id: string;
@@ -162,7 +163,7 @@ function toast({ ...props }: Toast) {
   // custom
   setTimeout(() => {
     dismiss();
-  }, TOAST_REMOVE_DELAY);
+  }, TOAST_DURATION);
 
   return {
     id: id,


### PR DESCRIPTION
## 배경
사용자 피드백: toast가 밋밋하고, 닫을 때 옆으로 스와이프해야 해서 부자연스러움 — 상단에 뜨는 toast는 **위로 스와이프**가 자연스러움.

## 변경 내용
- **스와이프 방향**: `ToastProvider swipeDirection="up"` + swipe 트랜스폼을 x축 → y축으로 전환, 닫힘 애니메이션도 위로 슬라이드 아웃 (`slide-out-to-top-full`). `swipeThreshold={30}`으로 가볍게 밀어도 닫힘
- **위치**: 상단 중앙 고정(모바일 우선, max-w 420px) — 기존 데스크톱 우하단 분기 제거 (앱은 `max-w-[480px]` 모바일 레이아웃)
- **스타일**: 다크 필(pill) 스타일 — `bg-gray-900/90` + `rounded-xl` + `backdrop-blur`, 콘텐츠에 맞는 너비(w-fit), 패딩 슬림화 (p-6 → px-4 py-3)
- **표시 시간**: 자동 소멸 1.5s → **2.5s** (한도 안내 등 긴 문구 가독성), DOM 제거 대기(1.5s)와 상수 분리
- destructive variant는 기존 스타일 유지

## 검증
- `npm run lint`(기존 경고 4개 외 0) / `npm run build` 통과
- 수동 확인 권장: 아무 toast 트리거(예: 말씀카드 중복 안내) → 상단 중앙 표시 / 위로 스와이프 닫힘 / 2.5초 자동 소멸 / iOS·Android WebView에서 스와이프 제스처 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
