### PR TITLE
fix: 원고 붙여넣기가 안 먹는 경우와 날짜 인풋 정리

### DIFF
--- a/src/lib/noticeDraft.ts
+++ b/src/lib/noticeDraft.ts
@@ -221,8 +221,21 @@ const parseJson = (raw: string): ParseResult => {
   return { draft, warnings };
 };
 
+/**
+ * 붙여넣기 과정에서 딸려 오는 것들을 걷어낸다.
+ * 렌더된 마크다운에서 복사하면 코드펜스가, 일부 편집기·웹에서 복사하면
+ * 제로폭 문자가 앞에 붙는다. 그대로 두면 프론트매터로 인식되지 않아
+ * 원고 전체가 본문으로 처리된다.
+ */
+const stripPasteArtifacts = (raw: string): string => {
+  let value = raw.replace(/[\u200B-\u200D\uFEFF]/g, "").trim();
+  const fenced = value.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  if (fenced) value = fenced[1].trim();
+  return value;
+};
+
 export const parseNoticeDraft = (raw: string): ParseResult => {
-  const trimmed = raw.trim();
+  const trimmed = stripPasteArtifacts(raw);
   if (!trimmed) return { draft: {}, warnings: ["내용이 비어 있습니다"] };
 
   const result = trimmed.startsWith("{")

--- a/src/pages/AdminPage/NoticeManager.tsx
+++ b/src/pages/AdminPage/NoticeManager.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { ClipboardPaste, Eye, ImagePlus, Link2, Loader2, Pencil, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -53,6 +53,13 @@ const emptyForm = (): NoticeForm => ({
   endsAt: "",
 });
 
+/**
+ * 날짜 인풋은 값을 담을 만큼만 차지하게 한다.
+ * 기본 Input(h-10·폭 100%)에 네이티브 datetime-local 을 넣으면
+ * "연도. 월. 일. -- --:--" 자리표시자와 달력 아이콘 사이가 크게 벌어져 답답해 보인다.
+ */
+const DATE_INPUT_CLASS = "h-9 w-auto max-w-[15rem] px-2.5 text-xs";
+
 /** ISO → datetime-local 입력값(YYYY-MM-DDTHH:mm). 로컬 시간 기준으로 맞춘다 */
 const toLocalInputValue = (iso: string | null): string => {
   if (!iso) return "";
@@ -90,6 +97,7 @@ const NoticeManager = () => {
   const [isDraftOpen, setIsDraftOpen] = useState(false);
   const [draftText, setDraftText] = useState("");
   const [draftWarnings, setDraftWarnings] = useState<string[]>([]);
+  const editorScrollRef = useRef<HTMLDivElement>(null);
 
   const loadNotices = useCallback(async () => {
     setIsLoading(true);
@@ -156,12 +164,19 @@ const NoticeManager = () => {
       // images 키가 없으면 이미 올린 이미지를 지우지 않는다
       images: draft.images ?? prev.images,
     }));
+    // 경고가 있어도 닫는다 — 열린 채 두면 폼이 이미 채워졌는데도
+    // "아무 일도 일어나지 않은 것"으로 보인다. 경고는 에디터에 남겨 보여준다.
     setDraftWarnings(warnings);
-    if (warnings.length === 0) {
-      setIsDraftOpen(false);
-      setDraftText("");
-      toast({ description: "원고를 폼에 채웠어요" });
-    }
+    setIsDraftOpen(false);
+    setDraftText("");
+    // 채워진 제목·본문이 보이도록 맨 위로 돌려놓는다 (아래를 보고 있었다면 변화를 못 본다)
+    requestAnimationFrame(() => editorScrollRef.current?.scrollTo({ top: 0 }));
+    toast({
+      description:
+        warnings.length > 0
+          ? `원고를 채웠어요 · 건너뛴 항목 ${warnings.length}개`
+          : "원고를 폼에 채웠어요",
+    });
   };
 
   /** 공지 이미지 업로드 — 기존 prayu 버킷의 notice/ 경로를 쓴다 */
@@ -333,7 +348,7 @@ const NoticeManager = () => {
             </div>
           </DialogHeader>
 
-          <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div ref={editorScrollRef} className="flex-1 overflow-y-auto px-5 py-4">
           {isPreview ? (
             // 실제 공지 모달과 같은 구성(어두운 배경 · 카드 · 카드 밖 보조 액션)으로 그린다
             <div className="rounded-xl bg-gray-800 p-4">
@@ -354,6 +369,23 @@ const NoticeManager = () => {
             </div>
           ) : (
             <div className="flex flex-col gap-5">
+              {draftWarnings.length > 0 && (
+                <div className="flex flex-col gap-1 rounded-md bg-amber-50 p-3 text-xs text-amber-800">
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-medium">원고에서 건너뛴 항목</span>
+                    <button
+                      type="button"
+                      onClick={() => setDraftWarnings([])}
+                      className="shrink-0 text-amber-700 underline"
+                    >
+                      닫기
+                    </button>
+                  </div>
+                  {draftWarnings.map((warning, index) => (
+                    <span key={index}>· {warning}</span>
+                  ))}
+                </div>
+              )}
               <label className="flex flex-col gap-1.5">
                 <span className="text-xs font-medium text-gray-700">제목</span>
                 <Input
@@ -532,6 +564,7 @@ const NoticeManager = () => {
                     onChange={(e) =>
                       setForm((prev) => ({ ...prev, startsAt: e.target.value }))
                     }
+                    className={DATE_INPUT_CLASS}
                   />
                   <span className="text-[11px] text-gray-400">
                     비워두면 저장 즉시 시작됩니다.
@@ -545,6 +578,7 @@ const NoticeManager = () => {
                     onChange={(e) =>
                       setForm((prev) => ({ ...prev, endsAt: e.target.value }))
                     }
+                    className={DATE_INPUT_CLASS}
                   />
                   <span className="text-[11px] text-gray-400">
                     비워두면 중지할 때까지 계속 노출됩니다.


### PR DESCRIPTION
## 원고 붙여넣기 — 무엇이 문제였나

로컬에서 정상 경로(파일 내용 그대로 붙여넣기)는 잘 동작해서 처음엔 재현되지 않았다.
파서에 실제 복사 경로를 넣어 보고 원인을 찾았다.

| 붙여넣은 형태 | 고치기 전 | 고친 후 |
|---|---|---|
| 파일 내용 그대로 | ✅ | ✅ |
| **코드펜스로 감싸짐** (렌더된 마크다운에서 복사) | ❌ 제목 인식 실패 | ✅ |
| **제로폭 문자가 앞에 붙음** (일부 편집기·웹에서 복사) | ❌ 제목 인식 실패 | ✅ |
| CRLF 줄바꿈 · 앞의 빈 줄 · BOM | ✅ | ✅ |

인식에 실패하면 원고 전체가 본문으로 처리되고 제목이 비어 경고가 뜬다.
그런데 **경고가 있으면 다이얼로그를 닫지 않도록** 해뒀던 탓에, 화면상으로는
"버튼을 눌렀는데 아무 일도 일어나지 않는" 것으로 보였다.

## 고친 것

- 파서가 **코드펜스와 제로폭 문자를 걷어낸다**
- 적용 시 **경고가 있어도 다이얼로그를 닫는다.** 경고는 에디터 안에 남겨 무엇을 건너뛰었는지 보여준다
- 적용 후 **에디터를 맨 위로 되돌린다** — 아래(노출 설정)를 보던 중이었다면 제목·본문이 채워져도 변화를 볼 수 없었다. 실제로 날짜 인풋을 보다가 발견하신 상황과 맞물린다
- 토스트가 결과를 말한다: `원고를 폼에 채웠어요` / `원고를 채웠어요 · 건너뛴 항목 N개`

## 날짜 인풋

기본 `Input`(h-10·폭 100%)에 네이티브 `datetime-local` 을 넣으면
`연도. 월. 일. -- --:--` 자리표시자와 달력 아이콘 사이가 크게 벌어져 답답해 보였다.
값이 들어갈 만큼만 차지하도록 줄였다 — **276×40 → 240×36**, 글자 `text-xs`.

## 검증

로컬 어드민에서 **코드펜스로 감싼 원고**를 붙여넣어 확인했다 —
제목·이미지 2장·본문·CTA가 채워지고, 다이얼로그가 닫히며, 스크롤이 맨 위(0)로 돌아온다.
파서 단위로는 6가지 입력 형태를 모두 통과한다.

`npm run build` 통과, lint 경고 baseline(3) 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)