### PR TITLE
fix: 성경 본문의 원본 표기(구역 제목·○) 표시 시 제거

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -44,7 +44,11 @@
 
 ## 배포 대기
 
-- [ ] staging 인수테스트 후 **prod release(태그) 발행** — 순서는 **Api 먼저 → web**
+- [ ] ⚠️ **성경 본문 동기화 짝 배포는 순서가 반대다 — web 먼저 → Api** ([PrayU-Api#44](https://github.com/TeamVisioneer/PrayU-Api/pull/44) / 이 레포 표시 정리 PR)
+  평소 규칙(Api 먼저)은 web이 새 스키마·함수에 의존하기 때문인데, 이번 건은 그 의존이 없다.
+  반대로 Api가 먼저 나가면 본문에 들어온 `○`가 **구버전 web에서 그대로 노출**된다.
+  web을 먼저 내보내면 아직 없는 표기를 지우는 no-op이라 무해하다. 상세: `../PrayU-Api/docs/bible-sync-plan.md`
+- [ ] staging 인수테스트 후 **prod release(태그) 발행** — 순서는 **Api 먼저 → web** (위 성경 동기화 건은 예외)
 - [ ] 실기기 확인(뷰포트 개편분): iOS Safari 하단 툴바 뒤 흰 띠 소멸, 회전·키보드, **앱 WebView 회귀**(`viewport-fit=cover` 영향)
 
 ## 완료

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -44,10 +44,18 @@
 
 ## 배포 대기
 
-- [ ] ⚠️ **성경 본문 동기화 짝 배포는 순서가 반대다 — web 먼저 → Api** ([PrayU-Api#44](https://github.com/TeamVisioneer/PrayU-Api/pull/44) / 이 레포 표시 정리 PR)
-  평소 규칙(Api 먼저)은 web이 새 스키마·함수에 의존하기 때문인데, 이번 건은 그 의존이 없다.
-  반대로 Api가 먼저 나가면 본문에 들어온 `○`가 **구버전 web에서 그대로 노출**된다.
-  web을 먼저 내보내면 아직 없는 표기를 지우는 no-op이라 무해하다. 상세: `../PrayU-Api/docs/bible-sync-plan.md`
+### 성경 본문 원본 동기화 — 짝 배포
+[#475](https://github.com/TeamVisioneer/PrayU-Web/pull/475) (표시 정리) · [PrayU-Api#44](https://github.com/TeamVisioneer/PrayU-Api/pull/44) (본문 동기화) · 상세: [../../PrayU-Api/docs/bible-sync-plan.md](../../PrayU-Api/docs/bible-sync-plan.md)
+
+DB는 원본(goodtv) 표기를 **그대로 보존**한다 — `<구역 제목>`(2,431행)·`○`(3,383행, 30개 절은 중간에 위치).
+따라서 표시 시 제거는 프론트 몫이고, `apis/bible.ts` 입구에서 `stripBibleMarkers()`로 한 번만 정리한다
+(표시뿐 아니라 **말씀카드 본문 저장·QT LLM 입력**도 같은 문장을 쓰기 때문에 입구가 맞는 위치다).
+
+- [ ] ⚠️ **배포 순서가 평소와 반대 — web 먼저 → Api.** 평소 규칙(Api 먼저)은 web이 새 스키마·함수에 의존하기 때문인데
+  이번 건은 그 의존이 없다. 반대로 Api가 먼저 나가면 본문에 들어온 `○`가 **구버전 web에서 그대로 노출**된다.
+  web을 먼저 내보내면 아직 없는 표기를 지우는 no-op이라 무해하다
+- [ ] **staging 확인** — QT 본문·말씀카드 생성 본문에 `○`·`<구역제목>` 없음, 기존 말씀카드(저장된 본문)도 정상 표시
+- [ ] **기존 QT 결과(`qt_data`)에는 표기가 남아 있을 수 있다** — LLM 응답에 원문이 인용된 경우. 새로 생성되는 것부터 정리되며, 과거분 보정은 하지 않는다(판단 필요 시 별도 작업)
 - [ ] staging 인수테스트 후 **prod release(태그) 발행** — 순서는 **Api 먼저 → web** (위 성경 동기화 건은 예외)
 - [ ] 실기기 확인(뷰포트 개편분): iOS Safari 하단 툴바 뒤 흰 띠 소멸, 회전·키보드, **앱 WebView 회귀**(`viewport-fit=cover` 영향)
 

--- a/src/apis/bible.ts
+++ b/src/apis/bible.ts
@@ -1,7 +1,15 @@
 import { supabase } from "./../../supabase/client";
 import { Bible } from "../../supabase/types/tables";
 import { fetchTodayLlmUsage } from "@/apis/llmUsage";
+import { stripBibleMarkers } from "@/lib/bibleText";
 import * as Sentry from "@sentry/react";
+
+// DB 는 원본 표기(`<구역 제목>`·`○`)를 보존한다 — 앱으로 나가는 입구에서 한 번만 걷어낸다.
+// 여기서 처리하면 표시(QT·구절 선택)와 저장(말씀카드 본문)·LLM 입력이 모두 정리된 문장을 쓴다.
+const toDisplayBible = (row: Bible): Bible => ({
+  ...row,
+  sentence: stripBibleMarkers(row.sentence),
+});
 
 export const getBible = async (
   longLabel: string,
@@ -20,7 +28,7 @@ export const getBible = async (
       Sentry.captureException(error.message);
       return null;
     }
-    return data as Bible;
+    return toDisplayBible(data as Bible);
   } catch (error) {
     Sentry.captureException(error);
 
@@ -47,7 +55,7 @@ export const fetchBibleList = async (
       Sentry.captureException(error.message);
       return null;
     }
-    return data as Bible[];
+    return (data as Bible[]).map(toDisplayBible);
   } catch (error) {
     Sentry.captureException(error);
     return null;
@@ -99,7 +107,7 @@ export const searchBible = async (
       };
     }
     return {
-      bible: data.bible as Bible[],
+      bible: (data.bible as Bible[]).map(toDisplayBible),
       keywords: data.keywords as string[],
     };
   } catch (error) {

--- a/src/components/prayCard/BibleCardBase.tsx
+++ b/src/components/prayCard/BibleCardBase.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { stripBibleMarkers } from "@/lib/bibleText";
 import {
   BIBLE_CARD_HEIGHT,
   BIBLE_CARD_TEXT_DARK,
@@ -22,7 +23,8 @@ export const BibleCardBase = ({ content }: { content: BibleCardContent }) => {
     borderBottomRightRadius = "80px",
     borderBottomLeftRadius = "120px",
   ] = content.radius;
-  const bibleSentence = content.bibleSentence.replace(/<[^>]*>/g, "").trim();
+  // 이미 저장된 카드에는 원본 표기가 섞여 있을 수 있어 표시 시점에도 한 번 더 정리한다
+  const bibleSentence = stripBibleMarkers(content.bibleSentence);
   const verseStyle = getBibleVerseStyle(bibleSentence.length);
   // 글씨는 중립 모노크롬: 구절은 배경 밝기 기반(다크/흰색), 이름은 다크, 키워드는 옅은 그레이
   const verseColor = getCardTextColorOnGradient(content.colors);

--- a/src/lib/bibleText.ts
+++ b/src/lib/bibleText.ts
@@ -1,0 +1,17 @@
+/**
+ * 성경 본문 표시용 정리.
+ *
+ * DB(`public.bible`)는 원본(goodtvbible.goodtv.co.kr)을 **그대로 보존**한다.
+ * 따라서 본문에 다음 두 표기가 섞여 있다:
+ *   - `<구역 제목>` — 구역이 시작되는 절의 맨 앞
+ *   - `○` — 문단 시작 표시. 절 맨 앞이 대부분이나 절 중간에도 온다(30개 절)
+ *
+ * 본문을 훼손하지 않으려고 DB에 남긴 것이므로, 사용자에게 보여줄 때 걷어내는 것은 프론트 몫이다.
+ * (PrayU-Api `docs/bible-sync-plan.md`)
+ */
+export const stripBibleMarkers = (sentence: string): string =>
+  sentence
+    .replace(/<[^>]*>/g, "")
+    .replace(/○/g, "")
+    .replace(/\s+/g, " ")
+    .trim();


### PR DESCRIPTION
짝 PR: [PrayU-Api#44](https://github.com/TeamVisioneer/PrayU-Api/pull/44) (성경 본문을 원본과 동기화)

## 배경

Api#44에서 `public.bible`을 원본(goodtvbible.goodtv.co.kr)과 일치시키면서,
원본의 표기를 **DB에 그대로 보존**하기로 했다 — 본문을 임의로 자르면 의미가 훼손되기 때문이다.

- `<구역 제목>` — 구역이 시작되는 절의 맨 앞 (2,431행)
- `○` — 문단 시작 표시 (3,383행. 대부분 절 맨 앞이나 **30개 절은 중간**에 온다)

따라서 **표시 시 제거는 프론트 몫**이고, 이 PR이 그 짝이다.

## 변경

| 파일 | 내용 |
|---|---|
| `src/lib/bibleText.ts` (신규) | `stripBibleMarkers()` — 규칙을 한 곳에 모은다. `<...>` 제거 → `○` 제거 → 공백 정리 |
| `src/apis/bible.ts` | 앱으로 나가는 입구에서 한 번만 정리 (`getBible`·`fetchBibleList`·`searchBible`) |
| `src/components/prayCard/BibleCardBase.tsx` | 인라인 정규식을 공용 헬퍼로 교체 |

### 왜 API 계층인가

`sentence`를 쓰는 곳은 표시만이 아니다 — **말씀카드 본문으로 DB에 저장**되고 **QT LLM 입력**으로도 나간다.
입구에서 한 번 정리하면 이 셋이 모두 정리된 문장을 쓰고, 표시 지점마다 정규식을 흩어 넣지 않아도 된다.

`BibleCardBase`는 **이미 저장된 카드**를 다루므로 표시 시점 정리를 유지한다.
기존 인라인 정규식은 `<...>`만 지우고 `○`는 남겼는데, 공용 헬퍼로 바꾸면서 함께 처리된다.

## 검증

로컬 스택(교정된 DB)에서 **실제 모듈을 직접 호출**해 확인:

| 절 | DB 원문 | 반환값 |
|---|---|---|
| 창 1:1 | `<천지 창조> 태초에 하나님이…` | `태초에 하나님이…` |
| 창 1:3 | `○하나님이 이르시되…` | `하나님이 이르시되…` |
| 창 2:4 | `<에덴 동산> ○이것이 천지가…` | `이것이 천지가…` |

절 중간 `○`(예: 삼하 2:4)는 앞뒤 공백이 유지된 채 표기만 사라지는 것도 확인했다.

`npm run build` 통과, lint 경고 baseline(3) 유지.

## ⚠️ 배포 순서 — 이번 건만 web 먼저

평소 규칙은 **Api 먼저 → web**이지만(web이 새 스키마·함수에 의존하므로), 이번 짝은 그 의존이 없다.
Api가 먼저 나가면 새로 들어온 `○`가 **구버전 web에서 그대로 노출**된다.
web을 먼저 내보내면 아직 없는 표기를 지우는 no-op이라 무해하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)