### PR TITLE
chore: max-w-[480px] → max-w-app 토큰화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div
       className={`mx-auto h-100vh overflow-x-hidden no-scrollbar bg-mainBg ${
-        isFullWidth ? "w-full" : "max-w-[480px]"
+        isFullWidth ? "w-full" : "max-w-app"
       }`}
     >
       {children}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 max-w-[480px] mx-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 max-w-app mx-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -45,7 +45,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 max-w-[480px] mx-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 max-w-app mx-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -49,7 +49,7 @@ const DrawerOverlay = React.forwardRef<
   <DrawerPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 max-w-[480px] mx-auto",
+      "fixed inset-0 z-50 bg-black/80 max-w-app mx-auto",
       className
     )}
     {...props}
@@ -67,7 +67,7 @@ const DrawerContent = React.forwardRef<
       <DrawerPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto mx-auto flex-col rounded-t-[20px] border bg-background focus:outline-none max-w-[480px]",
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto mx-auto flex-col rounded-t-[20px] border bg-background focus:outline-none max-w-app",
           className
         )}
         {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -44,7 +44,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 max-w-[480px] mx-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 max-w-app mx-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/pages/Group/GroupJoinPage.tsx
+++ b/src/pages/Group/GroupJoinPage.tsx
@@ -149,7 +149,7 @@ const GroupJoinPage: React.FC = () => {
 
   // Header component for reuse
   const Header = () => (
-    <div className="fixed top-0 left-0 right-0 h-14 flex items-center justify-between px-4 border-b z-10 max-w-[480px] mx-auto">
+    <div className="fixed top-0 left-0 right-0 h-14 flex items-center justify-between px-4 border-b z-10 max-w-app mx-auto">
       <button onClick={() => navigate("/")} className="p-2">
         <X size={20} />
       </button>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -153,7 +153,7 @@ const MainPage: React.FC = () => {
         </div>
 
         {!isApp && (
-          <div className="fixed bottom-0 w-full max-w-[480px] mx-auto">
+          <div className="fixed bottom-0 w-full max-w-app mx-auto">
             <DownloadBanner />
           </div>
         )}

--- a/src/pages/MainPage/DownloadBanner.tsx
+++ b/src/pages/MainPage/DownloadBanner.tsx
@@ -19,7 +19,7 @@ const DownloadBanner = () => {
       className="w-full bg-purple-100 px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))]"
       onClick={() => onClickInstallPrayU()}
     >
-      <div className="flex justify-between items-center max-w-[480px] mx-auto">
+      <div className="flex justify-between items-center max-w-app mx-auto">
         <p className="text-purple-800 font-medium">앱으로 시작하기</p>
         <button className="bg-purple-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-purple-700 transition-colors">
           다운로드

--- a/src/pages/MainPage/MainHeader.tsx
+++ b/src/pages/MainPage/MainHeader.tsx
@@ -23,7 +23,7 @@ const MainHeader: React.FC<MainHeaderProps> = ({ className }) => {
   return (
     <header
       className={cn(
-        "fixed top-0 max-w-[480px] mx-auto w-full bg-mainBg z-50 border-y border-l-gray-500",
+        "fixed top-0 max-w-app mx-auto w-full bg-mainBg z-50 border-y border-l-gray-500",
         className
       )}
     >

--- a/src/pages/StoryPage/StoryPage.tsx
+++ b/src/pages/StoryPage/StoryPage.tsx
@@ -23,7 +23,7 @@ const StoryPage = () => {
 
       <img
         src="/images/story/prayu_1000_600.png"
-        className="w-full max-w-[480px] h-auto"
+        className="w-full max-w-app h-auto"
         onClick={() => onClickStartPrayU()}
       />
       <div className="font-sans text-center">

--- a/src/pages/TutorialPage.tsx
+++ b/src/pages/TutorialPage.tsx
@@ -268,7 +268,7 @@ const TutorialPage: React.FC = () => {
 
   const DimUI = (
     <div
-      className="fixed inset-x-0 z-30 top-0 mx-auto w-full h-full max-w-[480px] bg-black/80 flex flex-col items-center p-5 text-white gap-10"
+      className="fixed inset-x-0 z-30 top-0 mx-auto w-full h-full max-w-app bg-black/80 flex flex-col items-center p-5 text-white gap-10"
       onClick={(e) => {
         const clickedX = e.clientX;
         const windowWidth = window.innerWidth;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -128,6 +128,10 @@ module.exports = {
         500: "500ms",
         600: "600ms",
       },
+      maxWidth: {
+        // 앱 셸 컬럼 폭 — 셸·오버레이·하단 고정 요소가 함께 참조 (max-w-app)
+        app: "480px",
+      },
       spacing: {
         // viewport-fit=cover 환경의 노치/홈 인디케이터 영역 (예: pb-safe-bottom)
         "safe-top": "env(safe-area-inset-top)",


### PR DESCRIPTION
## 변경 내용

- `tailwind.config.js`에 `maxWidth: { app: "480px" }` 토큰 추가
- 하드코딩된 `max-w-[480px]` 12곳(셸·dialog/sheet/drawer 오버레이·페이지 fixed 요소)을 `max-w-app`으로 일괄 치환

앱 셸 폭을 바꿀 일이 생기면 토큰 한 곳만 수정하면 되도록 결합 제거. **시각 변화 0** (computed max-width 480px 동일 확인).

[#464](https://github.com/TeamVisioneer/PrayU-Web/pull/464) 후속 chore — 계획 문서 `docs/viewport-layout-improvement-plan.md` 5절.

## 검증

- lint(기존 경고 3개 외 신규 0) + build 통과
- 로컬 미리보기에서 `.max-w-app` computed max-width 480px 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)