### PR TITLE
fix: 히스토리 드로워 — 말씀카드 면 우선 표시 및 버튼 간격 조정

### DIFF
--- a/src/components/profile/PrayCardHistoryDrawer.tsx
+++ b/src/components/profile/PrayCardHistoryDrawer.tsx
@@ -38,7 +38,7 @@ const PrayCardHistoryDrawer: React.FC = () => {
     <Button
       variant="primary"
       onClick={onClickCreateBibleCard}
-      className="h-[48px] w-full rounded-xl text-base"
+      className="mt-3 h-[48px] w-full rounded-xl text-base"
     >
       말씀카드 만들기
     </Button>
@@ -58,7 +58,13 @@ const PrayCardHistoryDrawer: React.FC = () => {
         </DrawerHeader>
         {historyCard?.bible_card ? (
           <div className="flex flex-col gap-4 px-10 pt-5 pb-10 overflow-y-auto">
-            <PrayCardWithBibleCard prayCard={historyCard} />
+            {/* 목록에서 말씀카드 썸네일을 눌러 진입하므로 말씀카드 면부터 보여준다.
+                key: 다른 카드로 전환 시 플립 상태 리셋 */}
+            <PrayCardWithBibleCard
+              key={historyCard.id}
+              prayCard={historyCard}
+              initialFlipped
+            />
             <ReactionResultBox
               prayCard={historyCard || undefined}
               variant="separated"


### PR DESCRIPTION
## 배경 (사용자 피드백)
- 히스토리 드로워의 '말씀카드 만들기' 버튼이 위 콘텐츠와 너무 붙어 있음
- 목록에서 **말씀카드 썸네일**을 눌렀는데 드로워가 **기도카드 면**부터 열려 방향이 어색함

## 변경
- `PrayCardWithBibleCard`에 `initialFlipped` 적용 — 말씀카드 연결 카드는 드로워에서 **말씀카드 면부터** 열림 (목록 진입 맥락과 일치. 텍스트 카드는 기존대로 기도카드 면). `key`로 카드 전환 시 플립 상태 리셋
- '말씀카드 만들기' 버튼에 `mt-3` 간격 추가

## 검증
- lint 기존 경고 4개 외 0
- 로컬 미리보기에서 두 케이스 스크린샷 확인 완료 (말씀카드 면 우선 + 버튼 간격)

🤖 Generated with [Claude Code](https://claude.com/claude-code)