### PR TITLE
chore: 원격 쓰기·merge·push 를 권한 규칙으로 막는다

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "ask": [
+      "Bash(gh pr merge:*)",
+      "Bash(gh api:*)",
+      "Bash(git push:*)"
+    ],
+    "deny": [
+      "Bash(supabase link:*)",
+      "Bash(supabase db push:*)",
+      "Bash(supabase db reset --linked:*)",
+      "Bash(supabase db remote:*)",
+      "Bash(supabase migration up --linked:*)",
+      "Bash(supabase secrets set:*)",
+      "Bash(supabase secrets unset:*)",
+      "Bash(supabase functions deploy:*)",
+      "Bash(supabase functions delete:*)",
+      "Bash(supabase projects delete:*)",
+      "Bash(supabase branches:*)",
+      "Bash(supabase domains:*)",
+      "Bash(vercel env add:*)",
+      "Bash(vercel env rm:*)",
+      "Bash(vercel deploy:*)",
+      "Bash(vercel promote:*)",
+      "Bash(vercel rollback:*)",
+      "Bash(vercel link:*)",
+      "Bash(vercel alias:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist-ssr
 # local AI tooling — 개인 설정(settings.local.json 등)은 무시하고, 공유할 스킬만 커밋한다
 .claude/*
 !.claude/skills/
+!.claude/settings.json


### PR DESCRIPTION
짝 PR: [PrayU-Api#53](https://github.com/TeamVisioneer/PrayU-Api/pull/53) — **규칙 내용과 근거는 그쪽 설명 참조** (같은 파일)

[#490](https://github.com/TeamVisioneer/PrayU-Web/pull/490) 으로 `CLAUDE.md` 에 merge 규칙을 넣었지만 문서는 지켜야 성립한다.
설정으로도 강제한다.

- `deny`: supabase/vercel 의 **원격을 바꾸는** 서브커맨드. 읽기는 열어둔다
- `ask`: `gh pr merge` · `gh api` · `git push` — 실행 전 사람 승인

## `.gitignore` 한 줄

`.claude/*` 가 ignore 되어 있어 `!.claude/settings.json` 예외를 추가했다.
`!.claude/skills/` 와 같은 방식이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)