### PR TITLE
fix: 사용량 집계에 user_id 필터 명시

### DIFF
--- a/src/apis/bible.ts
+++ b/src/apis/bible.ts
@@ -112,5 +112,6 @@ export const searchBible = async (
 };
 
 // KST 기준 오늘 말씀카드 생성(LLM 호출) 횟수 — 공용 조회로 위임
-export const fetchTodayBibleCardUsage = (): Promise<number | null> =>
-  fetchTodayLlmUsage("bible_card");
+export const fetchTodayBibleCardUsage = (
+  userId: string,
+): Promise<number | null> => fetchTodayLlmUsage(userId, "bible_card");

--- a/src/apis/llmUsage.ts
+++ b/src/apis/llmUsage.ts
@@ -7,15 +7,18 @@ const kstDayStartISO = () => {
   return `${year}-${month}-${day}T00:00:00+09:00`;
 };
 
-// KST 기준 오늘 LLM 호출 횟수 — RLS로 본인 로그만 조회됨.
+// KST 기준 오늘 LLM 호출 횟수.
 // 표시용이며 실제 한도 강제는 edge function이 담당 (실패 시 null → 표시 생략)
+// user_id 필터는 필수다 — 로그 읽기가 열려 있어 빼면 전체 사용자 집계가 잡힌다
 export const fetchTodayLlmUsage = async (
+  userId: string,
   feature: "bible_card" | "qt",
 ): Promise<number | null> => {
   try {
     const { count, error } = await supabase
       .from("llm_usage_log")
       .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
       .eq("feature", feature)
       .gte("created_at", kstDayStartISO());
     if (error) {
@@ -31,12 +34,14 @@ export const fetchTodayLlmUsage = async (
 
 // KST 기준 오늘 공유 보상 수 — 생성 한도는 서버에서 (기본 + 보상)으로 계산되며 여기는 표시용
 export const fetchTodayShareReward = async (
+  userId: string,
   feature: "bible_card",
 ): Promise<number | null> => {
   try {
     const { count, error } = await supabase
       .from("share_reward_log")
       .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
       .eq("feature", feature)
       .gte("created_at", kstDayStartISO());
     if (error) {

--- a/src/pages/BibleCardPage/BibleCardNewPage.tsx
+++ b/src/pages/BibleCardPage/BibleCardNewPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { IoChevronBack } from "react-icons/io5";
 import { Info, Repeat } from "lucide-react";
@@ -281,9 +281,10 @@ const BibleCardNewPage = () => {
           BIBLE_CARD_DAILY_LIMIT + (todayRewardCount ?? 0) - todayUsedCount,
         );
 
-  const refreshQuota = () => {
-    fetchTodayBibleCardUsage().then(setTodayUsedCount);
-    fetchTodayShareReward("bible_card").then((rewards) => {
+  const refreshQuota = useCallback(() => {
+    if (!user) return;
+    fetchTodayBibleCardUsage(user.id).then(setTodayUsedCount);
+    fetchTodayShareReward(user.id, "bible_card").then((rewards) => {
       if (rewards === null) return;
       // 공유 보상(웹훅)은 비동기 도착 — 복귀 시 증가를 감지해 안내
       if (prevRewardRef.current !== null && rewards > prevRewardRef.current) {
@@ -292,7 +293,7 @@ const BibleCardNewPage = () => {
       prevRewardRef.current = rewards;
       setTodayRewardCount(rewards);
     });
-  };
+  }, [user]);
 
   useEffect(() => {
     if (!user) return;
@@ -303,7 +304,7 @@ const BibleCardNewPage = () => {
     };
     document.addEventListener("visibilitychange", onVisible);
     return () => document.removeEventListener("visibilitychange", onVisible);
-  }, [user]);
+  }, [user, refreshQuota]);
 
   useEffect(() => {
     if (!user) return;

--- a/src/pages/QuietTimePage.tsx
+++ b/src/pages/QuietTimePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { analyticsTrack } from "@/analytics/analytics";
 import useBaseStore from "@/stores/baseStore";
@@ -48,14 +48,15 @@ const QuietTimePage = () => {
       ? null
       : Math.max(0, QT_DAILY_LIMIT - todayUsedCount);
 
-  const refreshUsage = () => {
-    fetchTodayLlmUsage("qt").then(setTodayUsedCount);
-  };
+  const refreshUsage = useCallback(() => {
+    if (!user) return;
+    fetchTodayLlmUsage(user.id, "qt").then(setTodayUsedCount);
+  }, [user]);
 
   useEffect(() => {
     if (!user) return;
     refreshUsage();
-  }, [user]);
+  }, [user, refreshUsage]);
 
   useEffect(() => {
     if (!user) return;


### PR DESCRIPTION
짝 PR: [PrayU-Api#40](https://github.com/TeamVisioneer/PrayU-Api/pull/40) — **Api 먼저 merge**

## 배경

Api PR에서 `llm_usage_log`·`share_reward_log`의 읽기를 열면서 "RLS가 본인 것만 준다"는 전제가 사라집니다. 그런데 이 두 쿼리는 `user_id` 필터 없이 그 전제에 의존하고 있었습니다:

```ts
// before — 필터 없음. RLS가 본인 것만 주던 시절의 코드
.from("llm_usage_log").select("id", { count: "exact", head: true })
  .eq("feature", feature).gte("created_at", kstDayStartISO())
```

그대로 두면 전체 사용자 사용량이 집계되어 **모든 사용자에게 "남은 생성 0회"** 로 표시됩니다.

## 변경 내용

- `fetchTodayLlmUsage(userId, feature)`, `fetchTodayShareReward(userId, feature)`, `fetchTodayBibleCardUsage(userId)` — userId 인자 추가 후 `.eq("user_id", userId)` 명시
- 호출부 `BibleCardNewPage`·`QuietTimePage`에서 `user.id` 전달
- 두 페이지의 `refreshQuota`/`refreshUsage`를 `useCallback`으로 감싸고 effect deps에 포함 (신규 lint 경고 0 유지)

암묵적으로 RLS에 기대던 스코프를 앱이 명시하게 되어, 정책 변경에 덜 취약해집니다.

## 검증

- lint(기존 경고 3개 외 신규 0) + build 통과
- 로컬 실측: 본인 1건 + 타인 5건 시드 후 REST 호출 — 전체는 6건 조회되지만 앱 쿼리는 `Content-Range: 0-0/1`로 본인 1건만

🤖 Generated with [Claude Code](https://claude.com/claude-code)