### PR TITLE
feat: 히스토리 드로워 하단 액션을 카드 면에 따라 분기

### DIFF
--- a/src/components/prayCard/PrayCardWithBibleCard.tsx
+++ b/src/components/prayCard/PrayCardWithBibleCard.tsx
@@ -7,11 +7,14 @@ import BibleCard from "./BibleCard";
 interface PrayCardWithBibleCardProps {
   prayCard: PrayCardWithProfiles | undefined;
   initialFlipped?: boolean;
+  // 부모가 현재 보이는 면에 따라 하단 액션을 바꿀 수 있도록 플립 상태를 알림
+  onFlipChange?: (isFlipped: boolean) => void;
 }
 
 const PrayCardWithBibleCard: React.FC<PrayCardWithBibleCardProps> = ({
   prayCard,
   initialFlipped = false,
+  onFlipChange,
 }) => {
   const [isFlipped, setIsFlipped] = useState(initialFlipped);
   const bibleCard = prayCard?.bible_card;
@@ -22,7 +25,9 @@ const PrayCardWithBibleCard: React.FC<PrayCardWithBibleCardProps> = ({
       from: isFlipped ? "BibleCard" : "PrayCard",
       to: isFlipped ? "PrayCard" : "BibleCard",
     });
-    setIsFlipped((prev) => !prev);
+    const next = !isFlipped;
+    setIsFlipped(next);
+    onFlipChange?.(next);
   };
 
   return (

--- a/src/components/profile/PrayCardHistoryDrawer.tsx
+++ b/src/components/profile/PrayCardHistoryDrawer.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Drawer,
@@ -27,7 +28,12 @@ const PrayCardHistoryDrawer: React.FC = () => {
   const user = useBaseStore((state) => state.user);
   const legacyBibleCardUrl = historyCard?.bible_card_url;
 
-  // 말씀카드 미연결 카드에만 노출 (레거시 bible_card_url 카드도 새 체계로 만들도록 유도)
+  // 말씀카드 면(진입 기본)인지 여부 — 보이는 면에 따라 하단 액션을 바꾼다
+  const [isBibleSideVisible, setIsBibleSideVisible] = useState(true);
+  useEffect(() => {
+    setIsBibleSideVisible(true);
+  }, [historyCard?.id]);
+
   const onClickCreateBibleCard = () => {
     if (!historyCard) return;
     analyticsTrack("클릭_말씀카드_페이지", {
@@ -37,13 +43,14 @@ const PrayCardHistoryDrawer: React.FC = () => {
     navigate(`/bible-card/new?praycard_id=${historyCard.id}`);
   };
 
-  const createBibleCardButton = (
+  // 미연결 카드: 만들기 유도 / 연결 카드의 말씀카드 면: 다시 만들기(교체)
+  const createBibleCardButton = (label: string) => (
     <Button
       variant="primary"
       onClick={onClickCreateBibleCard}
       className="mt-3 h-[48px] w-full rounded-xl text-base"
     >
-      말씀카드 만들기
+      {label}
     </Button>
   );
   return (
@@ -67,22 +74,29 @@ const PrayCardHistoryDrawer: React.FC = () => {
               key={historyCard.id}
               prayCard={historyCard}
               initialFlipped
+              onFlipChange={setIsBibleSideVisible}
             />
-            <ShareButtonGroup
-              where="PrayCardHistoryDrawer"
-              publicUrl={historyCard.bible_card.image_url ?? undefined}
-              shareUrl={`${getDomainUrl()}/bible-card/share/${historyCard.bible_card.id}`}
-              kakaoServerCallbackArgs={
-                user
-                  ? { user_id: user.id, feature: "bible_card" }
-                  : undefined
-              }
-            />
-            <ReactionResultBox
-              prayCard={historyCard || undefined}
-              variant="separated"
-              eventOption={{ where: "HistoryCard" }}
-            />
+            {isBibleSideVisible ? (
+              <>
+                <ShareButtonGroup
+                  where="PrayCardHistoryDrawer"
+                  publicUrl={historyCard.bible_card.image_url ?? undefined}
+                  shareUrl={`${getDomainUrl()}/bible-card/share/${historyCard.bible_card.id}`}
+                  kakaoServerCallbackArgs={
+                    user
+                      ? { user_id: user.id, feature: "bible_card" }
+                      : undefined
+                  }
+                />
+                {createBibleCardButton("말씀카드 다시 만들기")}
+              </>
+            ) : (
+              <ReactionResultBox
+                prayCard={historyCard || undefined}
+                variant="separated"
+                eventOption={{ where: "HistoryCard" }}
+              />
+            )}
           </div>
         ) : legacyBibleCardUrl ? (
           <div className="flex flex-col gap-2 px-10 pt-5 pb-10 overflow-y-auto">
@@ -101,7 +115,7 @@ const PrayCardHistoryDrawer: React.FC = () => {
                 {historyCard.content}
               </p>
             </div>
-            {createBibleCardButton}
+            {createBibleCardButton("말씀카드 만들기")}
           </div>
         ) : (
           <div className="flex flex-col gap-2 px-10 pt-5 pb-10">
@@ -111,7 +125,7 @@ const PrayCardHistoryDrawer: React.FC = () => {
               variant="separated"
               eventOption={{ where: "HistoryCard" }}
             />
-            {historyCard && createBibleCardButton}
+            {historyCard && createBibleCardButton("말씀카드 만들기")}
           </div>
         )}
       </DrawerContent>


### PR DESCRIPTION
## 변경 내용

프로필 보관함 드로워에서 보이는 면에 따라 하단 구성이 바뀝니다:

- **말씀카드 면**(진입 기본): 공유 버튼 그룹(저장·링크·카카오·인스타) + **"말씀카드 다시 만들기"** 버튼(기존 생성 플로우 `/bible-card/new?praycard_id=`로 이동 — 재생성·교체)
- **기도카드 면**: 기존 기도해준 친구 카운트(ReactionResultBox)

구현: `PrayCardWithBibleCard`에 `onFlipChange` 콜백 prop 추가(이 드로워가 유일한 사용처), 드로워가 플립 상태를 받아 분기. 카드 전환 시 말씀카드 면 기준으로 리셋.

## 검증

- lint(기존 경고 3개 외 신규 0) + build 통과
- 로컬에서 양면 전환 스크린샷 확인: 말씀카드 면 = 공유+다시 만들기 / 기도카드 면 = 리액션 카운트

🤖 Generated with [Claude Code](https://claude.com/claude-code)