### PR TITLE
feat: primitives 글래스화 — Button·Card·Input·Dialog/Drawer/Sheet

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,8 @@
   :root {
     /* 글래스 표면 토큰 — docs/plans/identity/design-system.md.
        chrome 은 backdrop-blur 와 함께(고정 크롬 전용), card 는 blur 없이 쓴다 */
+    --accent-from: 96 140 255;   /* primary 그라디언트 시작 (#608CFF) */
+    --accent-to: 69 116 241;     /* primary 그라디언트 끝   (#4574F1) */
     --surface-chrome: 248 249 255;
     --surface-card: 255 255 255;
     --glass-border: 255 255 255;

--- a/src/components/navigation/CreateActionSheet.tsx
+++ b/src/components/navigation/CreateActionSheet.tsx
@@ -53,7 +53,7 @@ const CreateActionSheet = ({ open, onOpenChange }: CreateActionSheetProps) => {
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="mx-auto max-w-app bg-surfaceChrome/90 backdrop-blur-xl">
+      <DrawerContent className="mx-auto max-w-app">
         <DrawerHeader className="pb-2 text-left">
           <DrawerTitle>만들기</DrawerTitle>
           <DrawerDescription className="sr-only">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,15 +13,16 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-glassBorder/70 bg-surfaceCard/60 hover:bg-surfaceCard/90",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        // custom
+        // custom — 색은 토큰만 쓴다 (design-system.md: hex 리터럴 금지)
         primary:
-          "shadow-md bg-gradient-to-br from-[#608CFF] to-[#4574F1] text-white cursor-pointer hover:bg-gradient-to-br hover:from-[#608CFF]/90 hover:to-[#4574F1]/90",
-        primaryLight: "shadow-sm bg-white text-[#222222] cursor-pointer",
+          "shadow-md bg-gradient-to-br from-accentFrom to-accentTo text-white cursor-pointer hover:from-accentFrom/90 hover:to-accentTo/90",
+        primaryLight:
+          "shadow-sm border border-glassBorder/60 bg-surfaceCard/80 text-liteBlack cursor-pointer",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,8 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg bg-card text-card-foreground shadow-sm",
+      // glass-card: 반투명 + 유리 보더, blur 는 쓰지 않는다 (스크롤 아이템 성능 규칙)
+      "rounded-2xl border border-glassBorder/50 bg-surfaceCard/70 text-card-foreground shadow-member",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -64,7 +64,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] max-w-[440px] mx-auto z-50 grid w-full translate-x-[-50%] translate-y-[-50%] border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] max-w-[440px] mx-auto z-50 grid w-full translate-x-[-50%] translate-y-[-50%] border border-glassBorder/60 bg-surfaceChrome/90 p-6 shadow-glass backdrop-blur-xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -67,7 +67,7 @@ const DrawerContent = React.forwardRef<
       <DrawerPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto mx-auto flex-col rounded-t-[20px] border bg-background focus:outline-none max-w-app",
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto mx-auto flex-col rounded-t-[20px] border border-glassBorder/60 bg-surfaceChrome/90 backdrop-blur-xl focus:outline-none max-w-app",
           className
         )}
         {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-glassBorder/70 bg-white/70 px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -54,7 +54,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 rounded-l-[20px]",
+  "fixed z-50 border-glassBorder/60 bg-surfaceChrome/90 backdrop-blur-xl p-6 shadow-glass transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 rounded-l-[20px]",
   {
     variants: {
       side: {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex w-full rounded-md border border-glassBorder/70 bg-white/70 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,8 @@ module.exports = {
       },
       colors: {
         // 글래스 토큰 (semantic — App.css 변수 매핑)
+        accentFrom: "rgb(var(--accent-from) / <alpha-value>)",
+        accentTo: "rgb(var(--accent-to) / <alpha-value>)",
         surfaceChrome: "rgb(var(--surface-chrome) / <alpha-value>)",
         surfaceCard: "rgb(var(--surface-card) / <alpha-value>)",
         glassBorder: "rgb(var(--glass-border) / <alpha-value>)",


### PR DESCRIPTION
계획: [identity/design-system.md](docs/plans/identity/design-system.md) **1단계** · v1.0.0 컷라인 승인분

## 무엇

| primitive | 변화 |
|---|---|
| Button | **cva 안의 hex 제거** — primary 그라디언트를 `--accent-from/to` 토큰으로 (시각 동일). primaryLight·outline 은 glass-card 표면 |
| Card | `rounded-2xl` + 반투명 + 유리 보더. **blur 없음** (스크롤 아이템 성능 규칙) |
| Dialog·Drawer·Sheet | 오버레이 = 고정 크롬 → **glass-chrome**(blur). 액션시트의 인스턴스 오버라이드 제거(기본값이 됨) |
| Input·Textarea | 반투명 표면 + 유리 보더 |

## variant 통폐합 검토 결론

`separated`·`combined` 는 Button 이 아니라 **`ReactionResultBox`(도메인 컴포넌트)의 variant** 였다 — 정리 대상 아님.
Button 실사용은 primary(34)·secondary(15)·outline(15)·ghost(9) 4종으로 이미 수렴돼 있다.

## 영향 범위

primitives 라 전 화면에 적용된다 — 어드민·Office 포함(동작 무변). 시각 변화는 "흰 불투명 → 반투명 유리" 수준.
문제 화면이 발견되면 화면별 재스킨 PR(다음 단계)에서 잡는다.

검증: 그룹 만들기(헤더·Input·버튼), 액션시트. lint/tsc/build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)