### PR TITLE
feat: 프로필 히스토리 드로워 말씀카드에 공유 버튼 그룹 추가

### DIFF
--- a/src/components/profile/PrayCardHistoryDrawer.tsx
+++ b/src/components/profile/PrayCardHistoryDrawer.tsx
@@ -11,7 +11,9 @@ import useBaseStore from "@/stores/baseStore";
 import { PrayCard } from "../prayCard/PrayCard";
 import ReactionResultBox from "../pray/ReactionResultBox";
 import PrayCardWithBibleCard from "../prayCard/PrayCardWithBibleCard";
+import ShareButtonGroup from "../share/ShareButtonGroup";
 import { analyticsTrack } from "@/analytics/analytics";
+import { getDomainUrl } from "@/lib/utils";
 
 const PrayCardHistoryDrawer: React.FC = () => {
   const navigate = useNavigate();
@@ -22,6 +24,7 @@ const PrayCardHistoryDrawer: React.FC = () => {
     (state) => state.setIsOpenHistoryDrawer
   );
   const historyCard = useBaseStore((state) => state.historyCard);
+  const user = useBaseStore((state) => state.user);
   const legacyBibleCardUrl = historyCard?.bible_card_url;
 
   // 말씀카드 미연결 카드에만 노출 (레거시 bible_card_url 카드도 새 체계로 만들도록 유도)
@@ -64,6 +67,16 @@ const PrayCardHistoryDrawer: React.FC = () => {
               key={historyCard.id}
               prayCard={historyCard}
               initialFlipped
+            />
+            <ShareButtonGroup
+              where="PrayCardHistoryDrawer"
+              publicUrl={historyCard.bible_card.image_url ?? undefined}
+              shareUrl={`${getDomainUrl()}/bible-card/share/${historyCard.bible_card.id}`}
+              kakaoServerCallbackArgs={
+                user
+                  ? { user_id: user.id, feature: "bible_card" }
+                  : undefined
+              }
             />
             <ReactionResultBox
               prayCard={historyCard || undefined}


### PR DESCRIPTION
## 변경 내용

프로필 > 기도카드 보관함에서 말씀카드가 연결된 기도카드를 열면, 말씀카드 면 아래에 `ShareButtonGroup`(저장·링크 복사·카카오톡·인스타그램)이 함께 노출됩니다.

- `src/components/profile/PrayCardHistoryDrawer.tsx` 단일 파일 변경
- `publicUrl` = 말씀카드 이미지, `shareUrl` = `/bible-card/share/:id` 공개 페이지 — 생성 페이지(BibleCardNewPage)와 동일한 규약
- 카카오 공유에 `kakaoServerCallbackArgs(user_id, feature: bible_card)` 포함 → 히스토리에서 공유해도 공유 보상 웹훅 대상

## 검증

- lint(기존 경고 3개 외 신규 0) + build 통과
- 로컬(시드 데이터)에서 드로워 열림 → 말씀카드 면 + 공유 버튼 4종 표시 확인 (스크린샷 검증)
- 말씀카드 없는 카드 분기는 변경 없음 (기존 "말씀카드 만들기" CTA 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)