### PR TITLE
feat: 신규 이미지 업로드를 R2 로 — 경로(key)만 저장

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -50,7 +50,7 @@
 - [x] ~~**업로드 전 리사이즈**~~ — [#488](https://github.com/TeamVisioneer/PrayU-Web/pull/488). 폰 사진 6.75MB → 484KB(7%).
       **R2 와 무관하게 선행해야 할 작업이었다** — 원본 업로드는 어느 스토리지로 가도 문제다
 - [x] ~~`src/lib/assetUrl.ts` · `src/apis/file.ts` · 읽는 곳 전환~~ — [#489](https://github.com/TeamVisioneer/PrayU-Web/pull/489)
-- [ ] 🔴 **`VITE_ASSET_BASE_URL` 을 각 환경(Vercel)에 등록** — **이 값이 없으면 업로드는 계속 Supabase 로 나간다.**
+- [ ] 🔴 **`VITE_STORAGE_BASE_URL` 을 각 환경(Vercel)에 등록** — **이 값이 없으면 업로드는 계속 Supabase 로 나간다.**
       R2 시크릿(Api 쪽)과 **함께** 넣어야 한다. 한쪽만 넣으면 업로드가 실패한다
 - [ ] **손대지 않는 것**: `avatar_url`(카카오 외부 URL)·`pray_card.bible_card_url`(레거시) →
       `UserProfile`·`PrayListDrawer`·`PrayCard` 는 그대로

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -49,13 +49,13 @@
 
 - [x] ~~**업로드 전 리사이즈**~~ — [#488](https://github.com/TeamVisioneer/PrayU-Web/pull/488). 폰 사진 6.75MB → 484KB(7%).
       **R2 와 무관하게 선행해야 할 작업이었다** — 원본 업로드는 어느 스토리지로 가도 문제다
-- [ ] `src/lib/assetUrl.ts` — **키만 받아** URL 을 만든다. 절대 URL 을 넘기는 경로는 만들지 않는다
-- [ ] `src/apis/file.ts` — 서명 URL 방식으로 교체, 반환값을 `{ key }` 로
-- [ ] 읽는 곳 — `PrayCardHistoryDrawer`·`PrayCardHistoryList`·`ThanksCardItem` 을
-      `assetUrl(image_key) ?? image_url` 로. **값의 생김새로 판별하지 않는다** — 컬럼이 따로 있다
-- [ ] `.env` 각 환경에 `VITE_ASSET_BASE_URL`
+- [x] ~~`src/lib/assetUrl.ts` · `src/apis/file.ts` · 읽는 곳 전환~~ — [#489](https://github.com/TeamVisioneer/PrayU-Web/pull/489)
+- [ ] 🔴 **`VITE_ASSET_BASE_URL` 을 각 환경(Vercel)에 등록** — **이 값이 없으면 업로드는 계속 Supabase 로 나간다.**
+      R2 시크릿(Api 쪽)과 **함께** 넣어야 한다. 한쪽만 넣으면 업로드가 실패한다
 - [ ] **손대지 않는 것**: `avatar_url`(카카오 외부 URL)·`pray_card.bible_card_url`(레거시) →
       `UserProfile`·`PrayListDrawer`·`PrayCard` 는 그대로
+- [ ] 전환 후 확인: 말씀카드·감사카드 생성 → DB 에 **key 만** 들어가는지, 기존 카드가 그대로 보이는지,
+      카카오 공유 썸네일이 새 도메인으로 뜨는지
 
 **이번 범위는 앞으로 만드는 이미지뿐이다.** 이미 올라간 파일과 그 URL 은 건드리지 않는다 —
 옮길지 여부·방법은 나중에 별도로 정한다(계획 문서의 "기존 이미지는 이번에 건드리지 않는다" 절).

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -50,8 +50,16 @@
 - [x] ~~**업로드 전 리사이즈**~~ — [#488](https://github.com/TeamVisioneer/PrayU-Web/pull/488). 폰 사진 6.75MB → 484KB(7%).
       **R2 와 무관하게 선행해야 할 작업이었다** — 원본 업로드는 어느 스토리지로 가도 문제다
 - [x] ~~`src/lib/assetUrl.ts` · `src/apis/file.ts` · 읽는 곳 전환~~ — [#489](https://github.com/TeamVisioneer/PrayU-Web/pull/489)
-- [ ] 🔴 **`VITE_STORAGE_BASE_URL` 을 각 환경(Vercel)에 등록** — **이 값이 없으면 업로드는 계속 Supabase 로 나간다.**
-      R2 시크릿(Api 쪽)과 **함께** 넣어야 한다. 한쪽만 넣으면 업로드가 실패한다
+- [x] ~~Api 시크릿 `R2_*` 4개 — staging·prod 양쪽 등록 완료~~ (2026-07-31, 해시 대조로 값까지 검증)
+- [ ] 🔴 **staging Vercel(`prayu-staging`)에 `VITE_STORAGE_BASE_URL` 등록 + 재배포** —
+      이 값이 없으면 업로드는 계속 Supabase 로 나간다. `VITE_` 값은 **빌드 시점에 번들에 박히므로 재배포해야 적용**된다
+- [ ] 🔴 **prod Vercel(`prayu`)의 `VITE_STORAGE_BASE_URL` 은 release 때 넣는다 — 미리 넣지 않는다**
+      - 이유 1: 미리 넣으면 **다음 prod 빌드부터 R2 가 켜진다.** prod 순서는 **Api release 먼저 → web 태그 발행** 인데,
+        값이 먼저 있으면 순서가 어긋났을 때 조용히 깨진다 (업로드 엔드포인트가 아직 prod 에 없으면 500)
+      - 이유 2: 기존 변수들이 Production/Preview/Development **세 곳 모두**에 걸려 있어, 습관대로 넣으면
+        preview 빌드까지 **prod 버킷**을 쓴다. 넣을 때 스코프를 확인한다
+      - 값은 시크릿이 아니라 Cloudflare 콘솔에서 언제든 다시 볼 수 있다 — 미리 넣어둘 이유가 없다
+      - 순서: **Api release → prod Vercel 값 등록 → web 태그 발행**
 - [ ] **손대지 않는 것**: `avatar_url`(카카오 외부 URL)·`pray_card.bible_card_url`(레거시) →
       `UserProfile`·`PrayListDrawer`·`PrayCard` 는 그대로
 - [ ] 전환 후 확인: 말씀카드·감사카드 생성 → DB 에 **key 만** 들어가는지, 기존 카드가 그대로 보이는지,

--- a/src/apis/file.ts
+++ b/src/apis/file.ts
@@ -1,34 +1,123 @@
 import { supabase } from "./../../supabase/client";
 import * as Sentry from "@sentry/react";
+import { isAssetStorageConfigured } from "@/lib/assetUrl";
 
-export const uploadImage = async (file: File, path: string) => {
+/**
+ * 이미지 업로드.
+ *
+ * 새 스토리지(R2)에는 RLS 가 없어 브라우저가 직접 올릴 수 없다. 서버(`POST /api/upload-url`)가
+ * "이 키에, 이 타입으로, 5분 안에만" 서명한 URL 을 내주고 브라우저는 거기에 본문만 PUT 한다.
+ * 저장하는 값은 절대 URL 이 아니라 **키**다 (PrayU-Api/docs/storage-r2-plan.md).
+ *
+ * R2 환경변수(`VITE_ASSET_BASE_URL`)가 없으면 **기존 Supabase Storage 경로 그대로** 동작한다.
+ */
+
+/** 업로드 용도. 경로는 이 값으로 **서버가** 정한다 — 클라이언트가 경로를 만들지 않는다 */
+export type UploadKind = "bible_card" | "thanks_card" | "notice";
+
+export interface UploadedImage {
+  /** 새 스토리지 경로. DB 의 `image_key` 에 넣는다 */
+  key: string | null;
+  /** 레거시 Supabase 업로드일 때만 채워진다. 기존 URL 컬럼에 넣는다 */
+  url: string | null;
+}
+
+/** 레거시 경로 규칙 — 기존에 쓰던 디렉터리를 그대로 유지한다 */
+const LEGACY_DIRS: Record<UploadKind, string> = {
+  bible_card: "BibleCard/UserBibleCard",
+  thanks_card: "ThanksCard/UserImage",
+  notice: "notice",
+};
+
+/**
+ * `upsert: false` 라 같은 경로면 업로드가 실패한다.
+ * 사용자가 고른 사진 이름이 겹칠 수 있으므로 시각을 붙여 유일하게 만든다.
+ */
+const legacyPath = (kind: UploadKind, file: File): string =>
+  `${LEGACY_DIRS[kind]}/${Date.now()}-${file.name.replace(/[^\w.-]/g, "_")}`;
+
+/** 서명 URL 발급 요청 */
+const requestUploadUrl = async (
+  kind: UploadKind,
+  contentType: string,
+): Promise<{ url: string; key: string } | null> => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const response = await fetch(
+    `${import.meta.env.VITE_SUPA_PROJECT_URL}/functions/v1/api/upload-url`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: `Bearer ${session?.access_token}`,
+      },
+      body: JSON.stringify({ kind, contentType }),
+    },
+  );
+
+  const { data, error } = await response.json();
+  if (error || !data?.url || !data?.key) {
+    Sentry.captureException(
+      `upload-url 발급 실패 (${response.status}): ${error ?? "unknown"}`,
+    );
+    return null;
+  }
+  return data;
+};
+
+const uploadToSupabase = async (
+  file: File,
+  kind: UploadKind,
+): Promise<UploadedImage | null> => {
+  const { data, error } = await supabase.storage
+    .from("prayu")
+    .upload(legacyPath(kind, file), file, {
+      cacheControl: "3600",
+      upsert: false,
+    });
+
+  if (error) {
+    Sentry.captureException(error.message);
+    return null;
+  }
+
+  const { data: publicData } = supabase.storage
+    .from("prayu")
+    .getPublicUrl(data.path);
+  return { key: null, url: publicData.publicUrl };
+};
+
+/**
+ * 파일을 올리고 **저장할 값**을 돌려준다.
+ *
+ * 실패하면 `null`. 이미지 없이 진행할지 중단할지는 호출부가 정한다.
+ */
+export const uploadImage = async (
+  file: File,
+  kind: UploadKind,
+): Promise<UploadedImage | null> => {
   try {
-    const { data, error } = await supabase
-      .storage
-      .from("prayu")
-      .upload(path, file, {
-        cacheControl: "3600",
-        upsert: false,
-      });
+    if (!isAssetStorageConfigured()) return await uploadToSupabase(file, kind);
 
-    if (error) {
-      Sentry.captureException(error.message);
+    const issued = await requestUploadUrl(kind, file.type);
+    if (!issued) return null;
+
+    // 서명에 content-type 이 묶여 있다 — 헤더가 다르면 스토리지가 403 을 준다
+    const response = await fetch(issued.url, {
+      method: "PUT",
+      headers: { "Content-Type": file.type },
+      body: file,
+    });
+    if (!response.ok) {
+      Sentry.captureException(
+        `스토리지 업로드 실패 (${response.status}): ${issued.key}`,
+      );
       return null;
     }
 
-    return data;
-  } catch (error) {
-    Sentry.captureException(error);
-    return null;
-  }
-};
-
-export const getPublicUrl = (path: string) => {
-  try {
-    const { data } = supabase.storage
-      .from("prayu")
-      .getPublicUrl(path);
-    return data.publicUrl;
+    return { key: issued.key, url: null };
   } catch (error) {
     Sentry.captureException(error);
     return null;

--- a/src/apis/file.ts
+++ b/src/apis/file.ts
@@ -9,7 +9,7 @@ import { isAssetStorageConfigured } from "@/lib/assetUrl";
  * "이 키에, 이 타입으로, 5분 안에만" 서명한 URL 을 내주고 브라우저는 거기에 본문만 PUT 한다.
  * 저장하는 값은 절대 URL 이 아니라 **키**다 (PrayU-Api/docs/storage-r2-plan.md).
  *
- * R2 환경변수(`VITE_ASSET_BASE_URL`)가 없으면 **기존 Supabase Storage 경로 그대로** 동작한다.
+ * R2 환경변수(`VITE_STORAGE_BASE_URL`)가 없으면 **기존 Supabase Storage 경로 그대로** 동작한다.
  */
 
 /** 업로드 용도. 경로는 이 값으로 **서버가** 정한다 — 클라이언트가 경로를 만들지 않는다 */

--- a/src/components/profile/PrayCardHistoryDrawer.tsx
+++ b/src/components/profile/PrayCardHistoryDrawer.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import useBaseStore from "@/stores/baseStore";
+import { assetUrl } from "@/lib/assetUrl";
 import { PrayCard } from "../prayCard/PrayCard";
 import ReactionResultBox from "../pray/ReactionResultBox";
 import PrayCardWithBibleCard from "../prayCard/PrayCardWithBibleCard";
@@ -80,7 +81,11 @@ const PrayCardHistoryDrawer: React.FC = () => {
               <>
                 <ShareButtonGroup
                   where="PrayCardHistoryDrawer"
-                  publicUrl={historyCard.bible_card.image_url ?? undefined}
+                  publicUrl={
+                    assetUrl(historyCard.bible_card.image_key) ??
+                    historyCard.bible_card.image_url ??
+                    undefined
+                  }
                   shareUrl={`${getDomainUrl()}/bible-card/share/${historyCard.bible_card.id}`}
                   kakaoServerCallbackArgs={
                     user

--- a/src/components/profile/PrayCardHistoryList.tsx
+++ b/src/components/profile/PrayCardHistoryList.tsx
@@ -4,6 +4,7 @@ import { analyticsTrack } from "@/analytics/analytics";
 import { useState } from "react";
 import ShowMoreBtn from "../common/ShowMoreBtn";
 import { PrayType, PrayTypeDatas } from "@/Enums/prayType";
+import { assetUrl } from "@/lib/assetUrl";
 
 const PrayCardHistoryList = () => {
   const user = useBaseStore((state) => state.user);
@@ -66,7 +67,9 @@ const PrayCardHistoryList = () => {
       <div className="grid w-full grid-cols-3 gap-3">
         {historyPrayCardListView.map((prayCard, index) => {
           const bibleCardImageUrl =
-            prayCard.bible_card?.image_url || prayCard.bible_card_url;
+            assetUrl(prayCard.bible_card?.image_key) ||
+            prayCard.bible_card?.image_url ||
+            prayCard.bible_card_url;
 
           if (bibleCardImageUrl) {
             return (

--- a/src/components/thanksCard/ThanksCardItem.tsx
+++ b/src/components/thanksCard/ThanksCardItem.tsx
@@ -1,3 +1,4 @@
+import { assetUrl } from "@/lib/assetUrl";
 import { ThanksCardItemProps } from "./types";
 
 /**
@@ -66,6 +67,9 @@ const getDefaultImage = (cardId: string): string => {
  * 반응형 디자인으로 모바일, 태블릿, 데스크톱에서 모두 최적화됩니다.
  */
 export const ThanksCardItem = ({ card }: ThanksCardItemProps) => {
+  // 새 스토리지(key)를 먼저 보고, 없으면 기존 절대 URL 로 떨어진다
+  const cardImageUrl = assetUrl(card.image_key) ?? card.image;
+
   return (
     <div className="w-full max-w-sm sm:max-w-md lg:max-w-lg mx-auto">
       {/* 타원형 카드 */}
@@ -90,9 +94,9 @@ export const ThanksCardItem = ({ card }: ThanksCardItemProps) => {
 
           {/* 이미지 영역 */}
           <div className="flex-shrink-0 mb-4 sm:mb-5 lg:mb-6 flex justify-center">
-            {card.image ? (
+            {cardImageUrl ? (
               <img
-                src={card.image}
+                src={cardImageUrl}
                 alt={`${card.user_name}님의 감사기도`}
                 className="w-full h-full aspect-square object-cover rounded-xl sm:rounded-2xl"
               />

--- a/src/hooks/useSaveImage.ts
+++ b/src/hooks/useSaveImage.ts
@@ -1,10 +1,10 @@
 import { RefObject, useCallback } from "react";
 import { domToBlob } from "modern-screenshot";
-import { getPublicUrl, uploadImage } from "@/apis/file";
+import { UploadedImage, UploadKind, uploadImage } from "@/apis/file";
 import { getTodayNumber } from "@/lib/utils";
 
 interface SaveImageOptions {
-  storagePath?: string; // Supabase storage 경로 (기본값: 'BibleCard/UserBibleCard')
+  kind?: UploadKind; // 업로드 용도 — 저장 경로는 서버가 이 값으로 정한다 (기본값: 'bible_card')
   fileName?: string; // 파일명 (기본값: 'Card_{timestamp}.jpeg')
   imageFormat?: "jpeg" | "png"; // 이미지 포맷 (기본값: 'jpeg')
   quality?: number; // 이미지 품질 (0-1, 기본값: 0.85)
@@ -12,28 +12,18 @@ interface SaveImageOptions {
 }
 
 /**
- * DOM 요소를 이미지로 캡처하여 Supabase에 업로드하는 커스텀 훅
+ * DOM 요소를 이미지로 캡처해 업로드하는 커스텀 훅
  *
- * @returns saveImage 함수를 반환
+ * @returns saveImage — 저장할 값(`{ key, url }`)을 돌려준다. 실패 시 null
  *
  * @example
  * const { saveImage } = useSaveImage();
  * const cardRef = useRef<HTMLDivElement>(null);
  *
  * const handleSave = async () => {
- *   const url = await saveImage(cardRef, {
- *     storagePath: 'BibleCard/UserBibleCard',
- *     fileName: `Card_${Date.now()}.jpeg`,
- *     imageFormat: 'jpeg',
- *     quality: 0.95,
- *     scale: 2
- *   });
- *
- *   if (url) {
- *     console.log('이미지 저장 성공:', url);
- *   } else {
- *     alert('이미지 저장 실패');
- *   }
+ *   const uploaded = await saveImage(cardRef, { kind: "bible_card" });
+ *   if (!uploaded) return alert("이미지 저장 실패");
+ *   await createCard({ image_key: uploaded.key, image_url: uploaded.url });
  * };
  */
 export function useSaveImage() {
@@ -41,10 +31,10 @@ export function useSaveImage() {
     async (
       elementRef: RefObject<HTMLElement>,
       options?: SaveImageOptions,
-    ): Promise<string | null> => {
+    ): Promise<UploadedImage | null> => {
       // 기본값 설정
       const {
-        storagePath = "BibleCard/UserBibleCard",
+        kind = "bible_card",
         fileName = `Card_${getTodayNumber()}.jpeg`,
         imageFormat = "jpeg",
         quality = 0.85,
@@ -79,23 +69,15 @@ export function useSaveImage() {
           type: `image/${imageFormat}`,
         });
 
-        // Step 5: Supabase 업로드
-        const pathData = await uploadImage(file, `${storagePath}/${fileName}`);
+        // Step 5: 업로드 — 저장할 값(key 또는 레거시 url)을 그대로 돌려준다
+        const uploaded = await uploadImage(file, kind);
 
-        if (!pathData) {
-          console.error("useSaveImage: Failed to upload image to Supabase");
+        if (!uploaded) {
+          console.error("useSaveImage: Failed to upload image");
           return null;
         }
 
-        // Step 6: Public URL 생성 및 반환
-        const publicUrl = getPublicUrl(pathData.path);
-
-        if (!publicUrl) {
-          console.error("useSaveImage: Failed to get public URL");
-          return null;
-        }
-
-        return publicUrl;
+        return uploaded;
       } catch (error) {
         console.error("useSaveImage: Error during image save process", error);
         return null;

--- a/src/lib/assetUrl.ts
+++ b/src/lib/assetUrl.ts
@@ -6,7 +6,7 @@
  * 그 대가로 읽는 쪽에서 매번 한 번 조립한다.
  */
 
-const BASE = (import.meta.env.VITE_ASSET_BASE_URL ?? "").replace(/\/+$/, "");
+const BASE = (import.meta.env.VITE_STORAGE_BASE_URL ?? "").replace(/\/+$/, "");
 
 /**
  * 새 스토리지(R2)를 쓸 수 있는 환경인지.

--- a/src/lib/assetUrl.ts
+++ b/src/lib/assetUrl.ts
@@ -1,0 +1,29 @@
+/**
+ * 스토리지 키 → 공개 URL.
+ *
+ * DB 에는 절대 URL 이 아니라 **경로(key)** 만 저장한다. 스토리지 도메인이 데이터에 박히면
+ * 도메인을 바꿀 때 수만 행을 일괄 수정해야 하기 때문이다 (PrayU-Api/docs/storage-r2-plan.md).
+ * 그 대가로 읽는 쪽에서 매번 한 번 조립한다.
+ */
+
+const BASE = (import.meta.env.VITE_ASSET_BASE_URL ?? "").replace(/\/+$/, "");
+
+/**
+ * 새 스토리지(R2)를 쓸 수 있는 환경인지.
+ *
+ * 이 값이 없으면 업로드는 **기존 Supabase Storage 로** 나간다.
+ * R2 준비(버킷·토큰·CORS·시크릿)는 사람이 하는 단계라, 환경변수 하나로 켜고 끌 수 있게 둔다.
+ */
+export const isAssetStorageConfigured = (): boolean => BASE !== "";
+
+/**
+ * 키를 공개 URL 로 바꾼다.
+ *
+ * **키만 받는다.** 절대 URL 을 넘기면 그대로 통과시키는 식으로 만들지 않는다 —
+ * 값 모양으로 분기하면 나중에 다른 형태가 섞였을 때 조용히 틀린 URL 을 만든다.
+ * 키가 없거나 base URL 이 없으면 `null` 이고, 호출부는 기존 컬럼으로 폴백한다.
+ */
+export const assetUrl = (key: string | null | undefined): string | null => {
+  if (!key || !BASE) return null;
+  return `${BASE}/${key.replace(/^\/+/, "")}`;
+};

--- a/src/pages/AdminPage/NoticeManager.tsx
+++ b/src/pages/AdminPage/NoticeManager.tsx
@@ -20,7 +20,8 @@ import {
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/use-toast";
 import NoticeContent from "@/components/notice/NoticeContent";
-import { getPublicUrl, uploadImage } from "@/apis/file";
+import { uploadImage } from "@/apis/file";
+import { assetUrl } from "@/lib/assetUrl";
 import { resizeImageFile } from "@/lib/resizeImage";
 import { NoticeDraftFile, loadNoticeDrafts } from "@/lib/noticeDrafts";
 import {
@@ -224,19 +225,21 @@ const NoticeManager = () => {
     });
   };
 
-  /** 공지 이미지 업로드 — 기존 prayu 버킷의 notice/ 경로를 쓴다 */
+  /**
+   * 공지 이미지 업로드.
+   *
+   * `notice.images` 는 설계상 **URL 목록**이다 — 레포 원고는 `/images/notice/...`(웹 오리진),
+   * 즉석 업로드는 절대 URL 이 들어간다. 카드 이미지와 달리 행이 몇 개뿐이라
+   * 나중에 도메인을 바꿔도 UPDATE 몇 줄이면 된다. 그래서 여기만 URL 로 저장한다.
+   */
   const handleUploadImages = async (files: FileList) => {
     setIsUploading(true);
     const uploadedUrls: string[] = [];
     for (const original of Array.from(files)) {
       const file = await resizeImageFile(original);
-      const safeName = file.name.replace(/[^\w.-]/g, "_");
-      const uploaded = await uploadImage(
-        file,
-        `notice/${Date.now()}-${safeName}`,
-      );
+      const uploaded = await uploadImage(file, "notice");
       if (!uploaded) continue;
-      const publicUrl = getPublicUrl(uploaded.path);
+      const publicUrl = uploaded.url ?? assetUrl(uploaded.key);
       if (publicUrl) uploadedUrls.push(publicUrl);
     }
     setIsUploading(false);

--- a/src/pages/BibleCardPage/BibleCardGeneratorPage.tsx
+++ b/src/pages/BibleCardPage/BibleCardGeneratorPage.tsx
@@ -1,7 +1,8 @@
 import html2canvas from "html2canvas";
 import { useRef, useState } from "react";
 import { dataURLToFile, getTodayNumber } from "@/lib/utils";
-import { getPublicUrl, uploadImage } from "@/apis/file";
+import { uploadImage } from "@/apis/file";
+import { assetUrl } from "@/lib/assetUrl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -62,12 +63,10 @@ const BibleCardGenerator: React.FC = () => {
       });
       const dataUrl = canvas.toDataURL("image/jpeg", 0.9);
       const pngFile = dataURLToFile(dataUrl, `Card_${getTodayNumber()}.jpeg`);
-      const pathData = await uploadImage(
-        pngFile,
-        `BibleCard/UserBibleCard/${pngFile.name}`
-      );
-      if (!pathData) return null;
-      const publicUrl = getPublicUrl(pathData.path);
+      const uploaded = await uploadImage(pngFile, "bible_card");
+      if (!uploaded) return null;
+      // 이 페이지는 DB 에 저장하지 않고 URL 만 보여준다 — 키면 여기서 URL 로 만든다
+      const publicUrl = uploaded.url ?? assetUrl(uploaded.key);
       setPublicUrl(publicUrl || "");
       return publicUrl;
     } catch {

--- a/src/pages/BibleCardPage/BibleCardNewPage.tsx
+++ b/src/pages/BibleCardPage/BibleCardNewPage.tsx
@@ -36,6 +36,7 @@ import ShareButtonGroup from "@/components/share/ShareButtonGroup";
 import BibleCardGuideSheet from "./BibleCardGuideSheet";
 import useBaseStore from "@/stores/baseStore";
 import { useSaveImage } from "@/hooks/useSaveImage";
+import { assetUrl } from "@/lib/assetUrl";
 import { analyticsTrack } from "@/analytics/analytics";
 import { getDomainUrl, getISOTodayDateYMD, getTodayNumber } from "@/lib/utils";
 import {
@@ -267,6 +268,9 @@ const BibleCardNewPage = () => {
       ? historyPrayCardListView
       : historyPrayCardList || [];
   const selectedBibleCard = selectedPrayCard?.bible_card;
+  // 새 스토리지(key)를 먼저 보고, 없으면 기존 절대 URL 로 떨어진다
+  const selectedBibleCardImageUrl =
+    assetUrl(selectedBibleCard?.image_key) ?? selectedBibleCard?.image_url;
   const selectedBibleCardShareUrl = selectedBibleCard
     ? `${getDomainUrl()}/bible-card/share/${selectedBibleCard.id}`
     : undefined;
@@ -541,15 +545,15 @@ const BibleCardNewPage = () => {
         requestAnimationFrame(() => requestAnimationFrame(resolve));
       });
 
-      const imageUrl = await saveImage(bibleCardRef, {
-        storagePath: "BibleCard/UserBibleCard",
+      const uploaded = await saveImage(bibleCardRef, {
+        kind: "bible_card",
         fileName: `Card_${getTodayNumber()}_${selectedPrayCard.id}.jpeg`,
         imageFormat: "jpeg",
         quality: 0.85,
         scale: 2,
       });
 
-      if (!imageUrl) {
+      if (!uploaded) {
         toast({ description: "말씀카드 이미지를 저장하지 못했어요" });
         setIsFlipped(isReplacing);
         return;
@@ -563,7 +567,9 @@ const BibleCardNewPage = () => {
         bible_sentence: nextDraft.bibleSentence,
         colors,
         radius,
-        image_url: imageUrl,
+        // 새 스토리지면 key, 레거시면 URL 이 채워진다
+        image_url: uploaded.url,
+        image_key: uploaded.key,
       });
 
       if (!bibleCard) {
@@ -759,7 +765,7 @@ const BibleCardNewPage = () => {
             </div>
           </section>
 
-          {selectedBibleCard?.image_url && !isCreating && (
+          {selectedBibleCardImageUrl && !isCreating && (
             <section className="mx-auto mt-1 w-full max-w-[320px] space-y-3">
               <motion.div
                 className="rounded-2xl bg-white shadow-sm"
@@ -769,7 +775,7 @@ const BibleCardNewPage = () => {
               >
                 <ShareButtonGroup
                   where="BibleCardNewPage"
-                  publicUrl={selectedBibleCard.image_url}
+                  publicUrl={selectedBibleCardImageUrl}
                   shareUrl={selectedBibleCardShareUrl}
                   kakaoServerCallbackArgs={{
                     user_id: user.id,

--- a/src/pages/BibleCardPage/BibleCardSharePage.tsx
+++ b/src/pages/BibleCardPage/BibleCardSharePage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { getBibleCard } from "@/apis/bibleCard";
 import { fetchPrayCardByBibleCardId } from "@/apis/prayCard";
 import BibleCardView from "@/components/prayCard/BibleCard";
+import { assetUrl } from "@/lib/assetUrl";
 import PrayCard from "@/components/prayCard/PrayCard";
 import { analyticsTrack } from "@/analytics/analytics";
 import {
@@ -61,6 +62,9 @@ const BibleCardSharePage = () => {
   const [prayCard, setPrayCard] = useState<PrayCardWithProfiles | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isFlipped, setIsFlipped] = useState(false);
+  // 새 스토리지(key)를 먼저 보고, 없으면 기존 절대 URL 로 떨어진다
+  const bibleCardImageUrl =
+    assetUrl(bibleCard?.image_key) ?? bibleCard?.image_url;
 
   useEffect(() => {
     const fetchSharedBibleCard = async () => {
@@ -154,9 +158,9 @@ const BibleCardSharePage = () => {
                   }`}
                 >
                   <div className="absolute inset-0 backface-hidden">
-                    {bibleCard.image_url ? (
+                    {bibleCardImageUrl ? (
                       <img
-                        src={bibleCard.image_url}
+                        src={bibleCardImageUrl}
                         alt="공유된 말씀카드"
                         className="aspect-[3/4] w-full rounded-xl object-cover shadow-prayCard"
                       />

--- a/src/pages/NewThanksCardPage.tsx
+++ b/src/pages/NewThanksCardPage.tsx
@@ -9,9 +9,8 @@ import {
   StepType,
 } from "@/components/thanksCard/NewThanksCardStepper";
 import { thanksCardController } from "@/apis/thanksCard";
-import { uploadImage, getPublicUrl } from "@/apis/file";
+import { UploadedImage, uploadImage } from "@/apis/file";
 import { resizeImageFile } from "@/lib/resizeImage";
-import { getTodayNumber } from "@/lib/utils";
 import { IoChevronBack } from "react-icons/io5";
 
 /**
@@ -67,37 +66,27 @@ const NewThanksCardPage = () => {
       setCreateError(null);
 
       // 파일 업로드 처리
-      let imageUrl = "";
+      let uploaded: UploadedImage | null = null;
       if (formData.photo) {
         try {
-          // 파일명 생성: img_${getTodayNumber()}.jpeg
-          const fileName = `img_${getTodayNumber()}.jpeg`;
-          const uploadPath = `ThanksCard/UserImage/${fileName}`;
-
           // 원본 사진은 3~5MB 라 그대로 올리면 스토리지가 금방 찬다 — 줄여서 올린다
           const photo = await resizeImageFile(formData.photo);
-          const pathData = await uploadImage(photo, uploadPath);
-
-          if (pathData) {
-            // 업로드된 파일의 public URL 생성
-            const publicUrl = getPublicUrl(pathData.path);
-            imageUrl = publicUrl || "";
-          } else {
+          uploaded = await uploadImage(photo, "thanks_card");
+          if (!uploaded) {
             console.warn("Image upload failed, proceeding without image");
-            imageUrl = "";
           }
         } catch (error) {
           console.error("Error uploading image:", error);
           // 이미지 업로드 실패 시에도 카드 생성은 계속 진행
-          imageUrl = "";
         }
       }
 
-      // 감사 카드 생성
+      // 감사 카드 생성 — 새 스토리지면 key, 레거시면 URL 이 채워진다
       const newCard = await thanksCardController.createThanksCard({
         user_name: formData.name,
         content: formData.prayerContent,
-        image: imageUrl,
+        image: uploaded?.url ?? "",
+        image_key: uploaded?.key ?? null,
       });
 
       if (newCard) {

--- a/supabase/types/database.ts
+++ b/supabase/types/database.ts
@@ -77,6 +77,7 @@ export type Database = {
           colors: string[]
           created_at: string
           id: string
+          image_key: string | null
           image_url: string | null
           keywords: string[]
           name: string
@@ -89,6 +90,7 @@ export type Database = {
           colors?: string[]
           created_at?: string
           id?: string
+          image_key?: string | null
           image_url?: string | null
           keywords?: string[]
           name?: string
@@ -101,6 +103,7 @@ export type Database = {
           colors?: string[]
           created_at?: string
           id?: string
+          image_key?: string | null
           image_url?: string | null
           keywords?: string[]
           name?: string
@@ -662,6 +665,7 @@ export type Database = {
           deleted_at: string | null
           id: number
           image: string
+          image_key: string | null
           updated_at: string
           user_name: string
         }
@@ -671,6 +675,7 @@ export type Database = {
           deleted_at?: string | null
           id?: number
           image?: string
+          image_key?: string | null
           updated_at?: string
           user_name?: string
         }
@@ -680,6 +685,7 @@ export type Database = {
           deleted_at?: string | null
           id?: number
           image?: string
+          image_key?: string | null
           updated_at?: string
           user_name?: string
         }


### PR DESCRIPTION
짝 PR: [PrayU-Api#50](https://github.com/TeamVisioneer/PrayU-Api/pull/50) (merged) · 계획: [storage-r2-plan.md](https://github.com/TeamVisioneer/PrayU-Api/blob/main/docs/storage-r2-plan.md) 의 **3단계**

## 지금 merge 해도 동작은 그대로다

`VITE_ASSET_BASE_URL` **하나로** 갈린다. R2 준비(버킷·토큰·CORS·시크릿)는 사람이 하는 단계라,
그때까지는 **기존 Supabase Storage 로 계속 업로드**된다.

| 환경변수 | 업로드 | DB 에 들어가는 값 |
|---|---|---|
| 없음 (지금) | Supabase (기존 경로 그대로) | `image_url` / `image` |
| 있음 | R2 (서명 URL) | `image_key` |

읽는 쪽은 늘 `assetUrl(image_key) ?? image_url` 이라 두 상태가 섞여도 된다. 되돌리려면 환경변수를 지우면 되고,
그동안 R2 에 올라간 파일은 계속 읽힌다.

> ⚠️ **web 환경변수와 Api 시크릿은 같이 넣어야 한다.** 한쪽만 넣으면 서명 엔드포인트가 500 을 준다.

## 무엇

| 파일 | 내용 |
|---|---|
| `src/lib/assetUrl.ts` (신규) | 키 → URL. **키만 받는다** |
| `src/apis/file.ts` | 서명 URL 발급 → 브라우저가 직접 PUT. 반환값 `{ key, url }` |
| `src/hooks/useSaveImage.ts` | 반환값을 URL → `{ key, url }` 로 |
| 쓰는 곳 | `BibleCardNewPage` · `NewThanksCardPage` · `BibleCardGeneratorPage` · `NoticeManager` |
| 읽는 곳 | `PrayCardHistoryList` · `PrayCardHistoryDrawer` · `ThanksCardItem` · `BibleCardSharePage` · `BibleCardNewPage` |

계획서에 없던 읽는 곳 2개(`BibleCardSharePage`·`BibleCardNewPage`)를 찾아 함께 고쳤다 —
빠뜨렸으면 **새로 만든 카드가 공유 페이지와 생성 직후 화면에서 안 보였다.**

**손대지 않은 것**: `avatar_url`(카카오 외부 URL) · `pray_card.bible_card_url`(레거시).

## 값의 생김새로 분기하지 않는다

`startsWith("http")` 같은 판별은 넣지 않았다. 컬럼이 따로 있으니 컬럼으로 가른다.
`assetUrl()` 은 절대 URL 을 넘겨도 통과시키지 않는다 — 그래야 실수가 조용히 지나가지 않는다.

**예외는 공지 이미지 하나**다. `notice.images` 는 원래 URL 목록이고 레포 원고의 `/images/notice/...`(웹 오리진)이
이미 섞여 있어, 키를 넣으면 생김새 분기가 강제된다. 공지는 행이 몇 개뿐이라 도메인이 바뀌어도 UPDATE 몇 줄이면 된다.

## 곁다리 수정 — 사진 이름이 겹치면 업로드가 실패했다

감사카드 사진의 레거시 경로가 `ThanksCard/UserImage/<파일명>` 인데 `upsert: false` 라,
같은 이름의 사진(`IMG_1234.jpeg`)이면 두 번째부터 실패한다. 경로에 시각을 붙였다.

## 검증 (로컬)

로컬 Supabase 의 **S3 호환 엔드포인트**를 R2 자리에 두고 브라우저에서 실제로 돌렸다 — 서명 규격이 같다.

| 확인 | 결과 |
|---|---|
| 업로드 (발급 → PUT → 공개 조회) | **200**, 바이트·content-type 원본과 동일 |
| 반환값 | `{ key: "thanks_card/<uuid>.jpeg", url: null }` |
| `image_key` 만 있는 행 | 감사카드 목록·프로필 히스토리에 정상 표시 |
| `image_url` 만 있는 행 (기존 데이터) | 정상 표시 — **폴백 동작** |
| 환경변수 없는 상태 | Supabase 업로드 + 절대 URL 반환 — **기존 동작 유지** |

`npm run build` 통과 · lint 경고 3개는 기존 상태 그대로.

**CORS 는 로컬로 드러나지 않는 항목**이다 — R2 버킷에 허용 오리진을 넣지 않으면 브라우저 PUT 이 막힌다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)